### PR TITLE
Feature/rename molecule classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Join Calculus (JC) is a micro-framework for purely functional concurrency.
 The code is inspired by previous implementations by Jiansen He (https://github.com/Jiansen/ScalaJoin, 2011)
 and Philipp Haller (http://lampwww.epfl.ch/~phaller/joins/index.html, 2008).
 
+The implementation currently requires Scala 2.11 due to Akka support and openjdk7 performance issues.
+However, the code works also with Scala 2.10 (except for Akka functions) and Scala 2.12 (but only with oraclejdk).
+
 # Overview of join calculus
 
 If you are new to Join Calculus, begin with this [tutorial introduction to `JoinRun`](doc/join_calculus_joinrun_tutorial.md).

--- a/benchmark/src/main/scala/code/winitzki/benchmark/Benchmarks1.scala
+++ b/benchmark/src/main/scala/code/winitzki/benchmark/Benchmarks1.scala
@@ -9,11 +9,11 @@ object Benchmarks1 {
 
   def benchmark1(count: Int, threads: Int = 2): Long = {
 
-    val c = ja[Int]("c")
-    val g = js[Unit,Int]("g")
-    val i = ja[Unit]("i")
-    val d = ja[Unit]("d")
-    val f = js[LocalDateTime,Long]("f")
+    val c = m[Int]("c")
+    val g = b[Unit,Int]("g")
+    val i = m[Unit]("i")
+    val d = m[Unit]("d")
+    val f = b[LocalDateTime,Long]("f")
 
     val tp = new ReactionPool(threads)
 
@@ -58,11 +58,11 @@ object Benchmarks1 {
   }
 
   def make_counter(init: Int, threads: Int, tp: ReactionPool) = {
-    val c = ja[Int]("c")
-    val g = js[Unit,Int]("g")
-    val i = ja[Unit]("i")
-    val d = ja[Unit]("d")
-    val f = js[LocalDateTime,Long]("f")
+    val c = m[Int]("c")
+    val g = b[Unit,Int]("g")
+    val i = m[Unit]("i")
+    val d = m[Unit]("d")
+    val f = b[LocalDateTime,Long]("f")
 
     join(
       tp { case c(0) + f(tInit, r) =>

--- a/benchmark/src/main/scala/code/winitzki/benchmark/Benchmarks4.scala
+++ b/benchmark/src/main/scala/code/winitzki/benchmark/Benchmarks4.scala
@@ -10,9 +10,9 @@ object Benchmarks4 {
     val n = 20
     val g = {
       val is: IndexedSeq[Int] = 0 until n
-      val f = ja[Unit]("f")
-      val g = js[LocalDateTime, Long]("g")
-      val as = is.map(i => ja[Int](s"a$i"))
+      val f = m[Unit]("f")
+      val g = b[LocalDateTime, Long]("g")
+      val as = is.map(i => m[Int](s"a$i"))
       val jrs = IndexedSeq(
         run { case f(_) + g(initTime, r) => r(elapsed(initTime)) }
       ) ++ is.map(

--- a/benchmark/src/main/scala/code/winitzki/benchmark/Benchmarks7.scala
+++ b/benchmark/src/main/scala/code/winitzki/benchmark/Benchmarks7.scala
@@ -16,9 +16,9 @@ object Benchmarks7 {
   def benchmark7(count: Int, threads: Int = 2): Long = {
 
     println(s"Creating $counters concurrent counters, each going from $count to 0")
-    val done = ja[Unit]("done")
-    val all_done = ja[Int]("all_done")
-    val f = js[LocalDateTime,Long]("f")
+    val done = m[Unit]("done")
+    val all_done = m[Int]("all_done")
+    val f = b[LocalDateTime,Long]("f")
 
     val tp = new ReactionPool(threads)
 
@@ -68,8 +68,8 @@ object Benchmarks7 {
   }
 
   def make_counters(done: JA[Unit], counters: Int, init: Int, tp: ReactionPool) = {
-    val c = ja[Int]("c")
-    val d = ja[Unit]("d")
+    val c = m[Int]("c")
+    val d = m[Unit]("d")
 
     join(
       tp{ case c(0) => done() },

--- a/benchmark/src/test/scala/code/winitzki/benchmark/MapReduceSpec.scala
+++ b/benchmark/src/test/scala/code/winitzki/benchmark/MapReduceSpec.scala
@@ -13,10 +13,10 @@ class MapReduceSpec extends FlatSpec with Matchers {
 
     val initTime = LocalDateTime.now
 
-    val res = ja[List[Int]]
-    val r = ja[Int]
-    val d = ja[Int]
-    val get = js[Unit, List[Int]]
+    val res = m[List[Int]]
+    val r = m[Int]
+    val d = m[Int]
+    val get = b[Unit, List[Int]]
 
     join(
       &{ case d(n) => r(n*2) },

--- a/benchmark/src/test/scala/code/winitzki/benchmark/MergesortSpec.scala
+++ b/benchmark/src/test/scala/code/winitzki/benchmark/MergesortSpec.scala
@@ -53,8 +53,8 @@ class MergesortSpec extends FlatSpec with Matchers {
 
   def performMergeSort[T : Ordering : ClassTag](array: Array[T], threads: Int = 8): Array[T] = {
 
-    val finalResult = ja[Array[T]]
-    val getFinalResult = js[Unit, Array[T]]
+    val finalResult = m[Array[T]]
+    val getFinalResult = b[Unit, Array[T]]
 
     join(
       &{ case finalResult(arr) + getFinalResult(_, r) => r(arr) }

--- a/benchmark/src/test/scala/code/winitzki/benchmark/MultithreadSpec.scala
+++ b/benchmark/src/test/scala/code/winitzki/benchmark/MultithreadSpec.scala
@@ -17,8 +17,8 @@ class MultithreadSpec extends FlatSpec with Matchers {
         (1 to n).foreach(i => (1 to i).foreach(j => (1 to j).foreach(k => math.cos(10000.0))))
       }
 
-      val a = ja[Int]
-      val never = js[Unit, Unit]
+      val a = m[Int]
+      val never = b[Unit, Unit]
       val tp = new ReactionPool(threads)
       join(
         tp { case a(c) if c > 0 => performWork(); a(c - 1) },

--- a/doc/join_calculus_joinrun_tutorial.md
+++ b/doc/join_calculus_joinrun_tutorial.md
@@ -38,7 +38,11 @@ It is not difficult to implement a simulator for the “chemical soup” behavio
 Having specified the list of “chemical laws”, we start the simulation waiting for some molecules to be injected into the soup.
 Once molecules are injected, we check whether some reactions can start.
 
-In a reaction such as `a + b + c ⇒ d + e` the **input molecules** are  `a`, `b`, and `c`, and the **output molecules** are `d` and `e`.
+We will say that in a reaction such as
+
+`a + b + c ⇒ d + e`
+
+the **input molecules** are  `a`, `b`, and `c`, and the **output molecules** are `d` and `e`.
 A reaction can have one or more input molecules, and zero or more output molecules.
 
 Once a reaction starts, the input molecules instantaneously disappear from the soup (they are “consumed” by the reaction), and then the output molecules are injected into the soup.
@@ -47,37 +51,39 @@ The simulator can start many reactions concurrently whenever their input molecul
 
 ## Using chemistry for concurrent computation
 
-The runtime engine of `JoinRun` implements such a “chemical machine simulator”.
+The “chemical machine” is implemented by the runtime engine of `JoinRun`.
 Now, rather than merely watch as reactions happen, we are going to use this engine for practical computations.
 
-The basic idea is that we are going to specify some values and expressions to be computed whenever reactions occur:
+To this end, we are going to specify some values and expressions to be computed whenever reactions occur:
 
-- Each molecule will carry a value. Molecule values are strongly typed: a molecule of a given sort (such as `b`) can only carry values of some fixed specified type.
+- Each molecule will carry a value. Molecule values are strongly typed: A molecule of a given sort (such as `a` or `b`) can only carry values of some fixed specified type (such as `Boolean` or `String`).
 - Each reaction will carry a function (the **reaction body**) that computes some new values and puts these values on the output molecules.
 The input arguments of the reaction body are going to be the values carried by the input molecules of the reaction.
 
-In `JoinRun`, we use the syntax like `a(123)` to denote molecule values.
-In this example, `a(123)`, the molecule `a` carries an integer value.
+In `JoinRun`, we use the syntax like `b(123)` to denote molecule values.
+In this example, `b(123)`, the molecule `b` carries an integer value `123`.
 
 A typical Join Calculus reaction (equipped with molecule values and a reaction body) may look like this:
 
 ```scala
-a(x) + b(y) ⇒ val z = computeZ(x,y); a(z)
+b(x) + c(y) ⇒ {
+  val z = computeZ(x,y)
+  b(z)
+}
 ```
 
-In this example, the reaction's input molecules are `a(x)` and `b(y)`; that is, the input molecules have chemical designations `a` and `b`, and carry values `x` and `y` respectively.
+In this example, the reaction's input molecules are `b(x)` and `c(y)`; that is, the input molecules have chemical designations `b` and `c` and carry values `x` and `y` respectively.
 The reaction body is a function that receives `x` and `y` as input arguments.
-It computes a value `z` out of `x` and `y`, and puts that `z` onto the output molecule `a`.
+It computes a value `z` out of `x` and `y`, and puts that `z` onto the output molecule `b`.
 
 Whenever input molecules are available in the soup, the runtime engine will start a reaction that consumes these input molecules.
-If many copies of input molecules are available, the runtime engine will start several reactions concurrently.
+If many copies of input molecules are available, the runtime engine could start several reactions concurrently.
+(The runtime engine can decide how many reactions to run depending on system load and the number of available cores.)
 
-Note that each reaction depends only on the values of its _input_ molecules.
-So it is completely safe to execute concurrently several instances of the same reaction, starting from different sets of input molecules.
-This is the way Join Calculus uses the “chemical simulator” to execute concurrent computations.
-
-The reaction body can be a pure function since it will receive its arguments on the input molecules.
-In this way, Join Calculus enables pure functional concurrent programming.
+Every reaction receives the values carried by its _input_ molecules as input arguments.
+The reaction body can be a pure function that computes output values purely from input values and outputs some new molecules that carry the newly computed output values.
+Then it is completely safe to execute concurrently several instances of the same reaction, consuming each time a different set of input molecules.
+This is the way Join Calculus uses the “chemical simulator” to achieve safe and automatic concurrency in a purely functional way.
 
 ## The syntax of `JoinRun`
 

--- a/doc/join_calculus_joinrun_tutorial.md
+++ b/doc/join_calculus_joinrun_tutorial.md
@@ -95,8 +95,8 @@ import code.winitzki.jc.JoinRun._
 import code.winitzki.jc.Macros._
 
 // declare the molecule types
-val a = jA[Int] // a(...) will be a molecule with an integer value
-val b = jA[Int] // ditto for b(...)
+val a = m[Int] // a(...) will be a molecule with an integer value
+val b = m[Int] // ditto for b(...)
 
 // declare the available reaction(s)
 join(
@@ -107,7 +107,7 @@ join(
 )
 ```
 
-The helper functions `jA`, `join`, and `run` are defined in the `JoinRun` library.
+The helper functions `m`, `join`, and `run` are defined in the `JoinRun` library.
 
 ## Example 0: concurrent counter
 
@@ -118,7 +118,7 @@ To implement this using Join Calculus, we begin by deciding which molecules we w
 It is clear that we will need a molecule that carries the integer value of the counter:
 
 ```scala
-val counter = jA[Int]
+val counter = m[Int]
 ```
 
 The increment and decrement operations must be represented by other molecules.
@@ -126,8 +126,8 @@ Let us call them `incr` and `decr`.
 These molecules do not need to carry values, so we will use `Unit` as their value type. 
 
 ```scala
-val incr = jA[Unit]
-val decr = jA[Unit]
+val incr = m[Unit]
+val decr = m[Unit]
 ```
 
 The reactions must be such that the counter is incremented when we inject the `incr` molecule, and decremented when we inject the `decr` molecule.
@@ -178,9 +178,9 @@ import code.winitzki.jc.JoinRun._
 import code.winitzki.jc.Macros._
 
 // declare the molecule types
-val counter = jA[Int]
-val incr = jA[Unit]
-val decr = jA[Unit]
+val counter = m[Int]
+val incr = m[Unit]
+val decr = m[Unit]
 
 // helper function to be used in reactions
 def printAndInject(x: Int) = {
@@ -235,7 +235,7 @@ So this facility should be used only for debugging.
 It is an error to inject a molecule that is not yet defined as input molecule in any JD.
 
 ```scala
-val x = jA[Int]
+val x = m[Int]
 
 x(100) // java.lang.Exception: Molecule x is not bound to any join definition
 ```
@@ -249,9 +249,9 @@ The correct way of using `JoinRun` is first to define molecules, then to create 
 It is also an error to write a reaction whose input molecule is already used as input in another join definition.
 
 ```scala
-val x = jA[Int]
-val a = jA[Unit]
-val b = jA[Unit]
+val x = m[Int]
+val a = m[Unit]
+val b = m[Unit]
 
 join( run { case x(n) + a(_) => println(s"have x($n) + a") } ) // OK
 
@@ -262,9 +262,9 @@ join( run { case x(n) + b(_) => println(s"have x($n) + b") } )
 Correct use of Join Calculus requires that we put these two reactions into a single join definition:
  
 ```scala
-val x = jA[Int]
-val a = jA[Unit]
-val b = jA[Unit]
+val x = m[Int]
+val a = m[Unit]
+val b = m[Unit]
 
 join(
   run { case x(n) + a(_) => println(s"have x($n) + a") },
@@ -277,12 +277,12 @@ However, reactions that use a certain molecule only as an output molecule can be
 Here is an example where we define one JD that computes a result and sends it on a molecule to another JD that prints that result:
 
 ```scala
-val show = jA[Int]
+val show = m[Int]
 
 // JD where “show” is an input molecule
 join( run { case show(x) => println(s"") })
 
-val start = jA[Unit]
+val start = m[Unit]
 
 // JD where “show” is an output molecule
 join(
@@ -297,7 +297,7 @@ It is not allowed to have a reaction with repeated input molecules, e.g. of the 
 An input molecule list with a repeated molecule is called a “nonlinear pattern”.
 
 ```scala
-val x = jA[Int]
+val x = m[Int]
 
 join(run { case x(n1) + x(n2) =>  })
 // java.lang.Exception: Nonlinear pattern: x used twice
@@ -350,26 +350,26 @@ A “hungry philosopher” molecule reacts with two neighbor “fork” molecule
 The complete code is shown here:
 
 ```scala
-    def rw(m: AbsMol): Unit = {
+    def rw(m: Molecule): Unit = {
       println(m.toString)
       Thread.sleep(scala.util.Random.nextInt(20))
     }
 
-    val h1 = new JA[Int]("Aristotle is thinking")
-    val h2 = new JA[Int]("Kant is thinking")
-    val h3 = new JA[Int]("Marx is thinking")
-    val h4 = new JA[Int]("Russell is thinking")
-    val h5 = new JA[Int]("Spinoza is thinking")
-    val t1 = new JA[Int]("Aristotle is eating")
-    val t2 = new JA[Int]("Kant is eating")
-    val t3 = new JA[Int]("Marx is eating")
-    val t4 = new JA[Int]("Russell is eating")
-    val t5 = new JA[Int]("Spinoza is eating")
-    val f12 = new JA[Unit]("f12")
-    val f23 = new JA[Unit]("f23")
-    val f34 = new JA[Unit]("f34")
-    val f45 = new JA[Unit]("f45")
-    val f51 = new JA[Unit]("f51")
+    val h1 = new M[Int]("Aristotle is thinking")
+    val h2 = new M[Int]("Kant is thinking")
+    val h3 = new M[Int]("Marx is thinking")
+    val h4 = new M[Int]("Russell is thinking")
+    val h5 = new M[Int]("Spinoza is thinking")
+    val t1 = new M[Int]("Aristotle is eating")
+    val t2 = new M[Int]("Kant is eating")
+    val t3 = new M[Int]("Marx is eating")
+    val t4 = new M[Int]("Russell is eating")
+    val t5 = new M[Int]("Spinoza is eating")
+    val f12 = new M[Unit]("f12")
+    val f23 = new M[Unit]("f23")
+    val f34 = new M[Unit]("f34")
+    val f45 = new M[Unit]("f45")
+    val f51 = new M[Unit]("f51")
 
     join (
       run { case t1(_) => rw(h1); h1() },
@@ -428,7 +428,7 @@ Once the reply value has been sent, the injecting process is unblocked.
 Here is an example of declaring a blocking molecule:
 
 ```scala
-val f = jS[Int, String]
+val f = b[Int, String]
 ```
 
 The molecule `f` carries a value of type `Int`; the reply value is of type `String`.
@@ -438,8 +438,8 @@ The “replying” action is non-blocking within the reaction body.
 Example syntax for the reply action within a reaction body:
 
 ```scala
-val f = jS[Unit, Int]
-val c = jA[Int]
+val f = b[Unit, Int]
+val c = m[Int]
 
 join( run { case c(n) + f(_, reply) => reply(n) } )
 ```
@@ -488,9 +488,9 @@ import java.time.temporal.ChronoUnit.MILLIS
 object C extends App {
 
   // declare molecule types
-  val fetch = jS[Unit, Unit]
-  val counter = jA[Int]
-  val decr = jA[Unit]
+  val fetch = b[Unit, Unit]
+  val counter = m[Int]
+  val decr = m[Unit]
   
   // declare reactions
   join(
@@ -528,21 +528,21 @@ The runtime engine cannot detect this situation because it cannot determine whet
 - If several reactions are available for the blocking molecule, one of these reactions will be selected at random.
 - It is an error if a reaction does not reply to the calling process:
 ```scala
-val f = jS[Unit, Unit]
-val c = jA[Int]
+val f = b[Unit, Unit]
+val c = m[Int]
 join( run { case f(_,reply) + c(n) => c(n+1) } ) // forgot to reply!
 
 f()
-java.lang.Exception: Error: In Join{f/S => ...}: Reaction {f/S => ...} finished without replying to f/S
+java.lang.Exception: Error: In Join{f/B => ...}: Reaction {f/B => ...} finished without replying to f/B
 ```
-- Blocking molecules are printed with the suffix `"/S"`, to indicate that they involve synchronous behavior.
+- Blocking molecules are printed with the suffix `"/B"`.
 
 ## Further details: Molecules and molecule injectors
 
 Molecules are injected into the “chemical soup” using the syntax such as `c(123)`. Here, `c` is a value we define using a construction such as
 
 ```scala
-val c = jA[Int]
+val c = m[Int]
 ```
 
 In Join Calculus, an injected molecule must carry a value.
@@ -551,22 +551,22 @@ The value `c` is a **molecule injector**, - that is, a value that can be used to
 The result of calling the injector when evaluating `c(123)` is a _side-effect_ which injects the molecule of sort `c` with value `123` into the soup.
 
 If `c` is a non-blocking molecule, the call `c(123)` is non-blocking and immediately returns `Unit`.
-The injector `c` has type `JA[Int]` and can be also created directly using the class constructor:
+The injector `c` has type `M[Int]` and can be also created directly using the class constructor:
 
 ```scala
-val c = new JA[Int]
+val c = new M[Int]("c")
 ```
 
 For a blocking molecule, such as
 ```scala
-val f = jS[Int, String]
+val f = b[Int, String]
 ```
 the `f` is an injector that takes an `Int` value and returns a `String`.
 
-Injectors for blocking molecules are essentially functions: their type is `JS[T, R]`, which extends `Function1[T, R]`.
+Injectors for blocking molecules are essentially functions: their type is `B[T, R]`, which extends `Function1[T, R]`.
 The injector `f` could be equivalently defined by
 ```scala
-val f = new JS[Int, String]
+val f = new B[Int, String]("f")
 ```
 
 Once `f` is defined like this, an injection call such as
@@ -587,20 +587,23 @@ Molecule names are used only for debugging: they are printed when logging reacti
 
 There are two ways of assigning a name to a molecule:
 - specify the name explicitly, by using a class constructor;
-- use the macros `jA` and `jS`.
+- use the macros `m` and `b`.
 
 Here is an example of defining injectors using explicit class constructors and molecule names:
 
 ```scala
-val counter = new JA[Int]("counter")
-val fetch = new JS[Unit, Int]("fetch")
+val counter = new M[Int]("counter")
+val fetch = new B[Unit, Int]("fetch")
 ```
 
 This code is completely equivalent to the shorter code written using macros:
 
 ```scala
-val counter = jA[Int]
-val fetch = jS[Unit, Int]
+import code.winitzki.jc.JoinRun._
+import code.winitzki.jc.Macros._
+
+val counter = m[Int]
+val fetch = b[Unit, Int]
 ```
 
 These macros can read the names `"counter"` and `"fetch"` from the surrounding code context.
@@ -608,20 +611,20 @@ This functionality is intended as a syntactic convenience.
 
 Each molecule injector as a `toString` method.
 This method will return the molecule's name if it was assigned.
-For blocking molecules, the molecule's name is followed by `"/S"`.
+For blocking molecules, the molecule's name is followed by `"/B"`.
 
 ```scala
-val x = new JA[Int]("counter")
-val y = new JS[Unit, Int]("fetch")
+val x = new M[Int]("counter")
+val y = new B[Unit, Int]("fetch")
 
 x.toString // returns “counter"
-y.toString // returns “fetch/S"
+y.toString // returns “fetch/B"
 ```
 
 ## More about the semantics of `JoinRun`
 
-- Injectors are local values of class `JA` or `JS`, which both extend the abstract class `AbsMol`.
-Blocking molecule injectors are of class `JS`, non-blocking of class `JA`.
+- Injectors are local values of class `B` or `M`, which both extend the abstract class `Molecule`.
+Blocking molecule injectors are of class `B`, non-blocking of class `M`.
 - Reactions are local values of class `Reaction`. Reactions are created using the method `run { case ... => ... }`.
 - Only one `case` clause can be used in each reaction.
 - Join definitions are values of class `JoinDefinition`. These values are not visible to the user: they are created in a closed scope by the `join` method.
@@ -667,7 +670,7 @@ Our goal is to come up with a “chemical” approach to concurrent map/reduce.
 Since we would like to apply the function `f` concurrently to values of type `A`, we need to put all these values on separate copies of some “carrier” molecule.
 
 ```scala
-val carrier = jA[A]
+val carrier = m[A]
 ```
 
 We will inject a copy of the “carrier” molecule for each element of the initial array:
@@ -680,7 +683,7 @@ arr.foreach(i => carrier(i))
 As we apply `f` to each element, we will carry the intermediate results on molecules of another sort:
 
 ```scala
-val interm = jA[B]
+val interm = m[B]
 ```
  
 Therefore, we need a reaction of this shape:
@@ -694,8 +697,8 @@ For this, we define the “accumulator” molecule `accum` that will carry the f
 We can also define a blocking molecule `fetch` that can be used to read the accumulated result from another process.
 
 ```scala
-val accum = jA[B]
-val fetch = jS[Unit, B]
+val accum = m[B]
+val fetch = b[Unit, B]
 ```
 
 At first we might write reactions for `accum` such as this one:
@@ -724,7 +727,7 @@ Reactions with `accum` will increment the counter; the reaction with `fetch` wil
 We will also include a condition on the counter that will start the accumulation when the counter is equal to 0.
 
 ```scala
-val accum = jA[(Int, B)]
+val accum = m[(Int, B)]
 
 run { case interm(res) + accum((n, b)) if n > 0 => 
     accum((n+1, reduceB(b, res) )) 
@@ -754,10 +757,10 @@ object C extends App {
   val arr = 1 to 100
 
   // declare molecule types
-  val carrier = jA[Int]
-  val interm = jA[Int]
-  val accum = jA[(Int,Int)]
-  val fetch = jS[Unit,Int]
+  val carrier = m[Int]
+  val interm = m[Int]
+  val accum = m[(Int,Int)]
+  val fetch = b[Unit,Int]
 
   // declare the reaction for "map"
   join(
@@ -796,10 +799,10 @@ A solution is to define `counter` and its reactions within a function that retur
 The `counter` injector will not be returned to the outside scope, and so the user will not be able to inject extra copies of that molecule.
 
 ```scala
-def makeCounter(initCount: Int): (JA[Unit], JS[Unit,Int]) = {
-  val counter = jA[Int]
-  val decr = jA[Unit]
-  val fetch = jA[Unit, Int]
+def makeCounter(initCount: Int): (M[Unit], B[Unit,Int]) = {
+  val counter = m[Int]
+  val decr = m[Unit]
+  val fetch = m[Unit, Int]
   
   join(
     run { counter(n) + fetch(_, r) => counter(n) + r(n)},
@@ -846,8 +849,8 @@ The initial data will be an array, and we will therefore need a molecule to carr
 We will also need another molecule to carry the sorted result.
 
 ```scala
-val mergesort = jA[Array[Int]]
-val sorted = jA[Array[Int]]
+val mergesort = m[Array[Int]]
+val sorted = m[Array[Int]]
 ```
 
 The main idea of the merge-sort algorithm is to split the array in half, sort each half recursively, and then merge the two sorted halves into the resulting array.
@@ -879,8 +882,8 @@ join ( run { case mergesort(arr) =>
     if (arr.length == 1) sorted(arr) else {
       val (part1, part2) = arr.splitAt(arr.length / 2)
       // define lower-level "sorted" molecules
-      val sorted1 = jA[Array[Int]]
-      val sorted2 = jA[Array[Int]]
+      val sorted1 = m[Array[Int]]
+      val sorted2 = m[Array[Int]]
       join( run { case sorted1(arr1) + sorted2(arr2) => sorted( arrayMerge(arr1, arr2) ) } )
       // inject recursively
       mergesort(part1) + mergesort(part2)
@@ -894,7 +897,7 @@ The way to achieve this is to pass the injectors for the `sorted` molecules as v
 We will then pass the lower-level `sorted` molecule injectors to the recursive calls of `mergesort`.
 
 ```scala
-val mergesort = new JA[(Array[T], JA[Array[T]])]
+val mergesort = new M[(Array[T], M[Array[T]])]
 
 join(
   run {
@@ -903,8 +906,8 @@ join(
       else {
         val (part1, part2) = arr.splitAt(arr.length/2)
         // "sorted1" and "sorted2" will be the sorted results from lower level
-        val sorted1 = new JA[Array[T]]
-        val sorted2 = new JA[Array[T]]
+        val sorted1 = new M[Array[T]]
+        val sorted2 = new M[Array[T]]
         join(
           run { case sorted1(arr1) + sorted2(arr2) => sorted(arrayMerge(arr1, arr2)) }
         )
@@ -913,7 +916,7 @@ join(
       }
   }
 )
-// sort our array at top level, assuming `finalResult: JA[Array[Int]]`
+// sort our array at top level, assuming `finalResult: M[Array[Int]]`
 mergesort((array, finalResult))
 ```
 
@@ -975,8 +978,8 @@ A convenient implementation is to define a function that will return an injector
 * @param finished A previously bound non-blocking molecule to be injected when the calculation is done
 * @return A new non-blocking molecule that will start the job
 */
-def submitJob[R](closure: Unit => R, finished: JA[R]): JA[R] = {
-  val startJobMolecule = new JA[Unit]
+def submitJob[R](closure: Unit => R, finished: M[R]): M[R] = {
+  val startJobMolecule = new M[Unit]
   
   join( run { case startJobMolecule(_) => 
     val result = closure()
@@ -994,7 +997,7 @@ Another implementation of the same idea will put the `finished` injector into th
 However, we lose some polymorphism since Scala values cannot be parameterized by types.
 
 ```scala
-val startJobMolecule = new JA[(Unit => Any, JA[Any])]
+val startJobMolecule = new M[(Unit => Any, M[Any])]
 
 join(
   run {
@@ -1016,9 +1019,9 @@ We also need to make sure that the molecule `godot()` is never injected into the
 So we declare `godot` locally within the scope of `wait_forever`, where will inject nothing into the soup.
 
 ```scala
-def wait_forever: jS[Unit, Unit] = {
-  val godot = jA[Unit]
-  val wait = jS[Unit, Unit]
+def wait_forever: b[Unit, Unit] = {
+  val godot = m[Unit]
+  val wait = b[Unit, Unit]
   
   join( run { case godot(_,r) + wait(_) => r() } )
   
@@ -1070,9 +1073,9 @@ This method will create a new molecule and a new future value.
 We can then use this molecule as output in some reaction.
 
 ```scala
-val a = jA[Int]
+val a = m[Int]
 
-val (c: JA[String], fut: Future[String]) = moleculeFuture[String]
+val (c: M[String], fut: Future[String]) = moleculeFuture[String]
 // injecting the molecule c(...) resolves "fut"
 
 join( run { case a(x) => c("finished") } ) // our reactions that eventually inject "c"

--- a/doc/joinrun.md
+++ b/doc/joinrun.md
@@ -24,8 +24,8 @@ Join Calculus is implemented using molecule injectors, reactions, and join defin
 
 There are only two primitive operations:
 
-- define reactions using a join definition
-- inject molecules using molecule injectors
+- define reactions by writing a join definition
+- inject molecules by calling molecule injectors with argument values
 
 ## Molecule injectors
 

--- a/lib/src/main/scala/code/winitzki/jc/JoinRun.scala
+++ b/lib/src/main/scala/code/winitzki/jc/JoinRun.scala
@@ -10,11 +10,8 @@ and Philipp Haller (http://lampwww.epfl.ch/~phaller/joins/index.html, 2008).
 
 TODO and roadmap:
   value * difficulty - description
- 4 * 2 - make thread pools an Option, so that default thread pool can be used for all reactions except some. Do not use implicit arguments - use default arguments.
 
  4 * 2 - make helper functions to create a new joinpool
-
- 2 * 2 - unify join pools and reaction pools into one type; replace implicits by default argument values.
 
  2 * 2 - should `run` take ReactionBody or simply UnapplyArg => Unit?
 

--- a/lib/src/main/scala/code/winitzki/jc/JoinRun.scala
+++ b/lib/src/main/scala/code/winitzki/jc/JoinRun.scala
@@ -132,12 +132,12 @@ object JoinRun {
     */
   def js[T: ClassTag,R](name: String) = new SynMol[T,R](Some(name))
 
-  // Wait until the join definition to which `molecule` belongs becomes quiescent, then inject `callback`.
+  // Wait until the join definition to which `molecule` is bound becomes quiescent, then inject `callback`.
   // TODO: implement
   def wait_until_quiet[T](molecule: AsynMol[T], callback: AsynMol[Unit]): Unit = {
     molecule.joinDef match {
       case Some(owner) => owner.setQuiescenceCallback(callback)
-      case None => throw new Exception(s"Molecule $molecule belongs to no join definition")
+      case None => throw new Exception(s"Molecule $molecule is not bound to a join definition")
     }
   }
 
@@ -215,7 +215,7 @@ object JoinRun {
     def getName: String = name.getOrElse(super.toString)
 
     protected def errorNoJoinDef =
-      new ExceptionNoJoinDef(s"Molecule ${this} does not belong to any join definition")
+      new ExceptionNoJoinDef(s"Molecule ${this} is not bound to any join definition")
 
     def setLogLevel(logLevel: Int): Unit =
       joinDef.map(o => o.logLevel = logLevel).getOrElse(throw errorNoJoinDef)
@@ -323,7 +323,7 @@ object JoinRun {
       */
     def apply(v: T): R =
       joinDef.map(_.injectSyncAndReply[T,R](this, v, SyncReplyValue[R]()))
-        .getOrElse(throw new ExceptionNoJoinDef(s"Molecule $this does not belong to any join definition"))
+        .getOrElse(throw new ExceptionNoJoinDef(s"Molecule $this is not bound to any join definition"))
 
     /** Inject a blocking molecule and receive a value when the reply action is performed, unless a timeout is reached.
       *
@@ -333,7 +333,7 @@ object JoinRun {
       */
     def apply(timeout: Long)(v: T): Option[R] =
       joinDef.map(_.injectSyncAndReplyWithTimeout[T,R](timeout, this, v, SyncReplyValue[R]()))
-        .getOrElse(throw new ExceptionNoJoinDef(s"Molecule $this does not belong to any join definition"))
+        .getOrElse(throw new ExceptionNoJoinDef(s"Molecule $this is not bound to any join definition"))
 
     override def toString: String = getName + "/S"
 
@@ -430,7 +430,7 @@ object JoinRun {
 
   /** Create a join definition with one or more reactions.
     * All input and output molecules in reactions used in this JD should have been
-    * already defined, and input molecules should not already belong to another JD.
+    * already defined, and input molecules should not be already bound to another JD.
     *
     * @param rs One or more reactions of type [[JoinRun#Reaction]]
     * @param reactionPool Thread pool for running new reactions.

--- a/lib/src/main/scala/code/winitzki/jc/Library.scala
+++ b/lib/src/main/scala/code/winitzki/jc/Library.scala
@@ -12,8 +12,8 @@ object Library {
     * @tparam T Type of value carried by the molecule and by the future.
     * @return Tuple consisting of new molecule injector and the new future
     */
-  def moleculeFuture[T : ClassTag]: (JA[T], Future[T]) = {
-    val f = ja[T]
+  def moleculeFuture[T : ClassTag]: (M[T], Future[T]) = {
+    val f = new M[T]("future")
     val p = Promise[T]()
 
     join(
@@ -32,7 +32,7 @@ object Library {
       * @param m Molecule injector, must have the same type as the future.
       * @return The modified future.
       */
-    def &(m: JA[T]): Future[T] = f map { x =>
+    def &(m: M[T]): Future[T] = f map { x =>
       m(x)
       x
     }

--- a/lib/src/test/scala/code/winitzki/benchmark/DiningPhilosophersSpec.scala
+++ b/lib/src/test/scala/code/winitzki/benchmark/DiningPhilosophersSpec.scala
@@ -10,7 +10,7 @@ class DiningPhilosophersSpec extends FlatSpec with Matchers with TimeLimitedTest
 
   val timeLimit = Span(10000, Millis)
 
-  def rw(m: AbsMol): Unit = {
+  def rw(m: Molecule): Unit = {
     println(m.toString)
     Thread.sleep(math.floor(scala.util.Random.nextDouble*20.0 + 2.0).toLong)
   }
@@ -23,24 +23,24 @@ class DiningPhilosophersSpec extends FlatSpec with Matchers with TimeLimitedTest
 
     val tp = new FixedPool(8)
 
-    val h1 = ja[Int]("Aristotle is hungry")
-    val h2 = ja[Int]("Kant is hungry")
-    val h3 = ja[Int]("Marx is hungry")
-    val h4 = ja[Int]("Russell is hungry")
-    val h5 = ja[Int]("Spinoza is hungry")
-    val t1 = ja[Int]("Aristotle is thinking")
-    val t2 = ja[Int]("Kant is thinking")
-    val t3 = ja[Int]("Marx is thinking")
-    val t4 = ja[Int]("Russell is thinking")
-    val t5 = ja[Int]("Spinoza is thinking")
-    val f12 = ja[Unit]("f12")
-    val f23 = ja[Unit]("f23")
-    val f34 = ja[Unit]("f34")
-    val f45 = ja[Unit]("f45")
-    val f51 = ja[Unit]("f51")
+    val h1 = new M[Int]("Aristotle is hungry")
+    val h2 = new M[Int]("Kant is hungry")
+    val h3 = new M[Int]("Marx is hungry")
+    val h4 = new M[Int]("Russell is hungry")
+    val h5 = new M[Int]("Spinoza is hungry")
+    val t1 = new M[Int]("Aristotle is thinking")
+    val t2 = new M[Int]("Kant is thinking")
+    val t3 = new M[Int]("Marx is thinking")
+    val t4 = new M[Int]("Russell is thinking")
+    val t5 = new M[Int]("Spinoza is thinking")
+    val f12 = new M[Unit]("f12")
+    val f23 = new M[Unit]("f23")
+    val f34 = new M[Unit]("f34")
+    val f45 = new M[Unit]("f45")
+    val f51 = new M[Unit]("f51")
 
-    val done = ja[Unit]("done")
-    val check = js[Unit, Unit]("check")
+    val done = new M[Unit]("done")
+    val check = new B[Unit, Unit]("check")
 
     join(tp, tp) (
       & { case t1(n) => rw(h1); h1(n - 1) },

--- a/lib/src/test/scala/code/winitzki/benchmark/FairnessSpec.scala
+++ b/lib/src/test/scala/code/winitzki/benchmark/FairnessSpec.scala
@@ -12,7 +12,7 @@ class FairnessSpec extends FlatSpec with Matchers with TimeLimitedTests {
   behavior of "join definition"
 
   // fairness over reactions:
-  // We have n molecules A:JA[Unit], which can all interact with a single molecule C:JA[(Int,Array[Int])].
+  // We have n molecules A:M[Unit], which can all interact with a single molecule C:M[(Int,Array[Int])].
   // We first inject all A's and then a single C.
   // Each molecule A_i will increment C's counter at index i upon reaction.
   // We repeat this for N iterations, then we read the array and check that its values are distributed more or less randomly.
@@ -22,13 +22,13 @@ class FairnessSpec extends FlatSpec with Matchers with TimeLimitedTests {
     val reactions = 4
     val N = 1000
 
-    val c = ja[(Int, Array[Int])]("c")
-    val done = ja[Array[Int]]("done")
-    val getC = js[Unit, Array[Int]]("getC")
-    val a0 = ja[Unit]("a0")
-    val a1 = ja[Unit]("a1")
-    val a2 = ja[Unit]("a2")
-    val a3 = ja[Unit]("a3")
+    val c = new M[(Int, Array[Int])]("c")
+    val done = new M[Array[Int]]("done")
+    val getC = new B[Unit, Array[Int]]("getC")
+    val a0 = new M[Unit]("a0")
+    val a1 = new M[Unit]("a1")
+    val a2 = new M[Unit]("a2")
+    val a3 = new M[Unit]("a3")
     //n = 4
 
     join(
@@ -61,11 +61,11 @@ class FairnessSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
     val cycles = 1000
 
-    val c = ja[Int]("c")
-    val done = ja[List[Int]]("done")
-    val getC = js[Unit, List[Int]]("getC")
-    val gather = ja[List[Int]]("gather")
-    val a = ja[Int]("a")
+    val c = new M[Int]("c")
+    val done = new M[List[Int]]("done")
+    val getC = new B[Unit, List[Int]]("getC")
+    val gather = new M[List[Int]]("gather")
+    val a = new M[Int]("a")
 
     join(
       &{ case done(arr) + getC(_, r) => r(arr) },
@@ -92,13 +92,13 @@ class FairnessSpec extends FlatSpec with Matchers with TimeLimitedTests {
     * Verify that both reactions proceed with probability roughly 1/2.
     */
   it should "schedule reactions fairly after multiple injection" in {
-    val a = ja[Unit]("a")
-    val b = ja[Unit]("b")
-    val c = ja[Unit]("c")
-    val d = ja[Unit]("d")
-    val e = ja[Unit]("e")
-    val f = ja[(Int,Int,Int)]("f")
-    val g = js[Unit, (Int,Int)]("g")
+    val a = new M[Unit]("a")
+    val b = new M[Unit]("b")
+    val c = new M[Unit]("c")
+    val d = new M[Unit]("d")
+    val e = new M[Unit]("e")
+    val f = new M[(Int,Int,Int)]("f")
+    val g = new B[Unit, (Int,Int)]("g")
 
     join(
       &{ case a(_) + b(_) => d() },
@@ -123,10 +123,10 @@ class FairnessSpec extends FlatSpec with Matchers with TimeLimitedTests {
   // interestingly, this test fails to complete in 500ms on Travis CI with Scala 2.10, but succeeds with 2.11
   it should "fail to schedule reactions fairly after multiple injection into separate JDs" in {
 
-    def makeJD(d1: JA[Unit], d2: JA[Unit]): (JA[Unit],JA[Unit],JA[Unit]) = {
-      val a = ja[Unit]("a")
-      val b = ja[Unit]("b")
-      val c = ja[Unit]("c")
+    def makeJD(d1: M[Unit], d2: M[Unit]): (M[Unit],M[Unit],M[Unit]) = {
+      val a = new M[Unit]("a")
+      val b = new M[Unit]("b")
+      val c = new M[Unit]("c")
       join(
         &{ case a(_) + b(_) => d1() },
         &{ case b(_) + c(_) => d2() }
@@ -134,10 +134,10 @@ class FairnessSpec extends FlatSpec with Matchers with TimeLimitedTests {
       (a,b,c)
     }
 
-    val d = ja[Unit]("d")
-    val e = ja[Unit]("e")
-    val f = ja[(Int,Int,Int)]("f")
-    val g = js[Unit, (Int,Int)]("g")
+    val d = new M[Unit]("d")
+    val e = new M[Unit]("e")
+    val f = new M[(Int,Int,Int)]("f")
+    val g = new B[Unit, (Int,Int)]("g")
 
     join(
       &{ case d(_) + f((x,y,t)) => f((x+1,y,t-1)) },

--- a/lib/src/test/scala/code/winitzki/benchmark/ParallelOrSpec.scala
+++ b/lib/src/test/scala/code/winitzki/benchmark/ParallelOrSpec.scala
@@ -16,12 +16,12 @@ class ParallelOrSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
   lazy val never = neverReturn[Boolean]
 
-  def or(b1: => Boolean, b2: => Boolean): JS[Unit, Boolean] = {
-    val res = js[Unit, Boolean]
-    val res1 = ja[Boolean]
-    val res2 = ja[Boolean]
-    val res1_false = js[Unit, Boolean]
-    val res2_false = js[Unit, Boolean]
+  def or(b1: => Boolean, b2: => Boolean): B[Unit, Boolean] = {
+    val res = new B[Unit, Boolean]("res")
+    val res1 = new M[Boolean]("res1")
+    val res2 = new M[Boolean]("res2")
+    val res1_false = new B[Unit, Boolean]("res1_false")
+    val res2_false = new B[Unit, Boolean]("res2_false")
 
     join (
       &{ case res(_, res_reply) + res1(b) => if (b) res_reply(b) else res_reply(res1_false()) },

--- a/lib/src/test/scala/code/winitzki/jc/JoinRunSpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/JoinRunSpec.scala
@@ -150,7 +150,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
     val thrown = intercept[Exception] {
       b()
     }
-    thrown.getMessage shouldEqual "Molecule b does not belong to any join definition"
+    thrown.getMessage shouldEqual "Molecule b is not bound to any join definition"
 
   }
 
@@ -244,7 +244,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
       val a = js[Unit,Unit]("x")
       a()
     }
-    thrown.getMessage shouldEqual "Molecule x/S does not belong to any join definition"
+    thrown.getMessage shouldEqual "Molecule x/S is not bound to any join definition"
   }
 
   it should "throw exception when trying to inject a non-blocking molecule that has no join" in {
@@ -252,7 +252,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
       val a = ja[Unit]("x")
       a()
     }
-    thrown.getMessage shouldEqual "Molecule x does not belong to any join definition"
+    thrown.getMessage shouldEqual "Molecule x is not bound to any join definition"
   }
 
   it should "throw exception when trying to log soup of a blocking molecule that has no join" in {
@@ -260,7 +260,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
       val a = js[Unit,Unit]("x")
       a.logSoup
     }
-    thrown.getMessage shouldEqual "Molecule x/S does not belong to any join definition"
+    thrown.getMessage shouldEqual "Molecule x/S is not bound to any join definition"
   }
 
   it should "throw exception when trying to log soup a non-blocking molecule that has no join" in {
@@ -268,7 +268,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
       val a = ja[Unit]("x")
       a.logSoup
     }
-    thrown.getMessage shouldEqual "Molecule x does not belong to any join definition"
+    thrown.getMessage shouldEqual "Molecule x is not bound to any join definition"
   }
 
   it should "fail to start reactions when pattern is not matched" in {

--- a/lib/src/test/scala/code/winitzki/jc/JoinRunSpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/JoinRunSpec.scala
@@ -17,9 +17,9 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
   behavior of "join definition"
 
   it should "define a reaction with correct inputs" in {
-    val a = ja[Unit]("a")
-    val b = ja[Unit]("b")
-    val c = ja[Unit]("c")
+    val a = new M[Unit]("a")
+    val b = new M[Unit]("b")
+    val c = new M[Unit]("c")
 
     a.toString shouldEqual "a"
 
@@ -35,9 +35,9 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
   }
 
   it should "define a reaction with correct inputs with non-default pattern-matching at end of reaction" in {
-    val a = ja[Option[Int]]("a")
-    val b = ja[Unit]("b")
-    val c = ja[Unit]("c")
+    val a = new M[Option[Int]]("a")
+    val b = new M[Unit]("b")
+    val c = new M[Unit]("c")
 
     join(&{ case b(_) + c(_) + a(Some(x)) => })
 
@@ -45,9 +45,9 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
   }
 
   it should "define a reaction with correct inputs with non-default pattern-matching in the middle of reaction" in {
-    val a = ja[Option[Int]]("a")
-    val b = ja[Unit]("b")
-    val c = ja[Unit]("c")
+    val a = new M[Option[Int]]("a")
+    val b = new M[Unit]("b")
+    val c = new M[Unit]("c")
 
     join(&{ case b(_) + a(Some(x)) + c(_) => })
 
@@ -56,9 +56,9 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
   }
 
   it should "define a reaction with correct inputs with default pattern-matching in the middle of reaction" in {
-    val a = ja[Option[Int]]("a")
-    val b = ja[Unit]("b")
-    val c = ja[Unit]("c")
+    val a = new M[Option[Int]]("a")
+    val b = new M[Unit]("b")
+    val c = new M[Unit]("c")
 
     join(&{ case b(_) + a(None) + c(_) => })
 
@@ -66,9 +66,9 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
   }
 
   it should "define a reaction with correct inputs with non-simple default pattern-matching in the middle of reaction" in {
-    val a = ja[Seq[Int]]("a")
-    val b = ja[Unit]("b")
-    val c = ja[Unit]("c")
+    val a = new M[Seq[Int]]("a")
+    val b = new M[Unit]("b")
+    val c = new M[Unit]("c")
 
     join(&{ case b(_) + a(List()) + c(_) => })
 
@@ -76,9 +76,9 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
   }
 
   it should "define a reaction with correct inputs with empty option pattern-matching at start of reaction" in {
-    val a = ja[Option[Int]]("a")
-    val b = ja[Unit]("b")
-    val c = ja[Unit]("c")
+    val a = new M[Option[Int]]("a")
+    val b = new M[Unit]("b")
+    val c = new M[Unit]("c")
 
     join(&{ case a(None) + b(_) + c(_) => })
 
@@ -86,9 +86,9 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
   }
 
   it should "define a reaction with correct inputs with constant default pattern-matching at start of reaction" in {
-    val a = ja[Int]("a")
-    val b = ja[Unit]("b")
-    val c = ja[Unit]("c")
+    val a = new M[Int]("a")
+    val b = new M[Unit]("b")
+    val c = new M[Unit]("c")
 
     join(&{ case a(0) + b(_) + c(_) => })
 
@@ -96,9 +96,9 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
   }
 
   it should "define a reaction with correct inputs with constant non-default pattern-matching at start of reaction" in {
-    val a = ja[Int]("a")
-    val b = ja[Unit]("b")
-    val c = ja[Unit]("c")
+    val a = new M[Int]("a")
+    val b = new M[Unit]("b")
+    val c = new M[Unit]("c")
 
     join(&{ case a(1) + b(_) + c(_) => })
 
@@ -107,9 +107,9 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
   }
 
   it should "define a reaction with correct inputs with constant default option pattern-matching at start of reaction" in {
-    val a = ja[Option[Int]]("a")
-    val b = ja[Unit]("b")
-    val c = ja[Unit]("c")
+    val a = new M[Option[Int]]("a")
+    val b = new M[Unit]("b")
+    val c = new M[Unit]("c")
 
     join(&{ case a(None) + b(_) + c(_) => })
 
@@ -117,9 +117,9 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
   }
 
   it should "define a reaction with correct inputs with constant non-default pattern-matching at end of reaction" in {
-    val a = ja[Int]("a")
-    val b = ja[Unit]("b")
-    val c = ja[Unit]("c")
+    val a = new M[Int]("a")
+    val b = new M[Unit]("b")
+    val c = new M[Unit]("c")
 
     join(&{ case b(_) + c(_) + a(1) => })
 
@@ -127,9 +127,9 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
   }
 
   it should "define a reaction with correct inputs with non-default pattern-matching at start of reaction" in {
-    val a = ja[Option[Int]]("a")
-    val b = ja[Unit]("b")
-    val c = ja[Unit]("c")
+    val a = new M[Option[Int]]("a")
+    val b = new M[Unit]("b")
+    val c = new M[Unit]("c")
 
     join(&{ case a(Some(x)) + b(_) + c(_) => })
 
@@ -138,8 +138,8 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
   }
 
   it should "generate an error message when the inputs are incorrectly inferred from reaction" in {
-    val a = ja[Option[Int]]("a")
-    val b = ja[Unit]("b")
+    val a = new M[Option[Int]]("a")
+    val b = new M[Unit]("b")
 
     join(&{ case a(Some(x)) + b(_) => }) // currently, the limitations in the pattern-macher will cause this
     // to fail to recognize that "b" is an input molecule in this reaction.
@@ -158,7 +158,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
     val waiter = new Waiter
 
-    val a = new JA[Unit]
+    val a = new M[Unit]("a")
 
     join( &{ case a(_) => waiter.dismiss() })
 
@@ -170,7 +170,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
     val waiter = new Waiter
 
-    val a = ja[Unit]
+    val a = new M[Unit]("a")
     join( &{ case a(_) => waiter.dismiss() })
     a()
     waiter.await()
@@ -180,8 +180,8 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
     val waiter = new Waiter
 
-    val a = ja[Unit]("a")
-    val b = ja[Unit]("b")
+    val a = new M[Unit]("a")
+    val b = new M[Unit]("b")
     join( &{ case a(_) => b() }, &{ case b(_) => waiter.dismiss() })
 
     a()
@@ -192,9 +192,9 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
     val waiter = new Waiter
 
-    val a = ja[Int]
-    val b = ja[Int]
-    val c = ja[Int]
+    val a = new M[Int]("a")
+    val b = new M[Int]("b")
+    val c = new M[Int]("c")
     join( &{ case a(x) + b(y) => c(x+y) }, &{ case c(z) => waiter { z shouldEqual 3 }; waiter.dismiss() })
     a(1)
     b(2)
@@ -203,7 +203,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
   it should "throw exception when join pattern is nonlinear" in {
     val thrown = intercept[Exception] {
-      val a = ja[Unit]("a")
+      val a = new M[Unit]("a")
       join( &{ case a(_) + a(_) => () })
       a()
     }
@@ -213,26 +213,26 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
   it should "throw exception when join pattern is nonlinear, with blocking molecule" in {
     val thrown = intercept[Exception] {
-      val a = js[Unit,Unit]("a")
+      val a = new B[Unit,Unit]("a")
       join( &{ case a(_,r) + a(_,s) => () })
       a()
     }
-    thrown.getMessage shouldEqual "Nonlinear pattern: a/S used twice"
+    thrown.getMessage shouldEqual "Nonlinear pattern: a/B used twice"
   }
 
   it should "throw exception when join pattern attempts to redefine a blocking molecule" in {
     val thrown = intercept[Exception] {
-      val a = js[Unit,Unit]("a")
+      val a = new B[Unit,Unit]("a")
       join( &{ case a(_,_) => () })
       join( &{ case a(_,_) => () })
     }
-    thrown.getMessage shouldEqual "Molecule a/S cannot be used as input since it was already used in Join{a/S => ...}"
+    thrown.getMessage shouldEqual "Molecule a/B cannot be used as input since it was already used in Join{a/B => ...}"
   }
 
   it should "throw exception when join pattern attempts to redefine a non-blocking molecule" in {
     val thrown = intercept[Exception] {
-      val a = ja[Unit]("x")
-      val b = ja[Unit]("y")
+      val a = new M[Unit]("x")
+      val b = new M[Unit]("y")
       join( &{ case a(_) + b(_) => () })
       join( &{ case a(_) => () })
     }
@@ -241,15 +241,15 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
   it should "throw exception when trying to inject a blocking molecule that has no join" in {
     val thrown = intercept[Exception] {
-      val a = js[Unit,Unit]("x")
+      val a = new B[Unit,Unit]("x")
       a()
     }
-    thrown.getMessage shouldEqual "Molecule x/S is not bound to any join definition"
+    thrown.getMessage shouldEqual "Molecule x/B is not bound to any join definition"
   }
 
   it should "throw exception when trying to inject a non-blocking molecule that has no join" in {
     val thrown = intercept[Exception] {
-      val a = ja[Unit]("x")
+      val a = new M[Unit]("x")
       a()
     }
     thrown.getMessage shouldEqual "Molecule x is not bound to any join definition"
@@ -257,15 +257,15 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
   it should "throw exception when trying to log soup of a blocking molecule that has no join" in {
     val thrown = intercept[Exception] {
-      val a = js[Unit,Unit]("x")
+      val a = new B[Unit,Unit]("x")
       a.logSoup
     }
-    thrown.getMessage shouldEqual "Molecule x/S is not bound to any join definition"
+    thrown.getMessage shouldEqual "Molecule x/B is not bound to any join definition"
   }
 
   it should "throw exception when trying to log soup a non-blocking molecule that has no join" in {
     val thrown = intercept[Exception] {
-      val a = ja[Unit]("x")
+      val a = new M[Unit]("x")
       a.logSoup
     }
     thrown.getMessage shouldEqual "Molecule x is not bound to any join definition"
@@ -273,9 +273,9 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
   it should "fail to start reactions when pattern is not matched" in {
 
-    val a = ja[Int]
-    val b = ja[Int]
-    val f = js[Unit,Int]
+    val a = new M[Int]("a")
+    val b = new M[Int]("b")
+    val f = new B[Unit,Int]("f")
 
     join( &{ case a(x) + b(0) => a(x+1) }, &{ case a(z) + f(_, r) => r(z) })
     a(1)
@@ -285,9 +285,9 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
   }
 
   it should "implement the non-blocking single-access counter" in {
-    val c = ja[Int]("c")
-    val d = ja[Unit]("decrement")
-    val g = js[Unit,Int]("getValue")
+    val c = new M[Int]("c")
+    val d = new M[Unit]("decrement")
+    val g = new B[Unit,Int]("getValue")
     join(
       &{ case c(n) + d(_) => c(n-1) },
       &{ case c(n) + g(_,r) => c(n) + r(n) }
@@ -298,11 +298,11 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
   }
 
   it should "use one thread for concurrent computations" in {
-    val c = ja[Int]("counter")
-    val d = ja[Unit]("decrement")
-    val f = ja[Unit]("finished")
-    val a = ja[Int]("all_finished")
-    val g = js[Unit,Int]("getValue")
+    val c = new M[Int]("counter")
+    val d = new M[Unit]("decrement")
+    val f = new M[Unit]("finished")
+    val a = new M[Int]("all_finished")
+    val g = new B[Unit,Int]("getValue")
 
     val tp = new FixedPool(1)
 
@@ -321,11 +321,11 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
   }
 
   it should "use two threads for concurrent computations" in {
-    val c = ja[Int]("counter")
-    val d = ja[Unit]("decrement")
-    val f = ja[Unit]("finished")
-    val a = ja[Int]("all_finished")
-    val g = js[Unit,Int]("getValue")
+    val c = new M[Int]("counter")
+    val d = new M[Unit]("decrement")
+    val f = new M[Unit]("finished")
+    val a = new M[Int]("all_finished")
+    val g = new B[Unit,Int]("getValue")
 
     val tp = new FixedPool(2)
 
@@ -344,9 +344,9 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
   it should "process simple reactions quickly enough" in {
     val n = 1000
 
-    val c = ja[Int]("counter")
-    val d = ja[Unit]("decrement")
-    val g = js[Unit, Int]("getValue")
+    val c = new M[Int]("counter")
+    val d = new M[Unit]("decrement")
+    val g = new B[Unit, Int]("getValue")
     val tp = new FixedPool(2)
     join(
       & { case c(x) + d(_) => c(x - 1) } onThreads tp,
@@ -366,9 +366,9 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
     val probabilityOfCrash = 0.5
 
-    val c = ja[Int]("counter")
-    val d = ja[Unit]("decrement")
-    val g = js[Unit, Int]("getValue")
+    val c = new M[Int]("counter")
+    val d = new M[Unit]("decrement")
+    val g = new B[Unit, Int]("getValue")
     val tp = new FixedPool(2)
 
     join(

--- a/lib/src/test/scala/code/winitzki/jc/LibrarySpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/LibrarySpec.scala
@@ -23,7 +23,7 @@ class LibrarySpec extends FlatSpec with Matchers with TimeLimitedTests {
   it should "inject a molecule from a future computed out of a given future" in {
     val waiter = new Waiter
 
-    val c = ja[Unit]("c")
+    val c = new M[Unit]("c")
 
     join(
       & { case c(_) => waiter.dismiss() }
@@ -37,7 +37,7 @@ class LibrarySpec extends FlatSpec with Matchers with TimeLimitedTests {
   it should "inject a molecule from a future with a lazy injection" in {
     val waiter = new Waiter
 
-    val c = ja[String]("c")
+    val c = new M[String]("c")
 
     join(
       & { case c(x) => waiter {x shouldEqual "send it off"}; waiter.dismiss() }
@@ -51,11 +51,11 @@ class LibrarySpec extends FlatSpec with Matchers with TimeLimitedTests {
   it should "not inject a molecule from a future prematurely" in {
     val waiter = new Waiter
 
-    val c = ja[Unit]("c")
-    val rmC = ja[Unit]("remove c")
-    val d = ja[Unit]("d")
-    val e = ja[Unit]("e")
-    val f = js[Unit, String]("f")
+    val c = new M[Unit]("c")
+    val rmC = new M[Unit]("remove c")
+    val d = new M[Unit]("d")
+    val e = new M[Unit]("e")
+    val f = new B[Unit, String]("f")
 
     join(
       & { case c(_) + rmC(_) => },
@@ -84,7 +84,7 @@ class LibrarySpec extends FlatSpec with Matchers with TimeLimitedTests {
   it should "create a future that succeeds when molecule is injected" in {
     val waiter = new Waiter
 
-    val b = ja[Unit]("b")
+    val b = new M[Unit]("b")
     // "fut" will succeed when "c" is injected
     val (c, fut) = moleculeFuture[String]
 

--- a/macros/src/main/scala/code/winitzki/jc/Macros.scala
+++ b/macros/src/main/scala/code/winitzki/jc/Macros.scala
@@ -25,27 +25,27 @@ object Macros {
     c.Expr[String](q"$s")
   }
 
-  def jA[T]: JA[T] = macro jAImpl[T]
+  def m[T]: M[T] = macro mImpl[T]
 
-  def jAImpl[T: c.WeakTypeTag](c: theContext): c.Expr[JA[T]] = {
+  def mImpl[T: c.WeakTypeTag](c: theContext): c.Expr[M[T]] = {
     import c.universe._
     val s = getEnclosingName(c)
 
     val t = c.weakTypeOf[T]
 
-    c.Expr[JA[T]](q"new JA[$t](Some($s))")
+    c.Expr[M[T]](q"new M[$t]($s)")
   }
 
-  def jS[T, R]: JS[T, R] = macro jSImpl[T, R]
+  def b[T, R]: B[T, R] = macro bImpl[T, R]
 
-  def jSImpl[T: c.WeakTypeTag, R: c.WeakTypeTag](c: blackbox.Context): c.Expr[JS[T, R]] = {
+  def bImpl[T: c.WeakTypeTag, R: c.WeakTypeTag](c: blackbox.Context): c.Expr[B[T, R]] = {
     import c.universe._
     val s = c.internal.enclosingOwner.name.decodedName.toString.stripSuffix(LOCAL_SUFFIX_STRING).stripSuffix("$lzy")
 
     val t = c.weakTypeOf[T]
     val r = c.weakTypeOf[R]
 
-    c.Expr[JS[T, R]](q"new JS[$t,$r](Some($s))")
+    c.Expr[B[T, R]](q"new B[$t,$r]($s)")
   }
 
   sealed trait PatternFlag

--- a/macros/src/test/scala/code/winitzki/jc/MacrosSpec.scala
+++ b/macros/src/test/scala/code/winitzki/jc/MacrosSpec.scala
@@ -9,21 +9,21 @@ class MacrosSpec extends FlatSpec with Matchers {
   behavior of "JoinRun macro utilities"
 
   it should "compute invocation names for molecule injectors" in {
-    val a = jA[Int]
+    val a = m[Int]
 
     a.toString shouldEqual "a"
 
-    val s = jS[Map[(Boolean,Unit),Seq[Int]], Option[List[(Int,Option[Map[Int,String]])]]] // complicated type
+    val s = b[Map[(Boolean,Unit),Seq[Int]], Option[List[(Int,Option[Map[Int,String]])]]] // complicated type
 
-    s.toString shouldEqual "s/S"
+    s.toString shouldEqual "s/B"
   }
 
   it should "inspect reaction body" in {
-    val a = jA[Int]
-    val b = jA[(Int, Option[Int])]
-    val s = jS[Unit,Int]
+    val a = m[Int]
+    val s = b[Unit,Int]
+    val bb = m[(Int, Option[Int])]
 
-    val result = findInputs({ case a(p) + a(y) + a(1) + b(_) + b((1,z)) + b((_, None)) + b((t, Some(q))) + s(_, r) => a(p+1) + r(p) })
+    val result = findInputs({ case a(p) + a(y) + a(1) + bb(_) + bb((1,z)) + bb((_, None)) + bb((t, Some(q))) + s(_, r) => a(p+1) + r(p) })
 
     println(s"debug: got $result")
     // desugared expression tree:


### PR DESCRIPTION
All names such as `ja`, `js`, `jA`, `jS`, `JA`, `JS` etc. are replaced by `M` and `B`.