### PR TITLE
Chymyst2, speculative tut, and macro& (scalatest run conflict) removal

### DIFF
--- a/benchmark/src/main/scala/code/winitzki/benchmark/Benchmarks1.scala
+++ b/benchmark/src/main/scala/code/winitzki/benchmark/Benchmarks1.scala
@@ -68,10 +68,10 @@ object Benchmarks1 {
     val f = b[LocalDateTime,Long]
 
     join(tp)(
-      & { case c(0) + f(tInit, r) => r(elapsed(tInit)) },
-      & { case g(_,reply) + c(n) => c(n); reply(n) },
-      & { case c(n) + i(_) => c(n+1) },
-      & { case c(n) + d(_) if n > 0 => c(n-1) }
+      run { case c(0) + f(tInit, r) => r(elapsed(tInit)) },
+      run { case g(_,reply) + c(n) => c(n); reply(n) },
+      run { case c(n) + i(_) => c(n+1) },
+      run { case c(n) + d(_) if n > 0 => c(n-1) }
     )
 
     c(init)

--- a/benchmark/src/main/scala/code/winitzki/benchmark/Benchmarks4.scala
+++ b/benchmark/src/main/scala/code/winitzki/benchmark/Benchmarks4.scala
@@ -18,7 +18,7 @@ object Benchmarks4 {
       val g = b[LocalDateTime, Long]
       val as = is.map(i => new M[Int](s"a$i"))
       val jrs = IndexedSeq(
-        & { case f(_) + g(initTime, r) => r(elapsed(initTime)) }
+        run { case f(_) + g(initTime, r) => r(elapsed(initTime)) }
       ) ++ is.map(
         i => {
           val a = as(i)

--- a/benchmark/src/main/scala/code/winitzki/benchmark/Benchmarks7.scala
+++ b/benchmark/src/main/scala/code/winitzki/benchmark/Benchmarks7.scala
@@ -70,8 +70,8 @@ object Benchmarks7 {
     val d = m[Unit]
 
     join(tp)(
-      & { case c(0) => done() },
-      & { case c(n) + d(_) if n > 0 => c(n - 1) }
+      run { case c(0) => done() },
+      run { case c(n) + d(_) if n > 0 => c(n - 1) }
     )
     (1 to counters).foreach(_ => c(init))
     // We return just one molecule.

--- a/benchmark/src/main/scala/code/winitzki/benchmark/Benchmarks9.scala
+++ b/benchmark/src/main/scala/code/winitzki/benchmark/Benchmarks9.scala
@@ -16,8 +16,8 @@ object Benchmarks9 {
     val d = b[Unit, Unit]
 
     join(tp)(
-      & { case c(0) => done() },
-      & { case c(n) + d(_, r) if n > 0 => c(n - 1); r() }
+      run { case c(0) => done() },
+      run { case c(n) + d(_, r) if n > 0 => c(n - 1); r() }
     )
     (1 to counters).foreach(_ => c(init))
     // We return just one molecule.
@@ -56,7 +56,7 @@ object Benchmarks9 {
     val e = b[Int, Int]
 
     join(tp)(
-      & { case c(_) + d(n, reply) => if (n > 0) {
+      run { case c(_) + d(n, reply) => if (n > 0) {
         c()
         e(n-1)
       }
@@ -65,7 +65,7 @@ object Benchmarks9 {
       }
       reply(n)
       },
-      & { case c(_) + e(n, reply) => if (n > 0) {
+      run { case c(_) + e(n, reply) => if (n > 0) {
         c()
         d(n-1)
       }
@@ -119,9 +119,9 @@ object Benchmarks9 {
     val tp = new FixedPool(threads)
 
     join(tp)(
-      & { case ff(_, reply) => var res = reply(123); a(res) },
-      & { case a(x) + collect(n) => collect(n + (if (x) 0 else 1)) },
-      & { case collect(n) + get(_, reply) => reply(n) }
+      run { case ff(_, reply) => var res = reply(123); a(res) },
+      run { case a(x) + collect(n) => collect(n + (if (x) 0 else 1)) },
+      run { case collect(n) + get(_, reply) => reply(n) }
     )
     collect(0)
 

--- a/benchmark/src/test/scala/code/winitzki/benchmark/MapReduceSpec.scala
+++ b/benchmark/src/test/scala/code/winitzki/benchmark/MapReduceSpec.scala
@@ -5,6 +5,7 @@ import java.time.LocalDateTime
 import code.winitzki.benchmark.Common._
 import code.winitzki.jc.FixedPool
 import code.winitzki.jc.JoinRun._
+import code.winitzki.jc.Macros.{run => &}
 import code.winitzki.jc.Macros._
 import org.scalatest.{FlatSpec, Matchers}
 

--- a/benchmark/src/test/scala/code/winitzki/benchmark/MergesortSpec.scala
+++ b/benchmark/src/test/scala/code/winitzki/benchmark/MergesortSpec.scala
@@ -2,6 +2,7 @@ package code.winitzki.benchmark
 
 import Common._
 import code.winitzki.jc.FixedPool
+import code.winitzki.jc.Macros.{run => &}
 import code.winitzki.jc.Macros._
 import code.winitzki.jc.JoinRun._
 import org.scalatest.{FlatSpec, Matchers}

--- a/benchmark/src/test/scala/code/winitzki/benchmark/MultithreadSpec.scala
+++ b/benchmark/src/test/scala/code/winitzki/benchmark/MultithreadSpec.scala
@@ -2,6 +2,7 @@ package code.winitzki.benchmark
 
 import code.winitzki.benchmark.Common._
 import code.winitzki.jc.FixedPool
+import code.winitzki.jc.Macros.{run => &}
 import code.winitzki.jc.Macros._
 import code.winitzki.jc.JoinRun._
 import org.scalatest.{FlatSpec, Matchers}

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,8 @@ val commonSettings = Defaults.coreDefaultSettings ++ Seq(
   scalacOptions ++= Seq()
 )
 
+tutSettings
+
 lazy val joinrun = (project in file("joinrun"))
   .settings(commonSettings: _*)
   .settings(

--- a/docs/chymyst02.md
+++ b/docs/chymyst02.md
@@ -72,12 +72,13 @@ Blocking molecules work at once as [synchronizing barriers](https://en.wikipedia
 
 The syntax for the reply action makes it appear as if the molecule `f` carries _two_ values - its `Unit` value and a special `reply` function, and that the reaction body calls this `reply` function with an integer value.
 However, `f` is injected with the syntax `f()` -- just as any other molecule with `Unit` value.
-The `reply` function appears only in the pattern matching expression for `f` inside a reaction.
+The `reply` function appears only in the pattern-matching expression for `f` inside a reaction.
 
 Blocking molecule injectors are values of type `B[T,R]`, while non-blocking molecule injectors have type `M[T]`.
 Here `T` is the type of value that the molecule carries, and `R` (for blocking molecules) is the type of the reply value.
 
-The pattern matching expression for a blocking molecule of type `B[T,R]` has the form `case ... + f(v, r) + ...` where `v` is of type `T` and `r` is of type `R => Boolean`.
+The pattern-matching expression for a blocking molecule of type `B[T,R]` has the form `case ... + f(v, r) + ...` where `v` is of type `T` and `r` is of type 
+`R => Boolean`.
 Since `r` has a function type, users must match it with a pattern variable.
 The names `reply` or `r` can be used for clarity.
 

--- a/docs/chymyst02.md
+++ b/docs/chymyst02.md
@@ -1,7 +1,7 @@
 # Blocking vs. non-blocking molecules
 
 So far, we have used molecules whose injection was a non-blocking call:
-Injecting a molecule, such as `b(123)`, immediately returns `Unit` but performs a concurrent side effect (to add a new molecule to the soup).
+Injecting a molecule, such as `a(123)`, immediately returns `Unit` but performs a concurrent side effect (to add a new molecule to the soup).
 Such molecules are called **non-blocking**.
 
 An important feature of the chemical machine is the ability to define **blocking molecules**.
@@ -64,20 +64,20 @@ Once the reaction starts, it will receive the value `n = 123` from the input mol
 Both `c(123)` and `f()` will be consumed by the reaction.
 The reaction will then perform the reply action `reply(n)` with `n` set to `123`.
 Only at this point the calling process will get unblocked and receive `123` as the return value of the function call `f()`.
-From the point of view of the reaction that consumed a blocking molecule, the reply action is a non-blocking (i.e. very fast) function call.
+From the point of view of the reaction that consumes a blocking molecule, the reply action is a non-blocking (i.e. very fast) function call.
 The reaction will continue evaluating its reaction body, concurrently with the newly unblocked process that received the reply value `123` and can continue its computations.
 
 This is how the chemical machine implements blocking molecules.
-Blocking molecules work at once as synchronizing barriers and as channels of communication between processes.
+Blocking molecules work at once as [synchronizing barriers](https://en.wikipedia.org/wiki/Barrier_(computer_science)) and as channels of communication between processes.
 
 The syntax for the reply action makes it appear as if the molecule `f` carries _two_ values - its `Unit` value and a special `reply` function, and that the reaction body calls this `reply` function with an integer value.
 However, `f` is injected with the syntax `f()` -- just as any other molecule with `Unit` value.
-The `reply` function appears only in the pattern-matching expression for `f` inside a reaction.
+The `reply` function appears only in the pattern matching expression for `f` inside a reaction.
 
 Blocking molecule injectors are values of type `B[T,R]`, while non-blocking molecule injectors have type `M[T]`.
 Here `T` is the type of value that the molecule carries, and `R` (for blocking molecules) is the type of the reply value.
 
-The pattern-matching expression for a blocking molecule of type `B[T,R]` has the form `case ... + f(v, r) + ...` where `v` is of type `T` and `r` is of type `R => Boolean`.
+The pattern matching expression for a blocking molecule of type `B[T,R]` has the form `case ... + f(v, r) + ...` where `v` is of type `T` and `r` is of type `R => Boolean`.
 Since `r` has a function type, users must match it with a pattern variable.
 The names `reply` or `r` can be used for clarity.
 
@@ -102,7 +102,7 @@ run { case fetch(_, reply) + counter(n) if n == 0  => reply() }
 
 ```
 
-For more clarity, we can also use the pattern-matching facility of `JoinRun` to implement the same reaction like this:
+For more clarity, we can also use the pattern matching facility of `JoinRun` to implement the same reaction like this:
 
 ```scala
 run { case counter(0) + fetch(_, reply)  => reply() }
@@ -149,12 +149,12 @@ Some remarks:
 - Molecules with unit values still require a pattern variable when used in the `case` construction.
 For this reason, we write `decr(_)` and `fetch(_, reply)` in the match patterns.
 However, these molecules can be injected simply by calling `decr()` and `fetch()`, since Scala inserts a `Unit` value automatically when calling functions.
-- We declared both reactions in one join definition, because these two reactions share the input molecule `counter`.
+- We declare both reactions in one join definition, because these two reactions share the input molecule `counter`.
 - The injected blocking molecule `fetch()` will not remain in the soup after the reaction is finished.
 Actually, it would not make sense for `fetch()` to remain in the soup:
 If a molecule remains in the soup after a reaction, it means that the molecule is going to be available for some later reaction without blocking its injecting call; but this is the behavior of a non-blocking molecule.
-- Blocking molecules are like functions except that they will block until their reactions are not available.
-If the relevant reaction never starts, a blocking molecule will block forever.
+- Blocking molecules are like functions except that they will block as long as their reactions are unavailable.
+If the relevant reaction never starts, a blocking molecule blocks forever.
 The runtime engine cannot detect this situation because it cannot determine whether the relevant input molecules for that reaction might become available in the future.
 - If several reactions are available for the blocking molecule, one of these reactions will be selected at random.
 - Blocking molecules are printed with the suffix `"/B"`.
@@ -386,7 +386,7 @@ run { case result(n) + done(x) =>
     }
 ```
 
-To make the chemistry clearer, we can rewrite this as three reactions using pattern-matching:
+To make the chemistry clearer, we can rewrite this as three reactions using pattern matching:
 
 ```scala
 join(
@@ -441,10 +441,10 @@ Sometimes, errors of this type can be caught at compile time:
 ```scala
 val f = b[Unit, Int]
 val c = m[Int]
-join( run { case f(_,reply) + c(n) => c(n+1) } ) // forgot to reply!
+join( run { case f(_,r) + c(n) => c(n+1) } ) // forgot to reply!
 // compile-time error: "blocking input molecules should receive a reply but no reply found"
 
-join( run { case f(_,reply) + c(n) => c(n+1) + r(n) + r(n) } ) // replied twice!
+join( run { case f(_,r) + c(n) => c(n+1) + r(n) + r(n) } ) // replied twice!
 // compile-time error: "blocking input molecules should receive one reply but multiple replies found"
 
 ```
@@ -455,7 +455,7 @@ In this case, a reaction that does not reply will generate a run-time error:
 ```scala
 val f = b[Unit, Int]
 val c = m[Int]
-join( run { case f(_,reply) + c(n) => c(n+1); if (n==0) reply(n) } )
+join( run { case f(_,r) + c(n) => c(n+1); if (n==0) r(n) } )
 
 c(1)
 f()
@@ -465,6 +465,6 @@ java.lang.Exception: Error: In Join{c + f/B => ...}: Reaction {c + f/B => ...} f
 
 Note that this error will occur only when reactions actually start and the run-time condition is evaluated to `false`.
 Also, the exception may be thrown on another thread, which may not be immediately visible.
-For these reasons, it is not easy to catch errors of this type, either at compile time or at runtime.
+For these reasons, it is not easy to catch errors of this type, either at compile time or at run time.
 To avoid these problems, it is advisable to reorganize the chemistry such that reply actions (and, more generally, output molecule injections) are unconditional.
 

--- a/joinrun/src/test/scala/code/winitzki/test/MoreBlockingSpec.scala
+++ b/joinrun/src/test/scala/code/winitzki/test/MoreBlockingSpec.scala
@@ -2,6 +2,7 @@ package code.winitzki.test
 
 import code.winitzki.jc.{FixedPool, SmartPool}
 import code.winitzki.jc.JoinRun._
+import code.winitzki.jc.Macros.{run => &}
 import code.winitzki.jc.Macros._
 import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.concurrent.TimeLimitedTests

--- a/joinrun/src/test/scala/code/winitzki/test/ParallelOrSpec.scala
+++ b/joinrun/src/test/scala/code/winitzki/test/ParallelOrSpec.scala
@@ -1,6 +1,7 @@
 package code.winitzki.test
 
 import code.winitzki.jc.JoinRun._
+import code.winitzki.jc.Macros.{run => &}
 import code.winitzki.jc.Macros._
 import code.winitzki.jc.{FixedPool, Pool}
 import org.scalatest.{FlatSpec, Matchers}

--- a/joinrun/src/test/scala/code/winitzki/test/SingletonMoleculeSpec.scala
+++ b/joinrun/src/test/scala/code/winitzki/test/SingletonMoleculeSpec.scala
@@ -1,6 +1,7 @@
 package code.winitzki.test
 
 import code.winitzki.jc.JoinRun._
+import code.winitzki.jc.Macros.{run => &}
 import code.winitzki.jc.Macros._
 import code.winitzki.jc.{FixedPool, SmartPool}
 import org.scalatest.concurrent.TimeLimitedTests

--- a/joinrun/src/test/scala/code/winitzki/test/StaticAnalysisSpec.scala
+++ b/joinrun/src/test/scala/code/winitzki/test/StaticAnalysisSpec.scala
@@ -1,6 +1,7 @@
 package code.winitzki.test
 
 import code.winitzki.jc.JoinRun._
+import code.winitzki.jc.Macros.{run => &}
 import code.winitzki.jc.Macros._
 import code.winitzki.jc.WarningsAndErrors
 import org.scalatest.concurrent.TimeLimitedTests

--- a/macros/src/main/scala/code/winitzki/jc/Macros.scala
+++ b/macros/src/main/scala/code/winitzki/jc/Macros.scala
@@ -58,17 +58,6 @@ object Macros {
     c.Expr[B[T, R]](q"new B[$t,$r]($s)")
   }
 
-  /**
-    * This is an alias for [[Macros#run]], to be used in case [[Macros#run]] clashes
-    * with another name imported into the local scope (e.g. in scalatest).
-    * Examples: & { a(_) => ... }
-    * & { a (_) => ...} onThreads threadPool
-    */
-  object & {
-    // Users will create reactions using these functions.
-    def apply(reactionBody: ReactionBody): Reaction = macro buildReactionImpl
-  }
-
   /** Describes the pattern matcher for input molecules.
     * Possible values:
     * Wildcard: a(_)

--- a/macros/src/test/scala/code/winitzki/jc/MacrosSpec.scala
+++ b/macros/src/test/scala/code/winitzki/jc/MacrosSpec.scala
@@ -1,6 +1,7 @@
 package code.winitzki.jc
 
 import JoinRun._
+import Macros.{run => &}
 import Macros._
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 

--- a/macros/src/test/scala/code/winitzki/jc/MacrosSpec.scala
+++ b/macros/src/test/scala/code/winitzki/jc/MacrosSpec.scala
@@ -1,8 +1,7 @@
 package code.winitzki.jc
 
 import JoinRun._
-import Macros.{run => &}
-import Macros._
+import Macros.{getName, rawTree, m,b, run => &}
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 
 import scala.concurrent.duration.DurationInt

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 logLevel := Level.Warn
+addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.7")


### PR DESCRIPTION
1) Chymyst2 rewording (including r/reply renaming in a late example, line 447 used both r and reply when only one should have been used)
2) getting rid of macro & with => run import as a substitute
3) slightly speculative intro of tut in plugins.sbt and build.sbt