### PR TITLE
Check some livelock situations

### DIFF
--- a/benchmark/src/test/scala/code/winitzki/benchmark/JoinRunStaticAnalysisSpec.scala
+++ b/benchmark/src/test/scala/code/winitzki/benchmark/JoinRunStaticAnalysisSpec.scala
@@ -164,14 +164,8 @@ class JoinRunStaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedT
       val a = m[Int]
       val b = m[Int]
 
-      val r = & { case a(1) + b(_) => b(1) + b(2) + a(1) }
-      r.info.outputs shouldEqual Some(List(
-        OutputMoleculeInfo(b, ConstOutputValue(1)),
-        OutputMoleculeInfo(b, ConstOutputValue(2)),
-        OutputMoleculeInfo(a, ConstOutputValue(1))
-      ))
+      join(& { case a(1) + b(_) => b(1) + b(2) + a(1) })
 
-      join(r)
     }
     thrown.getMessage shouldEqual "In Join{a + b => ...}: Unavoidable livelock: reaction a + b => ..."
   }

--- a/benchmark/src/test/scala/code/winitzki/benchmark/JoinRunStaticAnalysisSpec.scala
+++ b/benchmark/src/test/scala/code/winitzki/benchmark/JoinRunStaticAnalysisSpec.scala
@@ -208,6 +208,15 @@ class JoinRunStaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedT
     thrown.getMessage shouldEqual "In Join{a + b + b + c => ...}: Unavoidable livelock: reaction a + b + b + c => ..."
   }
 
+  it should "detect livelock in a simple reaction due to constant output values" in {
+    val thrown = intercept[Exception] {
+      val a = m[Int]
+      join(
+        & { case a(1) => a(1) }
+      )
+    }
+    thrown.getMessage shouldEqual "In Join{a => ...}: Unavoidable livelock: reaction a => ..."
+  }
 
   it should "detect livelock in a single reaction due to constant output values without value assigning" in {
     val thrown = intercept[Exception] {
@@ -227,11 +236,11 @@ class JoinRunStaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedT
 
       join(
         & { case a(1) + b(_) => b(1) + b(2) + a(1) },
-        & { case a(IsEven(x)) => },
+        & { case a(IsEven(x)) => a(2) },
         & { case a(2) + b(3) => }
       )
     }
-    thrown.getMessage shouldEqual "In Join{a + b => ...; a + b => ...; a => ...}: Unavoidable indeterminism: reaction a + b => ... is shadowed by a => ...; Unavoidable livelock: reaction a + b => ..."
+    thrown.getMessage shouldEqual "In Join{a + b => ...; a + b => ...; a => ...}: Unavoidable indeterminism: reaction a + b => ... is shadowed by a => ...; Unavoidable livelock: reactions a + b => ..., a => ..."
   }
 
 

--- a/lib/src/main/scala/code/winitzki/jc/JoinDefinition.scala
+++ b/lib/src/main/scala/code/winitzki/jc/JoinDefinition.scala
@@ -262,11 +262,17 @@ private final case class JoinDefinition(
   }
 
   private def checkSingleReactionLivelock: Option[String] = {
-    ???
+    val errorList = reactionInfos.keys
+      .filter { r => r.info.inputMatchersWeakerThanOutput(r.info)}
+      .map(_.toString)
+    if (errorList.nonEmpty)
+      Some(s"Unavoidable livelock: reaction${if (errorList.size == 1) "" else "s"} ${errorList.mkString(", ")}")
+    else None
+
   }
 
   private def checkMultiReactionLivelock: Option[String] = {
-    ???
+    None
   }
 
   private[jc] def performStaticChecking(): Unit = {

--- a/lib/src/main/scala/code/winitzki/jc/JoinDefinition.scala
+++ b/lib/src/main/scala/code/winitzki/jc/JoinDefinition.scala
@@ -261,10 +261,22 @@ private final case class JoinDefinition(
     } else None
   }
 
+  private def checkSingleReactionLivelock: Option[String] = {
+    ???
+  }
+
+  private def checkMultiReactionLivelock: Option[String] = {
+    ???
+  }
+
   private[jc] def performStaticChecking(): Unit = {
     // TODO Livelock warnings
 
-    val foundErrors = Seq(checkReactionShadowing).flatten
+    val foundErrors = Seq(
+      checkReactionShadowing,
+      checkSingleReactionLivelock,
+      checkMultiReactionLivelock
+    ).flatten
 
     if (foundErrors.nonEmpty) throw new Exception(s"In $this: ${foundErrors.mkString("; ")}")
 

--- a/lib/src/main/scala/code/winitzki/jc/JoinRun.scala
+++ b/lib/src/main/scala/code/winitzki/jc/JoinRun.scala
@@ -584,7 +584,7 @@ object JoinRun {
     val reactionInfos = rs.map { r => (r, r.info.inputs) }.toMap
 
     // create a join definition object holding the given reactions and inputs
-    val join = new JoinDefinition(reactionInfos, reactionPool, joinPool)
+    val join = JoinDefinition(reactionInfos, reactionPool, joinPool)
 
     // set the owner on all input molecules in this join definition
     rs.flatMap { r => r.inputMolecules }
@@ -597,7 +597,7 @@ object JoinRun {
       }
 
     val foundErrors = StaticChecking.performStaticChecking(rs.toSet)
-    if (foundErrors.nonEmpty) throw new Exception(s"In $this: ${foundErrors.mkString("; ")}")
+    if (foundErrors.nonEmpty) throw new Exception(s"In $join: ${foundErrors.mkString("; ")}")
 
   }
 

--- a/lib/src/main/scala/code/winitzki/jc/JoinRun.scala
+++ b/lib/src/main/scala/code/winitzki/jc/JoinRun.scala
@@ -49,7 +49,7 @@ TODO and roadmap:
 
  Kinds of situations to detect at runtime:
  - Input molecules with nontrivial matchers are a subset of output molecules. This is a warning. (Input molecules with trivial matchers can't be a subset of output molecules - this is a compile-time error.)
- - Input molecules of one reaction are a subset of input molecules of another reaction, with the same matchers. This is an error (uncontrollable indeterminism).
+ + Input molecules of one reaction are a subset of input molecules of another reaction, with the same matchers. This is an error (uncontrollable indeterminism).
  - A cycle of input molecules being subset of output molecules, possibly spanning several join definitions (a->b+..., b->c+..., c-> a+...). This is a warning if there are nontrivial matchers and an error otherwise.
  - Output molecules in a reaction include a blocking molecule that might deadlock because other reactions with it require molecules that are injected later. Example: if m is non-blocking and b is blocking, and we have reaction m + b =>... and another reaction that outputs ... => b; m. This is potentially a problem because the first reaction will block waiting for "m", while the second reaction will not inject "m" until "b" returns.
   This is a warning since we can't be sure that the output molecules are always injected, and in what exact order.

--- a/lib/src/main/scala/code/winitzki/jc/JoinRun.scala
+++ b/lib/src/main/scala/code/winitzki/jc/JoinRun.scala
@@ -229,7 +229,6 @@ object JoinRun {
 
   @tailrec
   private[JoinRun] def inputMatchersAreWeakerThanOutput(input: List[InputMoleculeInfo], output: List[OutputMoleculeInfo]): Boolean = {
-//    println(s"debug: inputMatchersAreWeakerThanOutput(input=$input, output=$output)")
     input match {
       case Nil => true
       case info :: rest => output match {

--- a/lib/src/main/scala/code/winitzki/jc/JoinRun.scala
+++ b/lib/src/main/scala/code/winitzki/jc/JoinRun.scala
@@ -229,7 +229,7 @@ object JoinRun {
 
   @tailrec
   private[JoinRun] def inputMatchersAreWeakerThanOutput(input: List[InputMoleculeInfo], output: List[OutputMoleculeInfo]): Boolean = {
-    println(s"debug: inputMatchersAreWeakerThanOutput(input=$input, output=$output)")
+//    println(s"debug: inputMatchersAreWeakerThanOutput(input=$input, output=$output)")
     input match {
       case Nil => true
       case info :: rest => output match {

--- a/lib/src/main/scala/code/winitzki/jc/JoinRun.scala
+++ b/lib/src/main/scala/code/winitzki/jc/JoinRun.scala
@@ -401,7 +401,7 @@ object JoinRun {
 
   // Abstract molecule injector. This type is used in collections of molecules that do not require knowing molecule types.
   abstract sealed class Molecule {
-    private[JoinRun] var joinDef: Option[JoinDefinition] = None
+    private[jc] var joinDef: Option[JoinDefinition] = None
 
     /** Check whether the molecule is already bound to a join definition.
       * Note that molecules can be injected only if they are bound.
@@ -595,7 +595,8 @@ object JoinRun {
         }
       }
 
-    join.performStaticChecking()
+    val foundErrors = StaticChecking.performStaticChecking(rs.toSet)
+    if (foundErrors.nonEmpty) throw new Exception(s"In $this: ${foundErrors.mkString("; ")}")
 
   }
 

--- a/lib/src/main/scala/code/winitzki/jc/JoinRun.scala
+++ b/lib/src/main/scala/code/winitzki/jc/JoinRun.scala
@@ -401,7 +401,8 @@ object JoinRun {
 
   // Abstract molecule injector. This type is used in collections of molecules that do not require knowing molecule types.
   abstract sealed class Molecule {
-    private[jc] var joinDef: Option[JoinDefinition] = None
+    private[JoinRun] var joinDef: Option[JoinDefinition] = None
+    private[jc] def reactions: Option[Set[Reaction]] = joinDef.map(_.reactionInfos.keys.toSet)
 
     /** Check whether the molecule is already bound to a join definition.
       * Note that molecules can be injected only if they are bound.

--- a/lib/src/test/scala/code/winitzki/benchmark/FairnessSpec.scala
+++ b/lib/src/test/scala/code/winitzki/benchmark/FairnessSpec.scala
@@ -163,7 +163,7 @@ class FairnessSpec extends FlatSpec with Matchers with TimeLimitedTests {
       runSimple { case g(_,r) + f((x,y,0)) => r((x,y)) }
     )
 
-    val n = 200
+    val n = 400
 
     f((0,0, n))
 

--- a/macros/src/main/scala/code/winitzki/jc/Macros.scala
+++ b/macros/src/main/scala/code/winitzki/jc/Macros.scala
@@ -13,7 +13,15 @@ object Macros {
 
   type theContext = blackbox.Context
 
-  def getName: String = macro getNameImpl
+  private[jc] def rawTree(x: Any): String = macro rawTreeImpl
+
+  def rawTreeImpl(c: theContext)(x: c.Expr[Any]) = {
+    import c.universe._
+    val result = showRaw(x.tree)
+    q"$result"
+  }
+
+  private[jc] def getName: String = macro getNameImpl
 
   def getEnclosingName(c: theContext): String =
     c.internal.enclosingOwner.name.decodedName.toString

--- a/macros/src/main/scala/code/winitzki/jc/Macros.scala
+++ b/macros/src/main/scala/code/winitzki/jc/Macros.scala
@@ -105,7 +105,7 @@ object Macros {
   def buildReactionImpl(c: theContext)(reactionBody: c.Expr[fmArg]) = {
     import c.universe._
 
-    val reactionBodyReset = c.untypecheck(reactionBody.tree)
+//    val reactionBodyReset = c.untypecheck(reactionBody.tree)
 
     /** Obtain the owner of the current macro call site.
       *
@@ -194,8 +194,8 @@ object Macros {
       override def traverse(tree: Tree): Unit = {
         tree match {
           // avoid traversing nested reactions: check whether this subtree is a Reaction() value
-          case q"code.winitzki.jc.JoinRun.Reaction.apply($a,$b,$_,$_)" => ()
-          case q"JoinRun.Reaction.apply($a,$b,$_,$_)" => ()
+          case q"code.winitzki.jc.JoinRun.Reaction.apply($_,$_,$_,$_)" => ()
+          case q"JoinRun.Reaction.apply($_,$_,$_,$_)" => ()
 
           // matcher with a single argument: a(x)
           case UnApply(Apply(Select(t@Ident(TermName(_)), TermName("unapply")), List(Ident(TermName("<unapply-selector>")))), List(binder)) if t.tpe <:< typeOf[Molecule] =>
@@ -217,8 +217,11 @@ object Macros {
 
           // possibly a molecule injection
           case Apply(Select(t@Ident(TermName(_)), TermName("apply")), binder) =>
-            if (!isOwnedBy(t.symbol, reactionBodyOwner) && t.tpe <:< typeOf[Molecule]) {
-              // skip any molecule injectors defined in the inner scope
+
+            // In the output list, we do not include any molecule injectors defined in the inner scope.
+            val includeThisSymbol = !isOwnedBy(t.symbol.owner, reactionBodyOwner)
+
+            if (includeThisSymbol && t.tpe <:< typeOf[Molecule]) {
               outputMolecules.append((t.symbol, getOutputFlag(binder)))
             }
 

--- a/macros/src/main/scala/code/winitzki/jc/Macros.scala
+++ b/macros/src/main/scala/code/winitzki/jc/Macros.scala
@@ -23,7 +23,7 @@ object Macros {
 
   private[jc] def getName: String = macro getNameImpl
 
-  def getEnclosingName(c: theContext): String =
+  private def getEnclosingName(c: theContext): String =
     c.internal.enclosingOwner.name.decodedName.toString
       .stripSuffix(LOCAL_SUFFIX_STRING).stripSuffix("$lzy")
 
@@ -217,14 +217,14 @@ object Macros {
 
           // possibly a molecule injection
           case Apply(Select(t@Ident(TermName(_)), TermName("apply")), binder) =>
-            if (!isOwnedBy(t.symbol, reactionBodyOwner) && t.tpe <:< typeOf[Molecule])
+            if (!isOwnedBy(t.symbol, reactionBodyOwner) && t.tpe <:< typeOf[Molecule]) {
               // skip any molecule injectors defined in the inner scope
               outputMolecules.append((t.symbol, getOutputFlag(binder)))
-            else ()
+            }
 
-            if (t.tpe <:< weakTypeOf[ReplyValue[_]])
+            if (t.tpe <:< weakTypeOf[ReplyValue[_]]) {
               replyMolecules.append((t.symbol, getOutputFlag(binder)))
-            else ()
+            }
 
           case _ => super.traverse(tree)
 

--- a/macros/src/test/scala/code/winitzki/jc/MacrosSpec.scala
+++ b/macros/src/test/scala/code/winitzki/jc/MacrosSpec.scala
@@ -484,6 +484,19 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
     thrown.getMessage shouldEqual "In Join{a => ...}: Unavoidable livelock: reaction a => ..."
   }
 
+  it should "compute outputs in the correct order for a reaction with no livelock" in {
+    val a = m[Int]
+    val b = m[Int]
+    join(
+      & { case a(2) => b(2) + a(1) + b(1) }
+    )
+    a.reactions.get.map(_.info.outputs) shouldEqual Set(Some(List(
+      OutputMoleculeInfo(b, ConstOutputValue(2)),
+      OutputMoleculeInfo(a, ConstOutputValue(1)),
+      OutputMoleculeInfo(b, ConstOutputValue(1))
+    )))
+  }
+
   behavior of "auxiliary functions"
 
   it should "find expression trees for constant values" in {
@@ -498,12 +511,12 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
 
   it should "find expression trees for matchers" in {
 
-    rawTree(Some(1) match {case Some(x) => } ) shouldEqual "Match(Apply(TypeApply(Select(Select(Ident(scala), scala.Some), TermName(\"apply\")), List(TypeTree())), List(Literal(Constant(1)))), List(CaseDef(Apply(TypeTree().setOriginal(Select(Ident(scala), scala.Some)), List(Bind(TermName(\"x\"), Ident(termNames.WILDCARD)))), EmptyTree, Literal(Constant(())))))"
+    rawTree(Some(1) match {case Some(1) => } ) shouldEqual "Match(Apply(TypeApply(Select(Select(Ident(scala), scala.Some), TermName(\"apply\")), List(TypeTree())), List(Literal(Constant(1)))), List(CaseDef(Apply(TypeTree().setOriginal(Select(Ident(scala), scala.Some)), List(Literal(Constant(1)))), EmptyTree, Literal(Constant(())))))"
     (Set(
-      "Match(Apply(TypeApply(Select(Select(Ident(scala), scala.Some), TermName(\"apply\")), List(TypeTree())), List(Literal(Constant(1)))), List(CaseDef(Apply(TypeTree().setOriginal(Select(Ident(scala), scala.Some)), List(Bind(TermName(\"x\"), Ident(termNames.WILDCARD)))), EmptyTree, Literal(Constant(())))))",
+      "Match(Apply(TypeApply(Select(Select(Ident(scala), scala.Some), TermName(\"apply\")), List(TypeTree())), List(Literal(Constant(1)))), List(CaseDef(Apply(TypeTree().setOriginal(Select(Ident(scala), scala.Some)), List(Literal(Constant(1)))), EmptyTree, Literal(Constant(())))))",
       ""
     ) contains
-    rawTree(Some(1) match  { case Some(x) => })) shouldEqual true
+    rawTree(Some(1) match  { case Some(1) => })) shouldEqual true
   }
 
   it should "find enclosing symbol names with correct scopes" in {

--- a/macros/src/test/scala/code/winitzki/jc/MacrosSpec.scala
+++ b/macros/src/test/scala/code/winitzki/jc/MacrosSpec.scala
@@ -454,6 +454,18 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
 
   }
 
+  behavior of "output value computation"
+
+  it should "not fail to compute outputs for livelock detection" in {
+    val thrown = intercept[Exception] {
+      val a = m[Int]
+      join(
+        & { case a(1) => a(1) }
+      )
+    }
+    thrown.getMessage shouldEqual "In Join{a => ...}: Unavoidable livelock: reaction a => ..."
+  }
+
   behavior of "auxiliary functions"
 
   it should "find expression trees for constant values" in {
@@ -464,6 +476,16 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
         "Apply(TypeApply(Select(Select(Ident(scala), scala.Some), TermName(\"apply\")), List(TypeTree())), List(Literal(Constant(1))))",
         ""
     ) contains rawTree(Some(1))) shouldEqual true
+  }
+
+  it should "find expression trees for matchers" in {
+
+    (rawTree(Some(1) match {case Some(x) => } )) shouldEqual "Match(Apply(TypeApply(Select(Select(Ident(scala), scala.Some), TermName(\"apply\")), List(TypeTree())), List(Literal(Constant(1)))), List(CaseDef(Apply(TypeTree().setOriginal(Select(Ident(scala), scala.Some)), List(Bind(TermName(\"x\"), Ident(termNames.WILDCARD)))), EmptyTree, Literal(Constant(())))))"
+    (Set(
+      "Match(Apply(TypeApply(Select(Select(Ident(scala), scala.Some), TermName(\"apply\")), List(TypeTree())), List(Literal(Constant(1)))), List(CaseDef(Apply(TypeTree().setOriginal(Select(Ident(scala), scala.Some)), List(Bind(TermName(\"x\"), Ident(termNames.WILDCARD)))), EmptyTree, Literal(Constant(())))))",
+      ""
+    ) contains
+    rawTree(Some(1) match  { case Some(x) => })) shouldEqual true
   }
 
   it should "find enclosing symbol names with correct scopes" in {

--- a/macros/src/test/scala/code/winitzki/jc/MacrosSpec.scala
+++ b/macros/src/test/scala/code/winitzki/jc/MacrosSpec.scala
@@ -462,6 +462,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
       join(
         & { case a(1) => a(1) }
       )
+      a.reactions.get.map(_.info.outputs) shouldEqual Set(Some(List(OutputMoleculeInfo(a, ConstOutputValue(1)))))
     }
     thrown.getMessage shouldEqual "In Join{a => ...}: Unavoidable livelock: reaction a => ..."
   }


### PR DESCRIPTION
- Input molecules with nontrivial matchers are a subset of output molecules. This is a warning. (Input molecules with trivial matchers can't be a subset of output molecules - this is a compile-time error.)
- A cycle of input molecules being subset of output molecules, possibly spanning several join definitions (a->b+..., b->c+..., c-> a+...). This is a warning if there are nontrivial matchers and an error otherwise.