### PR TITLE
Use macros to analyze reactions at compile time

### DIFF
--- a/benchmark/src/test/scala/code/winitzki/benchmark/JiansenFairnessSpec.scala
+++ b/benchmark/src/test/scala/code/winitzki/benchmark/JiansenFairnessSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.time.{Millis, Span}
 import org.scalatest.{FlatSpec, Matchers}
 
 
-class FairnessSpec extends FlatSpec with Matchers with TimeLimitedTests {
+class JiansenFairnessSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
   val timeLimit = Span(500, Millis)
 

--- a/benchmark/src/test/scala/code/winitzki/benchmark/MapReduceSpec.scala
+++ b/benchmark/src/test/scala/code/winitzki/benchmark/MapReduceSpec.scala
@@ -21,7 +21,7 @@ class MapReduceSpec extends FlatSpec with Matchers {
     val get = b[Unit, List[Int]]
 
     val tp = new FixedPool(4)
-    join(tp)(
+    join(tp,tp)(
       &{ case d(n) => r(n*2) },
       &{ case res(list) + r(s) => res(s::list) },
       &{ case get(_, reply) + res(list) if list.size == count => reply(list) }

--- a/benchmark/src/test/scala/code/winitzki/benchmark/MergesortSpec.scala
+++ b/benchmark/src/test/scala/code/winitzki/benchmark/MergesortSpec.scala
@@ -54,9 +54,10 @@ class MergesortSpec extends FlatSpec with Matchers {
 
     val finalResult = m[Array[T]]
     val getFinalResult = b[Unit, Array[T]]
-    val tp = new FixedPool(threads+1)
+    val tp = new FixedPool(threads)
+    val jp = new FixedPool(3)
 
-    join(tp,tp)(
+    join(jp,jp)(
       &{ case finalResult(arr) + getFinalResult(_, r) => r(arr) }
     )
 
@@ -64,7 +65,7 @@ class MergesortSpec extends FlatSpec with Matchers {
 
     val mergesort = m[(Array[T], M[Array[T]])]
 
-    join(tp,tp)(
+    join(tp,jp)(
       &{
         case mergesort((arr, resultToYield)) =>
           if (arr.length <= 1) resultToYield(arr)
@@ -73,7 +74,7 @@ class MergesortSpec extends FlatSpec with Matchers {
             // "sorted1" and "sorted2" will be the sorted results from lower level
             val sorted1 = m[Array[T]]
             val sorted2 = m[Array[T]]
-            join(tp)(
+            join(tp,jp)(
               &{ case sorted1(x) + sorted2(y) =>
                 resultToYield(arrayMerge(x,y)) }
             )
@@ -88,6 +89,7 @@ class MergesortSpec extends FlatSpec with Matchers {
 
     val result = getFinalResult()
     tp.shutdownNow()
+    jp.shutdownNow()
     result
   }
 

--- a/benchmark/src/test/scala/code/winitzki/benchmark/MergesortSpec.scala
+++ b/benchmark/src/test/scala/code/winitzki/benchmark/MergesortSpec.scala
@@ -54,8 +54,9 @@ class MergesortSpec extends FlatSpec with Matchers {
 
     val finalResult = m[Array[T]]
     val getFinalResult = b[Unit, Array[T]]
+    val tp = new FixedPool(threads+1)
 
-    join(
+    join(tp,tp)(
       &{ case finalResult(arr) + getFinalResult(_, r) => r(arr) }
     )
 
@@ -63,8 +64,7 @@ class MergesortSpec extends FlatSpec with Matchers {
 
     val mergesort = m[(Array[T], M[Array[T]])]
 
-    val tp = new FixedPool(threads)
-    join(tp)(
+    join(tp,tp)(
       &{
         case mergesort((arr, resultToYield)) =>
           if (arr.length <= 1) resultToYield(arr)

--- a/benchmark/src/test/scala/code/winitzki/benchmark/MultithreadSpec.scala
+++ b/benchmark/src/test/scala/code/winitzki/benchmark/MultithreadSpec.scala
@@ -23,8 +23,8 @@ class MultithreadSpec extends FlatSpec with Matchers {
       val finished = m[Unit]
       val counter = m[Int]
       val allFinished = b[Unit, Unit]
-      val tp = new FixedPool(threads)
-      join(tp)(
+      val tp = new FixedPool(threads+1)
+      join(tp,tp)(
         & { case work(_) => performWork(); finished() },
         & { case counter(n) + finished(_) => counter(n-1) },
         & { case allFinished(_, r) + counter(0) => r() }

--- a/benchmark/src/test/scala/code/winitzki/benchmark/ZZZShutdownSpec.scala
+++ b/benchmark/src/test/scala/code/winitzki/benchmark/ZZZShutdownSpec.scala
@@ -1,6 +1,5 @@
 package code.winitzki.benchmark
 
-import code.winitzki.benchmark.Common._
 import code.winitzki.jc.FixedPool
 import code.winitzki.jc.Macros._
 import code.winitzki.jc.JoinRun._
@@ -14,15 +13,15 @@ class ZZZShutdownSpec extends FlatSpec with Matchers {
 
   it should "fail to schedule reactions after shutdown of default thread pools" in {
 
-    defaultJoinPool.shutdownNow()
-    defaultReactionPool.shutdownNow()
+    val pool = new FixedPool(2)
+    pool.shutdownNow()
 
     val x = m[Unit]
-    join(runSimple{ case x(()) => })
+    join(pool,pool)(runSimple{ case x(()) => })
 
     val thrown = intercept[Exception] {
       x()
     }
-    thrown.getMessage shouldEqual "In Join{a => ...}: Cannot inject molecule x since join pool is not active"
+    thrown.getMessage shouldEqual "In Join{x => ...}: Cannot inject molecule x since join pool is not active"
   }
 }

--- a/benchmark/src/test/scala/code/winitzki/benchmark/ZZZShutdownSpec.scala
+++ b/benchmark/src/test/scala/code/winitzki/benchmark/ZZZShutdownSpec.scala
@@ -40,7 +40,7 @@ class ZZZShutdownSpec extends FlatSpec with Matchers {
 
     pool2.shutdownNow() shouldEqual ()
   }
-
+/*
   it should "fail to schedule reactions after shutdown of default thread pools" in {
 
     defaultJoinPool.shutdownNow()
@@ -54,4 +54,5 @@ class ZZZShutdownSpec extends FlatSpec with Matchers {
     }
     thrown.getMessage shouldEqual "In Join{x => ...}: Cannot inject molecule x since join pool is not active"
   }
+  */
 }

--- a/benchmark/src/test/scala/code/winitzki/benchmark/ZZZShutdownSpec.scala
+++ b/benchmark/src/test/scala/code/winitzki/benchmark/ZZZShutdownSpec.scala
@@ -40,7 +40,7 @@ class ZZZShutdownSpec extends FlatSpec with Matchers {
 
     pool2.shutdownNow() shouldEqual ()
   }
-/*
+
   it should "fail to schedule reactions after shutdown of default thread pools" in {
 
     defaultJoinPool.shutdownNow()
@@ -54,5 +54,5 @@ class ZZZShutdownSpec extends FlatSpec with Matchers {
     }
     thrown.getMessage shouldEqual "In Join{x => ...}: Cannot inject molecule x since join pool is not active"
   }
-  */
+
 }

--- a/benchmark/src/test/scala/code/winitzki/benchmark/ZZZShutdownSpec.scala
+++ b/benchmark/src/test/scala/code/winitzki/benchmark/ZZZShutdownSpec.scala
@@ -1,0 +1,28 @@
+package code.winitzki.benchmark
+
+import code.winitzki.benchmark.Common._
+import code.winitzki.jc.FixedPool
+import code.winitzki.jc.Macros._
+import code.winitzki.jc.JoinRun._
+import org.scalatest.{FlatSpec, Matchers}
+
+/** This test will shutdown the default thread pools and check that no reactions can occur afterwards.
+  *
+  * This test suite is run last, after all other tests, and hopefully will be able to shutdown the test suites in CI.
+  */
+class ZZZShutdownSpec extends FlatSpec with Matchers {
+
+  it should "fail to schedule reactions after shutdown of default thread pools" in {
+
+    defaultJoinPool.shutdownNow()
+    defaultReactionPool.shutdownNow()
+
+    val x = m[Unit]
+    join(runSimple{ case x(()) => })
+
+    val thrown = intercept[Exception] {
+      x()
+    }
+    thrown.getMessage shouldEqual "In Join{a => ...}: Cannot inject molecule x since join pool is not active"
+  }
+}

--- a/doc/join_calculus_joinrun_tutorial.md
+++ b/doc/join_calculus_joinrun_tutorial.md
@@ -1085,8 +1085,8 @@ We can then use this molecule as output in some reaction.
 
 ```scala
 val a = m[Int]
-
-val (result: M[String], fut: Future[String]) = moleculeFuture[String]
+val tp = new FixedPool(2)
+val (result: M[String], fut: Future[String]) = moleculeFuture[String](tp)
 // injecting the molecule result(...) will resolve "fut"
 
 join( run { case a(x) => result(s"finished: $x") } ) // we define our reaction that will eventually inject "result(...)"

--- a/doc/join_calculus_joinrun_tutorial.md
+++ b/doc/join_calculus_joinrun_tutorial.md
@@ -959,7 +959,7 @@ However, in order to organize a distributed computation, we would need to split 
 The organization and supervision of distributed computations, the maintenance of connections between machines, the handling of disconnections - all this remains the responsibility of the programmer and is not handled automatically by Join Calculus.
 
 In principle, a sufficiently sophisticated runtime engine could organize a distributed Join Calculus computation completely transparently to the programmer.
-It remains to be seen whether it is feasible to implement such a runtime engine.
+It remains to be seen whether it is feasible and/or useful to implement such a runtime engine.
 
 
 # Some useful concurrency patterns
@@ -1056,6 +1056,12 @@ There are several tricks we can use:
 - define molecules whose values are functions that manipulate other molecule injectors
 - incrementally define new molecules and new reactions, store them in data structures, and assemble a final join definition later
 
+### Packaging a reaction in a closure
+
+TODO
+
+### Packaging a reaction in a molecule
+
 TODO
 
 ## Working with an external asynchronous APIs
@@ -1085,8 +1091,8 @@ We can then use this molecule as output in some reaction.
 
 ```scala
 val a = m[Int]
-val tp = new FixedPool(2)
-val (result: M[String], fut: Future[String]) = moleculeFuture[String](tp)
+
+val (result: M[String], fut: Future[String]) = moleculeFuture[String]
 // injecting the molecule result(...) will resolve "fut"
 
 join( run { case a(x) => result(s"finished: $x") } ) // we define our reaction that will eventually inject "result(...)"

--- a/doc/join_calculus_joinrun_tutorial.md
+++ b/doc/join_calculus_joinrun_tutorial.md
@@ -1049,11 +1049,12 @@ For this reason, join definitions in `JoinRun` are still static in an important 
 For instance, when we receive a molecule injector `c` as a result of some computation, the reactions that can start by consuming `c` are already fixed.
 We cannot disable these reactions or add another reaction that will also consume `c`.
 
-Nevertheless, we can achieve more flexibility in definition reactions at runtime.
+Nevertheless, we can achieve more flexibility in defining reactions.
 There are several tricks we can use:
-- define new reactions by a closure that takes arguments and returns new molecule injectors;
-- pass molecule injectors as values on other molecules;
-- define molecules that carry functions as values, and make these functions manipulate other molecule injectors.
+- define new reactions by a closure that takes arguments and returns new molecule injectors
+- define molecules whose values contain other molecule injectors, and use them in reactions
+- define molecules whose values are functions that manipulate other molecule injectors
+- incrementally define new molecules and new reactions, store them in data structures, and assemble a final join definition later
 
 TODO
 
@@ -1063,15 +1064,20 @@ Suppose we are working with an external library (such as HTTP or database access
 In order to use such libraries together with Join Calculus, we need to be able to convert between `Future`s and molecules.
 The `JoinRun` library provides a basic implementation for this functionality.
 
-The first situation is when the external library produces a value `fut : Future[T]`, and we would like to automatically inject a certain molecule `m` when this `Future` is successfully resolved.
-This is as easy as doing a `fut.map( m(123) )` on the future.
-The library has helper functions that add implicit methods to `Future` in order to reduce boilerplate in the typical cases:
+### Attaching molecules to futures
 
-- the molecule needs to carry the same value as the result value of the future:
-`fut & m`
+The first situation is when the external library produces a future value `fut : Future[T]`, and we would like to automatically inject a certain molecule `m` when this `Future` is successfully resolved.
+This is as easy as doing a `fut.map( m(123) )` on the future.
+The library has helper functions that add implicit methods to `Future` in order to reduce boilerplate in the two typical cases:
+
+- the molecule needs to carry the same value as the result value of the future: `fut & m`
 - the molecule needs to carry a different value: `fut + m(123)`
 
-The second situation is when we have already defined some reactions that will eventually inject a molecule with a result value, and we would like to create a `Future` value that we can pass to the external library.
+### Attaching futures to molecules
+
+The second situation is when an external library requires us to pass a future value that we produce.
+Suppose we have a reaction that will eventually inject a molecule with a result value.
+We now need to convert the injection event into a `Future` value, resolving to that result value when the molecule is injected.
 
 This is implemented by the `Library.moleculeFuture` method.
 This method will create a new molecule and a new future value.
@@ -1080,12 +1086,12 @@ We can then use this molecule as output in some reaction.
 ```scala
 val a = m[Int]
 
-val (c: M[String], fut: Future[String]) = moleculeFuture[String]
-// injecting the molecule c(...) resolves "fut"
+val (result: M[String], fut: Future[String]) = moleculeFuture[String]
+// injecting the molecule result(...) will resolve "fut"
 
-join( run { case a(x) => c("finished") } ) // our reactions that eventually inject "c"
+join( run { case a(x) => result(s"finished: $x") } ) // we define our reaction that will eventually inject "result(...)"
 
-ExternalLibrary.consumeUserFuture(fut) // external library takes our value "fut" and does something with it
+ExternalLibrary.consumeUserFuture(fut) // the external library takes our value "fut" and does something with it
 ```
 
 # Other tutorials on Join Calculus

--- a/doc/joinrun.md
+++ b/doc/joinrun.md
@@ -164,6 +164,9 @@ It is a runtime error to write a reaction that either does not inject the reply 
 Also, the reply action object should not be used outside the reaction body.
 (This will have no effect.)
 
+When a reaction is defined using the `run` macro, the compiler will detect some errors at compile time.
+For instance, it is a compile-time error to omit the 
+
 ## Join definitions
 
 Join definitions activate molecules and reactions:
@@ -179,6 +182,7 @@ A join definition can take any number of reactions.
 With Scala's `:_*` syntax, a join definition can take a sequence of reactions computed at runtime.
 
 All reactions listed in the join definition will be activated at once.
+
 Whenever we inject any molecule that is used as input to one of these reactions, it is _this_ join definition (and no other) that will decide which reactions to run.
 For this reason, we say that those molecules are "bound" to this join definition, or that they are "consumed" in it, or that they are "input molecules" in this join definition.
 
@@ -348,7 +352,7 @@ These features are considered for implementation in the next versions:
 1. Implement injecting several molecules at once (and arbitrarily many at once).
 1. Implement nonlinear patterns for input molecules.
 
-These features are further away from implementation:
+These features are further away from implementation because they require some research:
 
 1. Investigate interoperability with streaming frameworks such as Scala Streams, Scalaz Streams, FS2, Akka streams.
 1. Investigate an implicit distributed execution of thread pools.

--- a/lib/src/main/scala/code/winitzki/jc/JoinRun.scala
+++ b/lib/src/main/scala/code/winitzki/jc/JoinRun.scala
@@ -389,12 +389,21 @@ object JoinRun {
 
   }
 
+  /** Add a random shuffle method to sequences.
+    *
+    * @param a Sequence to be shuffled.
+    * @tparam T Type of sequence elements.
+    */
   private implicit final class ShufflableSeq[T](a: Seq[T]) {
+    /** Shuffle sequence elements randomly.
+      *
+      * @return A new sequence with randomly permuted elements.
+      */
     def shuffle: Seq[T] = scala.util.Random.shuffle(a)
   }
 
-  // for JA[T] molecules, the value inside AbsMolValue[T] is of type T; for JS[T,R] molecules, the value is of type
-  // ReplyValue[T,R]
+  // for M[T] molecules, the value inside AbsMolValue[T] is of type T; for B[T,R] molecules, the value is of type
+  // ReplyValue[T,R]. For now, we don't use shapeless to enforce this typing relation.
   private type MoleculeBag = MutableBag[Molecule, AbsMolValue[_]]
   private type MutableLinearMoleculeBag = mutable.Map[Molecule, AbsMolValue[_]]
   private type LinearMoleculeBag = Map[Molecule, AbsMolValue[_]]

--- a/lib/src/main/scala/code/winitzki/jc/Library.scala
+++ b/lib/src/main/scala/code/winitzki/jc/Library.scala
@@ -13,7 +13,7 @@ object Library {
     * @tparam T Type of value carried by the molecule and by the future.
     * @return Tuple consisting of new molecule injector and the new future.
     */
-  def moleculeFuture[T : ClassTag](pool: Pool): (M[T], Future[T]) = {
+  def moleculeFuture[T : ClassTag](pool: Pool = defaultReactionPool): (M[T], Future[T]) = {
     val f = new M[T]("future")
     val p = Promise[T]()
 

--- a/lib/src/main/scala/code/winitzki/jc/Library.scala
+++ b/lib/src/main/scala/code/winitzki/jc/Library.scala
@@ -7,16 +7,17 @@ import scala.reflect.ClassTag
 
 object Library {
   /** Create a non-blocking molecule that, when injected, will resolve the future.
-    * Example usage: val (m, fut) = moleculeFuture[String]
+    * Example usage: val (m, fut) = moleculeFuture[String](pool)
     *
+    * @param pool Thread pool on which to run the new join definition.
     * @tparam T Type of value carried by the molecule and by the future.
-    * @return Tuple consisting of new molecule injector and the new future
+    * @return Tuple consisting of new molecule injector and the new future.
     */
-  def moleculeFuture[T : ClassTag]: (M[T], Future[T]) = {
+  def moleculeFuture[T : ClassTag](pool: Pool): (M[T], Future[T]) = {
     val f = new M[T]("future")
     val p = Promise[T]()
 
-    join(
+    join(pool,pool)(
       runSimple { case f(x) => p.success(x) }
     )
     (f, p.future)

--- a/lib/src/main/scala/code/winitzki/jc/SmartPool.scala
+++ b/lib/src/main/scala/code/winitzki/jc/SmartPool.scala
@@ -36,7 +36,7 @@ class SmartThread(r: Runnable, pool: SmartPool) extends Thread(r) {
 /** A cached pool that increases its thread count whenever a blocking molecule is injected, and decreases afterwards.
   * The {{{BlockingIdle}}} function, similar to {{{scala.concurrent.blocking}}}, is used to annotate expressions that should lead to an increase of thread count, and to a decrease of thread count once the idle blocking call returns.
   */
-class SmartPool(parallellism: Int) extends Pool {
+class SmartPool(parallelism: Int) extends Pool {
 
   def currentPoolSize = executor.getCorePoolSize
 
@@ -47,20 +47,20 @@ class SmartPool(parallellism: Int) extends Pool {
   }
 
   private[jc] def finishedBlockingCall() = synchronized {
-    val newPoolSize = math.max(parallellism, currentPoolSize - 1)
+    val newPoolSize = math.max(parallelism, currentPoolSize - 1)
     executor.setCorePoolSize(newPoolSize) // Must set them in this order, so that the core pool size is never larger than the maximum pool size.
     executor.setMaximumPoolSize(newPoolSize)
   }
 
-  val maxQueueCapacity = parallellism*1000 + 100
+  val maxQueueCapacity = parallelism*1000 + 100
 
   private val queue = new LinkedBlockingQueue[Runnable](maxQueueCapacity)
 
-  val initialThreads = parallellism
+  val initialThreads = parallelism
   val secondsToRecycleThread = 1
   val shutdownWaitTimeMs = 200
 
-  private val executor = new ThreadPoolExecutor(initialThreads, parallellism, secondsToRecycleThread, TimeUnit.SECONDS,
+  private val executor = new ThreadPoolExecutor(initialThreads, parallelism, secondsToRecycleThread, TimeUnit.SECONDS,
     queue, new ThreadFactory {
       override def newThread(r: Runnable): Thread = new SmartThread(r, SmartPool.this)
     })

--- a/lib/src/test/scala/code/winitzki/benchmark/FairnessSpec.scala
+++ b/lib/src/test/scala/code/winitzki/benchmark/FairnessSpec.scala
@@ -176,7 +176,7 @@ class FairnessSpec extends FlatSpec with Matchers with TimeLimitedTests {
     val (ab, bc) = g()
     ab + bc shouldEqual n
     val discrepancy = math.abs(ab - bc + 0.0) / n
-    discrepancy should be > 0.5
+    discrepancy should be > 0.4
 
     tp.shutdownNow()
   }

--- a/lib/src/test/scala/code/winitzki/benchmark/FairnessSpec.scala
+++ b/lib/src/test/scala/code/winitzki/benchmark/FairnessSpec.scala
@@ -32,9 +32,10 @@ class FairnessSpec extends FlatSpec with Matchers with TimeLimitedTests {
     val a3 = new M[Unit]("a3")
     //n = 4
 
-    val tp = new FixedPool(8)
+    val tp = new FixedPool(4)
+    val tp1 = new FixedPool(1)
 
-    join(tp, tp)(
+    join(tp, tp1)(
       runSimple { case getC(_, r) + done(arr) => r(arr) },
       runSimple { case a0(_) + c((n,arr)) => if (n > 0) { arr(0) += 1; c((n-1,arr)) + a0() } else done(arr) },
       runSimple { case a1(_) + c((n,arr)) => if (n > 0) { arr(1) += 1; c((n-1,arr)) + a1() } else done(arr) },
@@ -49,6 +50,7 @@ class FairnessSpec extends FlatSpec with Matchers with TimeLimitedTests {
 //    println(result.mkString(", "))
 
     tp.shutdownNow()
+    tp1.shutdownNow()
 
     result.min should be > (0.75*N/reactions).toInt
     result.max should be < (1.25*N/reactions).toInt

--- a/lib/src/test/scala/code/winitzki/benchmark/ParallelOrSpec.scala
+++ b/lib/src/test/scala/code/winitzki/benchmark/ParallelOrSpec.scala
@@ -1,6 +1,7 @@
 package code.winitzki.benchmark
 
 import code.winitzki.jc.JoinRun._
+import code.winitzki.jc.Pool
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.{Millis, Span}
 import org.scalatest.{FlatSpec, Matchers}
@@ -16,14 +17,14 @@ class ParallelOrSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
   lazy val never = neverReturn[Boolean]
 
-  def or(b1: => Boolean, b2: => Boolean): B[Unit, Boolean] = {
+  def or(b1: => Boolean, b2: => Boolean, tp: Pool): B[Unit, Boolean] = {
     val res = new B[Unit, Boolean]("res")
     val res1 = new M[Boolean]("res1")
     val res2 = new M[Boolean]("res2")
     val res1_false = new B[Unit, Boolean]("res1_false")
     val res2_false = new B[Unit, Boolean]("res2_false")
 
-    join (
+    join(tp, tp) (
       runSimple { case res(_, res_reply) + res1(b) => if (b) res_reply(b) else res_reply(res1_false()) },
       runSimple { case res1_false(_, res1f_reply) + res2(b) => res1f_reply(b) },
       runSimple { case res(_, res_reply) + res2(b) => if (b) res_reply(b) else res_reply(res2_false()) },

--- a/lib/src/test/scala/code/winitzki/jc/JoinRunBlockingSpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/JoinRunBlockingSpec.scala
@@ -13,7 +13,7 @@ import scala.concurrent.duration.DurationInt
   */
 class JoinRunBlockingSpec extends FlatSpec with Matchers with TimeLimitedTests with BeforeAndAfterAll {
 
-  val tp0 = new FixedPool(4)
+  val tp0 = new FixedPool(40)
 
   override def afterAll() = {
     tp0.shutdownNow()

--- a/lib/src/test/scala/code/winitzki/jc/JoinRunBlockingSpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/JoinRunBlockingSpec.scala
@@ -3,26 +3,20 @@ package code.winitzki.jc
 import JoinRun._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.{Millis, Span}
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.duration.DurationInt
 
 /** More unit tests for blocking molecule functionality.
   *
   */
-class JoinRunBlockingSpec extends FlatSpec with Matchers with TimeLimitedTests with BeforeAndAfterAll {
+class JoinRunBlockingSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
   val timeLimit = Span(1000, Millis)
 
   val warmupTimeMs = 50
 
   def waitSome(): Unit = Thread.sleep(warmupTimeMs)
-
-
-  override def afterAll(): Unit = {
-    defaultJoinPool.shutdownNow()
-    defaultReactionPool.shutdownNow()
-  }
 
   behavior of "blocking molecule"
   

--- a/lib/src/test/scala/code/winitzki/jc/JoinRunBlockingSpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/JoinRunBlockingSpec.scala
@@ -3,20 +3,26 @@ package code.winitzki.jc
 import JoinRun._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.{Millis, Span}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
 import scala.concurrent.duration.DurationInt
 
 /** More unit tests for blocking molecule functionality.
   *
   */
-class JoinRunBlockingSpec extends FlatSpec with Matchers with TimeLimitedTests {
+class JoinRunBlockingSpec extends FlatSpec with Matchers with TimeLimitedTests with BeforeAndAfterAll {
 
   val timeLimit = Span(1000, Millis)
 
   val warmupTimeMs = 50
 
   def waitSome(): Unit = Thread.sleep(warmupTimeMs)
+
+
+  override def afterAll(): Unit = {
+    defaultJoinPool.shutdownNow()
+    defaultReactionPool.shutdownNow()
+  }
 
   behavior of "blocking molecule"
   

--- a/lib/src/test/scala/code/winitzki/jc/JoinRunBlockingSpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/JoinRunBlockingSpec.scala
@@ -16,7 +16,6 @@ class JoinRunBlockingSpec extends FlatSpec with Matchers with TimeLimitedTests w
   val tp0 = new FixedPool(4)
 
   override def afterAll() = {
-    println("debug: shutting down tp0 in JoinRunBlockingSpec")
     tp0.shutdownNow()
   }
 

--- a/lib/src/test/scala/code/winitzki/jc/JoinRunBlockingSpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/JoinRunBlockingSpec.scala
@@ -249,7 +249,8 @@ class JoinRunBlockingSpec extends FlatSpec with Matchers with TimeLimitedTests w
     val g = new B[Unit,Int]("g")
     val g2 = new B[Unit,Int]("g2")
     val tp = new FixedPool(1)
-    join(tp)(
+    val tp1 = new FixedPool(1)
+    join(tp,tp1)(
       runSimple { case d(_) => g() }, // this will be used to inject g() and block one thread
       runSimple { case c(_) + g(_,r) => r(0) }, // this will not start because we have no c()
       runSimple { case g2(_, r) => r(1) } // we will use this to test whether the entire thread pool is blocked
@@ -259,6 +260,8 @@ class JoinRunBlockingSpec extends FlatSpec with Matchers with TimeLimitedTests w
     waitSome()
     g2(timeout = 100 millis)() shouldEqual None // this should be blocked now
     tp.shutdownNow()
+    tp1.shutdownNow()
+
   }
 
   def makeBlockingCheck(sleeping: => Unit, tp1: Pool): (B[Unit,Unit], B[Unit,Int]) = {

--- a/lib/src/test/scala/code/winitzki/jc/JoinRunSpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/JoinRunSpec.scala
@@ -213,7 +213,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests with Befo
     g() shouldEqual 0
   }
 
-  it should "use one thread for concurrent computations" in {
+  it should "use only one thread for concurrent computations" in {
     val c = new M[Int]("counter")
     val d = new M[Unit]("decrement")
     val f = new M[Unit]("finished")
@@ -230,6 +230,8 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests with Befo
     a(0) + c(1) + c(1) + d() + d()
     g() shouldEqual 0
     Thread.sleep(150) // This is less than 300ms, so we have not yet finished the second computation.
+    g() shouldEqual 0
+    Thread.sleep(300) // Now we should have finished the second computation.
     g() shouldEqual 1
     Thread.sleep(300) // Now we should have finished the second computation.
     g() shouldEqual 2

--- a/lib/src/test/scala/code/winitzki/jc/JoinRunSpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/JoinRunSpec.scala
@@ -4,20 +4,15 @@ import JoinRun._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.concurrent.Waiters.Waiter
 import org.scalatest.time.{Millis, Span}
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.{FlatSpec, Matchers}
 
-class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests with BeforeAndAfterAll {
+class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
   val timeLimit = Span(1000, Millis)
 
   val warmupTimeMs = 50
 
   def waitSome(): Unit = Thread.sleep(warmupTimeMs)
-
-  override def afterAll(): Unit = {
-    defaultJoinPool.shutdownNow()
-    defaultReactionPool.shutdownNow()
-  }
 
   behavior of "join definition"
 

--- a/lib/src/test/scala/code/winitzki/jc/JoinRunSpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/JoinRunSpec.scala
@@ -4,10 +4,16 @@ import JoinRun._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.concurrent.Waiters.Waiter
 import org.scalatest.time.{Millis, Span}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
-class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
+class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests with BeforeAndAfterAll {
 
+  val tp0 = new FixedPool(4)
+
+  override def afterAll() = {
+    tp0.shutdownNow()
+  }
+  
   val timeLimit = Span(1000, Millis)
 
   val warmupTimeMs = 50
@@ -23,7 +29,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
     a.toString shouldEqual "a"
 
-    join(runSimple { case a(_) + b(_) + c(_) => })
+    join(tp0,tp0)(runSimple { case a(_) + b(_) + c(_) => })
     a.logSoup shouldEqual "Join{a + b + c => ...}\nNo molecules"
 
     a()
@@ -39,7 +45,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
     val b = new M[Unit]("b")
     val c = new M[Unit]("c")
 
-    join(runSimple { case b(_) + c(_) + a(Some(x)) => })
+    join(tp0,tp0)(runSimple { case b(_) + c(_) + a(Some(x)) => })
 
     a.logSoup shouldEqual "Join{a + b + c => ...}\nNo molecules"
   }
@@ -70,7 +76,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
     val a = new M[Unit]("a")
 
-    join( runSimple { case a(_) => waiter.dismiss() })
+    join(tp0,tp0)( runSimple { case a(_) => waiter.dismiss() })
 
     a()
     waiter.await()
@@ -81,7 +87,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
     val waiter = new Waiter
 
     val a = new M[Unit]("a")
-    join( runSimple { case a(_) => waiter.dismiss() })
+    join(tp0,tp0)( runSimple { case a(_) => waiter.dismiss() })
     a()
     waiter.await()
   }
@@ -92,7 +98,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
     val a = new M[Unit]("a")
     val b = new M[Unit]("b")
-    join( runSimple { case a(_) => b() }, runSimple { case b(_) => waiter.dismiss() })
+    join(tp0,tp0)( runSimple { case a(_) => b() }, runSimple { case b(_) => waiter.dismiss() })
 
     a()
     waiter.await()
@@ -105,7 +111,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
     val a = new M[Int]("a")
     val b = new M[Int]("b")
     val c = new M[Int]("c")
-    join( runSimple { case a(x) + b(y) => c(x+y) }, runSimple { case c(z) => waiter { z shouldEqual 3 }; waiter.dismiss() })
+    join(tp0,tp0)( runSimple { case a(x) + b(y) => c(x+y) }, runSimple { case c(z) => waiter { z shouldEqual 3 }; waiter.dismiss() })
     a(1)
     b(2)
     waiter.await()
@@ -114,7 +120,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
   it should "throw exception when join pattern is nonlinear" in {
     val thrown = intercept[Exception] {
       val a = new M[Unit]("a")
-      join( runSimple { case a(_) + a(_) => () })
+      join(tp0,tp0)( runSimple { case a(_) + a(_) => () })
       a()
     }
     thrown.getMessage shouldEqual "Nonlinear pattern: a used twice"
@@ -124,7 +130,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
   it should "throw exception when join pattern is nonlinear, with blocking molecule" in {
     val thrown = intercept[Exception] {
       val a = new B[Unit,Unit]("a")
-      join( runSimple { case a(_,r) + a(_,s) => () })
+      join(tp0,tp0)( runSimple { case a(_,r) + a(_,s) => () })
       a()
     }
     thrown.getMessage shouldEqual "Nonlinear pattern: a/B used twice"
@@ -133,8 +139,8 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
   it should "throw exception when join pattern attempts to redefine a blocking molecule" in {
     val thrown = intercept[Exception] {
       val a = new B[Unit,Unit]("a")
-      join( runSimple { case a(_,_) => () })
-      join( runSimple { case a(_,_) => () })
+      join(tp0,tp0)( runSimple { case a(_,_) => () })
+      join(tp0,tp0)( runSimple { case a(_,_) => () })
     }
     thrown.getMessage shouldEqual "Molecule a/B cannot be used as input since it was already used in Join{a/B => ...}"
   }
@@ -143,8 +149,8 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
     val thrown = intercept[Exception] {
       val a = new M[Unit]("x")
       val b = new M[Unit]("y")
-      join( runSimple { case a(_) + b(_) => () })
-      join( runSimple { case a(_) => () })
+      join(tp0,tp0)( runSimple { case a(_) + b(_) => () })
+      join(tp0,tp0)( runSimple { case a(_) => () })
     }
     thrown.getMessage shouldEqual "Molecule x cannot be used as input since it was already used in Join{x + y => ...}"
   }
@@ -187,7 +193,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
     val b = new M[Int]("b")
     val f = new B[Unit,Int]("f")
 
-    join( runSimple { case a(x) + b(0) => a(x+1) }, runSimple { case a(z) + f(_, r) => r(z) })
+    join(tp0,tp0)( runSimple { case a(x) + b(0) => a(x+1) }, runSimple { case a(z) + f(_, r) => r(z) })
     a(1)
     b(2)
     waitSome()
@@ -198,7 +204,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
     val c = new M[Int]("c")
     val d = new M[Unit]("decrement")
     val g = new B[Unit,Int]("getValue")
-    join(
+    join(tp0,tp0)(
       runSimple { case c(n) + d(_) => c(n-1) },
       runSimple { case c(n) + g(_,r) => c(n) + r(n) }
     )
@@ -216,7 +222,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
     val tp = new FixedPool(1)
 
-    join(
+    join(tp0,tp0)(
       runSimple { case c(x) + d(_) => Thread.sleep(100); c(x-1) + f() } onThreads tp,
       runSimple { case a(x) + g(_, r) => a(x) + r(x) },
       runSimple { case f(_) + a(x) => a(x+1) }
@@ -239,7 +245,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
     val tp = new FixedPool(2)
 
-    join(
+    join(tp0,tp0)(
       runSimple { case c(x) + d(_) => Thread.sleep(100); c(x-1) + f() } onThreads tp,
       runSimple { case a(x) + g(_, r) => r(x) },
       runSimple { case f(_) + a(x) => a(x+1) }
@@ -258,7 +264,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
     val d = new M[Unit]("decrement")
     val g = new B[Unit, Int]("getValue")
     val tp = new FixedPool(2)
-    join(
+    join(tp0,tp0)(
       runSimple  { case c(x) + d(_) => c(x - 1) } onThreads tp,
       runSimple  { case c(0) + g(_, r) => c(0) + r(0) }
     )
@@ -280,7 +286,7 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
     val g = new B[Unit, Int]("getValue")
     val tp = new FixedPool(2)
 
-    join(
+    join(tp0,tp0)(
       runSimple  { case c(x) + d(_) =>
         if (scala.util.Random.nextDouble >= probabilityOfCrash) c(x - 1) else throw new Exception("crash! (it's OK, ignore this)")
       }.withRetry onThreads tp,

--- a/lib/src/test/scala/code/winitzki/jc/JoinRunSpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/JoinRunSpec.scala
@@ -4,15 +4,20 @@ import JoinRun._
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.concurrent.Waiters.Waiter
 import org.scalatest.time.{Millis, Span}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
-class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests {
+class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests with BeforeAndAfterAll {
 
   val timeLimit = Span(1000, Millis)
 
   val warmupTimeMs = 50
 
   def waitSome(): Unit = Thread.sleep(warmupTimeMs)
+
+  override def afterAll(): Unit = {
+    defaultJoinPool.shutdownNow()
+    defaultReactionPool.shutdownNow()
+  }
 
   behavior of "join definition"
 

--- a/lib/src/test/scala/code/winitzki/jc/JoinRunSpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/JoinRunSpec.scala
@@ -223,14 +223,15 @@ class JoinRunSpec extends FlatSpec with Matchers with TimeLimitedTests with Befo
     val tp = new FixedPool(1)
 
     join(tp0,tp0)(
-      runSimple { case c(x) + d(_) => Thread.sleep(100); c(x-1) + f() } onThreads tp,
+      runSimple { case c(x) + d(_) => Thread.sleep(300); c(x-1) + f() } onThreads tp,
       runSimple { case a(x) + g(_, r) => a(x) + r(x) },
       runSimple { case f(_) + a(x) => a(x+1) }
     )
     a(0) + c(1) + c(1) + d() + d()
-    Thread.sleep(150) // This is less than 200ms, so we have not yet finished the second computation.
+    g() shouldEqual 0
+    Thread.sleep(150) // This is less than 300ms, so we have not yet finished the second computation.
     g() shouldEqual 1
-    Thread.sleep(150) // Now we should have finished the second computation.
+    Thread.sleep(300) // Now we should have finished the second computation.
     g() shouldEqual 2
 
     tp.shutdownNow()

--- a/lib/src/test/scala/code/winitzki/jc/LibrarySpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/LibrarySpec.scala
@@ -61,12 +61,13 @@ class LibrarySpec extends FlatSpec with Matchers with TimeLimitedTests {
     val d = new M[Unit]("d")
     val e = new M[Unit]("e")
     val f = new B[Unit, String]("f")
+    val f2 = new B[Unit, String]("f2")
 
     val tp = new FixedPool(4)
     join(tp,tp)(
       runSimple { case e(_) + c(_) => d() },
       runSimple { case c(_) + f(_, r) => r("from c") + c() },
-      runSimple { case d(_) + f(_, r) => r("from d") + c() }
+      runSimple { case d(_) + f2(_, r) => r("from d") }
     )
 
     c()
@@ -81,7 +82,7 @@ class LibrarySpec extends FlatSpec with Matchers with TimeLimitedTests {
     Thread.sleep(20)
     f() shouldEqual "from c"
     waiter.await()
-    f() shouldEqual "from d"
+    f2() shouldEqual "from d"
 
     tp.shutdownNow()
   }

--- a/lib/src/test/scala/code/winitzki/jc/LibrarySpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/LibrarySpec.scala
@@ -103,7 +103,7 @@ class LibrarySpec extends FlatSpec with Matchers with TimeLimitedTests {
 
     val givenFuture = for {
       _ <- Future {
-        Thread.sleep(50)
+        Thread.sleep(20)
       } // waiter has 150 ms timeout
       s <- fut
     } yield {

--- a/lib/src/test/scala/code/winitzki/jc/LibrarySpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/LibrarySpec.scala
@@ -9,7 +9,6 @@ import org.scalatest.time.{Millis, Span}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.reflect.ClassTag
 
 class LibrarySpec extends FlatSpec with Matchers with TimeLimitedTests {
 
@@ -91,7 +90,7 @@ class LibrarySpec extends FlatSpec with Matchers with TimeLimitedTests {
 
   it should "create a future that succeeds when molecule is injected" in {
     val waiter = new Waiter
-    val tp = new FixedPool(2)
+    val tp = new FixedPool(4)
 
     val b = new M[Unit]("b")
 
@@ -104,7 +103,7 @@ class LibrarySpec extends FlatSpec with Matchers with TimeLimitedTests {
 
     val givenFuture = for {
       _ <- Future {
-        Thread.sleep(50)
+        Thread.sleep(20)
       } // waiter has 150 ms timeout
       s <- fut
     } yield {

--- a/lib/src/test/scala/code/winitzki/jc/LibrarySpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/LibrarySpec.scala
@@ -72,13 +72,12 @@ class LibrarySpec extends FlatSpec with Matchers with TimeLimitedTests {
     c()
 
     val givenFuture = Future {
-      Thread.sleep(50)
+      Thread.sleep(20)
     } // waiter has 150 ms timeout
 
     (givenFuture + e()).map { _ => waiter.dismiss() }
     // The test would fail if e() were injected right away at this point.
 
-    Thread.sleep(20)
     f() shouldEqual "from c"
     waiter.await()
     f2() shouldEqual "from d"

--- a/lib/src/test/scala/code/winitzki/jc/LibrarySpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/LibrarySpec.scala
@@ -105,7 +105,7 @@ class LibrarySpec extends FlatSpec with Matchers with TimeLimitedTests {
 
     val givenFuture = for {
       _ <- Future {
-        Thread.sleep(20)
+        Thread.sleep(50)
       } // waiter has 150 ms timeout
       s <- fut
     } yield {

--- a/lib/src/test/scala/code/winitzki/jc/LibrarySpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/LibrarySpec.scala
@@ -74,13 +74,13 @@ class LibrarySpec extends FlatSpec with Matchers with TimeLimitedTests {
     c()
 
     val givenFuture = Future {
-      Thread.sleep(100)
+      Thread.sleep(20)
     } // waiter has 150 ms timeout
 
     (givenFuture + e()).map { _ => waiter.dismiss() }
     // The test would fail if e() were injected right away at this point.
 
-    waitSome()
+    Thread.sleep(50)
     f() shouldEqual "from c"
     waiter.await()
     f() shouldEqual "from d"

--- a/lib/src/test/scala/code/winitzki/jc/LibrarySpec.scala
+++ b/lib/src/test/scala/code/winitzki/jc/LibrarySpec.scala
@@ -9,6 +9,7 @@ import org.scalatest.time.{Millis, Span}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import scala.reflect.ClassTag
 
 class LibrarySpec extends FlatSpec with Matchers with TimeLimitedTests {
 
@@ -91,12 +92,13 @@ class LibrarySpec extends FlatSpec with Matchers with TimeLimitedTests {
 
   it should "create a future that succeeds when molecule is injected" in {
     val waiter = new Waiter
+    val tp = new FixedPool(2)
 
     val b = new M[Unit]("b")
-    // "fut" will succeed when "c" is injected
-    val (c, fut) = moleculeFuture[String]
 
-    val tp = new FixedPool(2)
+    // "fut" will succeed when "c" is injected
+    val (c, fut) = moleculeFuture[String](tp)
+
     join(tp,tp)(
       runSimple { case b(_) => c("send it off") }
     )

--- a/macros/src/test/scala/code/winitzki/jc/MacrosSpec.scala
+++ b/macros/src/test/scala/code/winitzki/jc/MacrosSpec.scala
@@ -282,9 +282,10 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
     val a = b[Unit,Unit]
     val c = b[Unit, Unit]
 
-    "& { case a(_, r) => a() }" shouldNot compile   // no reply r
-    "& { case a(_, r) + a(_) + c(_) => r()  }" shouldNot compile // invalid patterns for a and c
-    "& { case a(_, r) + a(_) + c(_) => r() + r() }" shouldNot compile // two replies r
+    "& { case a(_, r) => a() }" shouldNot compile   // no reply is performed with r
+    "& { case a(_, _) => a() }" shouldNot compile   // no pattern match for reply in "a"
+    "& { case a(_, r) + a(_) + c(_) => r()  }" shouldNot compile // invalid patterns for "a" and "c"
+    "& { case a(_, r) + a(_) + c(_) => r() + r() }" shouldNot compile // two replies are performed with r
 
   }
 

--- a/macros/src/test/scala/code/winitzki/jc/MacrosSpec.scala
+++ b/macros/src/test/scala/code/winitzki/jc/MacrosSpec.scala
@@ -2,15 +2,20 @@ package code.winitzki.jc
 
 import JoinRun._
 import Macros._
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
-import org.scalatest.{FlatSpec, Matchers}
 import scala.concurrent.duration.DurationInt
 
-class MacrosSpec extends FlatSpec with Matchers {
+class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
 
   val warmupTimeMs = 50
 
   def waitSome(): Unit = Thread.sleep(warmupTimeMs)
+
+  override def afterAll(): Unit = {
+    defaultJoinPool.shutdownNow()
+    defaultReactionPool.shutdownNow()
+  }
 
   behavior of "macros for defining new molecule injectors"
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -25,16 +25,16 @@ object MyBuild extends Build {
   import BuildSettings._
 
   // main project
+  /* can we do without this?
   lazy val joinrun: Project = Project(
     "joinrun",
     file("."),
     settings = buildSettings ++ Seq(
       parallelExecution in Test := false,
-      libraryDependencies ++= Seq(
-        "org.scalatest" %% "scalatest" % "3.0.0" % "test"
-      ),
-      run <<= run in Compile in lib)
+      concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
+      run <<= run in Compile in benchmark)
   ) aggregate(lib, macros, benchmark)
+  */
 
   // Macros for the JoinRun library - the users will need this too.
   lazy val macros: Project = Project(
@@ -45,7 +45,7 @@ object MyBuild extends Build {
       libraryDependencies ++= Seq(
         "org.scalatest" %% "scalatest" % "3.0.0" % "test",
 
-  // this is a necessary dependency only if we want to debug macros;
+  // the "scala-compiler" is a necessary dependency only if we want to debug macros;
   // the project does not actually depend on scala-compiler.
         "org.scala-lang" % "scala-compiler" % scalaVersion.value % "test"
       )
@@ -58,6 +58,7 @@ object MyBuild extends Build {
     file("lib"),
     settings = buildSettings ++ Seq(
       parallelExecution in Test := false,
+      concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
       libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-actor" % "2.4.12",
         "org.scalatest" %% "scalatest" % "3.0.0" % "test"
@@ -70,6 +71,7 @@ object MyBuild extends Build {
     "benchmark",
     file("benchmark"),
     settings = buildSettings ++ Seq(
+      concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
       parallelExecution in Test := false,
       libraryDependencies ++= Seq(
         "org.scalatest" %% "scalatest" % "3.0.0" % "test"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -29,6 +29,7 @@ object MyBuild extends Build {
     "joinrun",
     file("."),
     settings = buildSettings ++ Seq(
+      parallelExecution in Test := false,
       libraryDependencies ++= Seq(
         "org.scalatest" %% "scalatest" % "3.0.0" % "test"
       ),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -24,6 +24,7 @@ object BuildSettings {
 object MyBuild extends Build {
   import BuildSettings._
 
+  // main project
   lazy val joinrun: Project = Project(
     "joinrun",
     file("."),
@@ -32,7 +33,7 @@ object MyBuild extends Build {
         "org.scalatest" %% "scalatest" % "3.0.0" % "test"
       ),
       run <<= run in Compile in lib)
-  ) aggregate(macros, lib, benchmark)
+  ) aggregate(lib, macros, benchmark)
 
   // Macros for the JoinRun library - the users will need this too.
   lazy val macros: Project = Project(
@@ -50,7 +51,7 @@ object MyBuild extends Build {
     )
   ) dependsOn lib
 
-  // The JoinRun library itself - this is what users depend on.
+  // The core JoinRun library.
   lazy val lib: Project = Project(
     "lib",
     file("lib"),


### PR DESCRIPTION
Possible directions:

- Check more errors
- Prepare partial functions to match each molecule value separately, for those that have nontrivial patterns; store constant values for those that have literal constants
- Check that all reply values have been used
- Make sure that reply values are removed from the soup on timeout
- Do not gather molecule values for molecules that use a wildcard