### PR TITLE
first crack at more structured error reporting, work in progress

### DIFF
--- a/lib/src/main/scala/code/chymyst/jc/Core.scala
+++ b/lib/src/main/scala/code/chymyst/jc/Core.scala
@@ -6,70 +6,6 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import scala.collection.JavaConverters.asScalaIteratorConverter
 import scala.collection.mutable
 
-
-trait Severity
-trait WarningSeverity extends Severity
-trait ErrorSeverity extends Severity
-
-final case class LogEntry(context: Product, message: String)
-
-final case class JoinRunInternalMessage(reactionInfo: ReactionInfo,
-                                        rs: ReactionSite,
-                                        moleculesAsString: String,
-                                        exceptionMessage: String) extends ErrorSeverity {
-  def show: String = s"""In ${rs.toString}: Reaction ${reactionInfo.toString} produced an exception that is internal to JoinRun. Input molecules "
-                        | "[$moleculesAsString] were not emitted again. Message: $exceptionMessage"""
-  // the actual name of show is unimportant here and not required, provided message1Show
-  // makes use of Messsage1 meaningfully and can obtain a String.
-}
-
-
-final case class JoinRunInternalAboutMessage(reactionInfo: ReactionInfo,
-                                             rs: ReactionSite,
-                                             moleculesAsString: String,
-                                             aboutMolecules: String,
-                                             exceptionMessage: String) extends ErrorSeverity {
-  def show: String = s"""In ${rs.toString}: Reaction ${reactionInfo.toString} produced an exception. Input molecules "
-                       | [$moleculesAsString] $aboutMolecules. Message: $exceptionMessage"""
-}
-
-final case class JoinRunComboOfTwoMessages(reactionInfo: ReactionInfo,
-                                          rs: ReactionSite,
-                                          blockingMoleculesWithNoReply: Option[String],
-                                          blockingMoleculesWithMultipleReply: Option[String],
-                                          moleculesAsString: String) extends ErrorSeverity {
-  def show: String = {
-    val messageNoReply: Option[String] = blockingMoleculesWithNoReply map { s =>
-      s"Error: In $this: Reaction {${reactionInfo}} with inputs [$moleculesAsString] finished without replying to $s"
-    }
-    val messageMultipleReply: Option[String] = blockingMoleculesWithMultipleReply map { s =>
-      s"Error: In $this: Reaction {$reactionInfo} with inputs [$moleculesAsString] replied to $s more than once" }
-
-    Seq(messageNoReply, messageMultipleReply).flatten.mkString("; ")
-
-  }
-
-}
-
-final case class ExceptionInJoinRunMessage(e: ExceptionInJoinRun) extends ErrorSeverity {
-  def show: String = e.getMessage
-}
-
-trait Show[A] {
-  def show(a: A): String
-}
-
-object Show {
-  def apply[A](f: A => String): Show[A] = new Show[A] {
-    def show(a: A): String = f(a)
-  }
-  // names of methods below need not convey a useful name, they must simply exist with proper return type and implementation.
-  implicit def joinRunInternalMessageShow: Show[JoinRunInternalMessage] = Show(m => m.show)
-  implicit def joinRunInternalAboutMessageShow: Show[JoinRunInternalAboutMessage] = Show(m => m.show)
-  implicit def joinRunComboOfTwoMessagesShow: Show[JoinRunComboOfTwoMessages] = Show(m => m.show)
-  implicit def exceptionInJoinRunMessageShow: Show[ExceptionInJoinRunMessage] = Show(m => m.show)
-}
-
 object Core {
 
   /** A special value for {{{ReactionInfo}}} to signal that we are not running a reaction.
@@ -201,12 +137,12 @@ object Core {
 
   }
 
-  private val errorLog = new ConcurrentLinkedQueue[LogEntry] // case class extends Product and we're willing to add case classes into the queue.
-  private[jc] def reportError[A <: Product](m: A)(implicit ev: Show[A]): Unit = {
-    errorLog.add(LogEntry(m, ev.show(m)))
+  private val errorLog = new ConcurrentLinkedQueue[LogMessage]
+  private[jc] def reportError(report: LogMessage): Unit = {
+    errorLog.add(report)
     ()
   }
 
-  def globalErrorLog: Iterable[LogEntry] = errorLog.iterator().asScala.toIterable
+  def globalErrorLog: Iterable[LogMessage] = errorLog.iterator().asScala.toIterable
 }
 

--- a/lib/src/main/scala/code/chymyst/jc/Core.scala
+++ b/lib/src/main/scala/code/chymyst/jc/Core.scala
@@ -6,6 +6,33 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import scala.collection.JavaConverters.asScalaIteratorConverter
 import scala.collection.mutable
 
+
+sealed trait Severity
+trait WarningSeverity extends Severity
+trait ErrorSeverity extends Severity
+
+case class Message1(m: Molecule, rs: ReactionSite) extends ErrorSeverity {
+  def show: String = ???  // the actual name of show is unimportant here and not required, provided message1Show
+  // makes use of Messsage1 meaningfully and can obtain a String.
+}
+
+case class Message2(rs: ReactionSite, r1: ReactionInfo, r2: ReactionInfo, m: Molecule) extends WarningSeverity {
+  def show: String = ???  // the actual name of show is unimportant here and not required, provided message2Show
+  // makes use of Messsage2 meaningfully and can obtain a String.
+}
+
+trait Show[A] {
+  def show(a: A): String
+}
+
+object Show {
+  def apply[A](f: A => String): Show[A] = new Show[A] {
+    def show(a: A): String = f(a)
+  }
+  implicit def message1Show: Show[Message1] = Show(_.show)
+  implicit def message2Show: Show[Message2] = Show(_.show)
+}
+
 sealed trait ReportSeverity
 case object ErrorSeverity extends ReportSeverity
 case object WarningSeverity extends ReportSeverity

--- a/lib/src/main/scala/code/chymyst/jc/LogMessage.scala
+++ b/lib/src/main/scala/code/chymyst/jc/LogMessage.scala
@@ -1,34 +1,34 @@
 package code.chymyst.jc
 
-trait WarningMessage { val isError = false }
-trait ErrorMessage { val isError = true }
-
-sealed trait LogMessage { def format: String }
+sealed trait LogMessage {
+  val reactionSite: ReactionSite
+  def format: String
+}
 
 final case class JoinRunInternalMessage(reactionInfo: ReactionInfo,
-                                        rs: ReactionSite,
+                                        override val reactionSite: ReactionSite,
                                         moleculesAsString: String,
-                                        exceptionMessage: String) extends LogMessage with ErrorMessage {
+                                        exceptionMessage: String) extends LogMessage {
   override def format: String =
-    s"""In ${rs.toString}: Reaction ${reactionInfo.toString} produced an exception that is internal to JoinRun. Input molecules "
+    s"""In ${reactionSite.toString}: Reaction ${reactionInfo.toString} produced an exception that is internal to JoinRun. Input molecules "
       | "[$moleculesAsString] were not emitted again. Message: $exceptionMessage"""
 }
 
 
 final case class JoinRunAboutMoleculesMessage(reactionInfo: ReactionInfo,
-                                              rs: ReactionSite,
+                                              override val reactionSite: ReactionSite,
                                               moleculesAsString: String,
                                               aboutMolecules: String,
-                                              exceptionMessage: String) extends LogMessage with ErrorMessage {
-  override def format: String = s"""In ${rs.toString}: Reaction ${reactionInfo.toString} produced an exception. Input molecules "
+                                              exceptionMessage: String) extends LogMessage {
+  override def format: String = s"""In ${reactionSite.toString}: Reaction ${reactionInfo.toString} produced an exception. Input molecules "
                                    | [$moleculesAsString] $aboutMolecules. Message: $exceptionMessage"""
 }
 
 final case class JoinRunComboOfTwoMessages(reactionInfo: ReactionInfo,
-                                           rs: ReactionSite,
+                                           override val reactionSite: ReactionSite,
                                            blockingMoleculesWithNoReply: Option[String],
                                            blockingMoleculesWithMultipleReply: Option[String],
-                                           moleculesAsString: String) extends LogMessage with ErrorMessage {
+                                           moleculesAsString: String) extends LogMessage {
   override def format: String = {
     val messageNoReply: Option[String] = blockingMoleculesWithNoReply map { s =>
       s"Error: In $this: Reaction {${reactionInfo}} with inputs [$moleculesAsString] finished without replying to $s"
@@ -42,6 +42,7 @@ final case class JoinRunComboOfTwoMessages(reactionInfo: ReactionInfo,
 
 }
 
-final case class ExceptionInJoinRunMessage(e: ExceptionInJoinRun) extends LogMessage with ErrorMessage {
+final case class ExceptionInJoinRunMessage(override val reactionSite: ReactionSite,
+                                           e: ExceptionInJoinRun) extends LogMessage {
   override def format: String = e.getMessage
 }

--- a/lib/src/main/scala/code/chymyst/jc/LogMessage.scala
+++ b/lib/src/main/scala/code/chymyst/jc/LogMessage.scala
@@ -1,0 +1,47 @@
+package code.chymyst.jc
+
+trait WarningMessage { val isError = false }
+trait ErrorMessage { val isError = true }
+
+sealed trait LogMessage { def format: String }
+
+final case class JoinRunInternalMessage(reactionInfo: ReactionInfo,
+                                        rs: ReactionSite,
+                                        moleculesAsString: String,
+                                        exceptionMessage: String) extends LogMessage with ErrorMessage {
+  override def format: String =
+    s"""In ${rs.toString}: Reaction ${reactionInfo.toString} produced an exception that is internal to JoinRun. Input molecules "
+      | "[$moleculesAsString] were not emitted again. Message: $exceptionMessage"""
+}
+
+
+final case class JoinRunAboutMoleculesMessage(reactionInfo: ReactionInfo,
+                                              rs: ReactionSite,
+                                              moleculesAsString: String,
+                                              aboutMolecules: String,
+                                              exceptionMessage: String) extends LogMessage with ErrorMessage {
+  override def format: String = s"""In ${rs.toString}: Reaction ${reactionInfo.toString} produced an exception. Input molecules "
+                                   | [$moleculesAsString] $aboutMolecules. Message: $exceptionMessage"""
+}
+
+final case class JoinRunComboOfTwoMessages(reactionInfo: ReactionInfo,
+                                           rs: ReactionSite,
+                                           blockingMoleculesWithNoReply: Option[String],
+                                           blockingMoleculesWithMultipleReply: Option[String],
+                                           moleculesAsString: String) extends LogMessage with ErrorMessage {
+  override def format: String = {
+    val messageNoReply: Option[String] = blockingMoleculesWithNoReply map { s =>
+      s"Error: In $this: Reaction {${reactionInfo}} with inputs [$moleculesAsString] finished without replying to $s"
+    }
+    val messageMultipleReply: Option[String] = blockingMoleculesWithMultipleReply map { s =>
+      s"Error: In $this: Reaction {$reactionInfo} with inputs [$moleculesAsString] replied to $s more than once" }
+
+    Seq(messageNoReply, messageMultipleReply).flatten.mkString("; ")
+
+  }
+
+}
+
+final case class ExceptionInJoinRunMessage(e: ExceptionInJoinRun) extends LogMessage with ErrorMessage {
+  override def format: String = e.getMessage
+}

--- a/lib/src/main/scala/code/chymyst/jc/ReactionSite.scala
+++ b/lib/src/main/scala/code/chymyst/jc/ReactionSite.scala
@@ -106,8 +106,6 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
         // Running the reaction body produced an exception that is internal to JoinRun.
         // We should not try to recover from this; it is most either an error on user's part
         // or a bug in JoinRun.
-        // reportError(s"In $this: Reaction {${reaction.info}} produced an exception that is internal to JoinRun. Input molecules [${moleculeBagToString
-         // (usedInputs)}] were not emitted again. Message: ${e.getMessage}")
 
         val error = JoinRunInternalMessage(reactionInfo = reaction.info,
           rs = this,
@@ -130,9 +128,7 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
         }
         else (ReactionExitFailure, "were consumed and not emitted again")
 
-     //   reportError(s"In $this: Reaction {${reaction.info}} produced an exception. Input molecules [${moleculeBagToString(usedInputs)}] $aboutMolecules. " +
-     //  s"Message: ${e.getMessage}")
-        val error = JoinRunInternalAboutMessage(reactionInfo = reaction.info,
+        val error = JoinRunAboutMoleculesMessage(reactionInfo = reaction.info,
           rs = this,
           moleculesAsString = moleculeBagToString(usedInputs),
           aboutMolecules = aboutMolecules,

--- a/lib/src/main/scala/code/chymyst/jc/ReactionSite.scala
+++ b/lib/src/main/scala/code/chymyst/jc/ReactionSite.scala
@@ -108,7 +108,7 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
         // or a bug in JoinRun.
 
         val error = JoinRunInternalMessage(reactionInfo = reaction.info,
-          rs = this,
+          reactionSite = this,
           moleculesAsString = moleculeBagToString(usedInputs),
           exceptionMessage = e.getMessage)
         reportError(error)
@@ -129,7 +129,7 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
         else (ReactionExitFailure, "were consumed and not emitted again")
 
         val error = JoinRunAboutMoleculesMessage(reactionInfo = reaction.info,
-          rs = this,
+          reactionSite = this,
           moleculesAsString = moleculeBagToString(usedInputs),
           aboutMolecules = aboutMolecules,
           exceptionMessage = e.getMessage)
@@ -179,7 +179,7 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
     if (haveErrorsWithBlockingMolecules) {
       val error = JoinRunComboOfTwoMessages(
         reactionInfo = reaction.info,
-        rs = this,
+        reactionSite = this,
         blockingMoleculesWithNoReply =  blockingMoleculesWithNoReply,
         blockingMoleculesWithMultipleReply = blockingMoleculesWithMultipleReply,
         moleculesAsString = moleculeBagToString(usedInputs))
@@ -276,7 +276,7 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
     }
 
   } catch {
-    case e: ExceptionInJoinRun => reportError(ExceptionInJoinRunMessage(e))
+    case e: ExceptionInJoinRun => reportError(ExceptionInJoinRunMessage(reactionSite = this, e))
   }
 
   /** This variable is true only at the initial stage of building the reaction site,

--- a/lib/src/main/scala/code/chymyst/jc/ReactionSite.scala
+++ b/lib/src/main/scala/code/chymyst/jc/ReactionSite.scala
@@ -106,7 +106,12 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
         // Running the reaction body produced an exception that is internal to JoinRun.
         // We should not try to recover from this; it is most either an error on user's part
         // or a bug in JoinRun.
-        reportError(s"In $this: Reaction {${reaction.info}} produced an exception that is internal to JoinRun. Input molecules [${moleculeBagToString(usedInputs)}] were not emitted again. Message: ${e.getMessage}")
+        // reportError(s"In $this: Reaction {${reaction.info}} produced an exception that is internal to JoinRun. Input molecules [${moleculeBagToString
+         // (usedInputs)}] were not emitted again. Message: ${e.getMessage}")
+        val format = "In %s: Reaction {%s} produced an exception that is internal to JoinRun. Input molecules [%s] were not emitted again. Message: %s"
+        val fArgs = List(this.toString , reaction.info.toString, moleculeBagToString(usedInputs), e.getMessage)
+        reportError(ErrorReport(severity = ErrorSeverity, format = format, fArgs = fArgs))
+
         // Let's not print it, and let's not throw it again, since it's our internal exception.
         //        e.printStackTrace() // This will be printed asynchronously, out of order with the previous message.
         //        throw e
@@ -121,7 +126,11 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
         }
         else (ReactionExitFailure, "were consumed and not emitted again")
 
-        reportError(s"In $this: Reaction {${reaction.info}} produced an exception. Input molecules [${moleculeBagToString(usedInputs)}] $aboutMolecules. Message: ${e.getMessage}")
+     //   reportError(s"In $this: Reaction {${reaction.info}} produced an exception. Input molecules [${moleculeBagToString(usedInputs)}] $aboutMolecules. " +
+     //  s"Message: ${e.getMessage}")
+        val format = "In %s: Reaction {%s} produced an exception. Input molecules [%s] %s. Message: %s"
+        val fArgs = List(this.toString , reaction.info.toString, moleculeBagToString(usedInputs), aboutMolecules, e.getMessage)
+        reportError(ErrorReport(severity = ErrorSeverity, format = format, fArgs = fArgs))
         //        e.printStackTrace() // This will be printed asynchronously, out of order with the previous message. Let's not print this.
         status
     }
@@ -162,7 +171,8 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
       case _ => ()
     }
 
-    if (haveErrorsWithBlockingMolecules) reportError(errorMessage)
+    // not exactly good, considering complexity of this errorMessage construction
+    if (haveErrorsWithBlockingMolecules) reportError(ErrorReport(severity = ErrorSeverity, format = errorMessage, fArgs = Nil))
 
   }
 
@@ -254,7 +264,8 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
     }
 
   } catch {
-    case e: ExceptionInJoinRun => reportError(e.getMessage)
+    case e: ExceptionInJoinRun =>
+      reportError(ErrorReport(severity = ErrorSeverity, format = e.getMessage, fArgs = Nil))
   }
 
   /** This variable is true only at the initial stage of building the reaction site,

--- a/lib/src/test/scala/code/chymyst/jc/MoleculesSpec.scala
+++ b/lib/src/test/scala/code/chymyst/jc/MoleculesSpec.scala
@@ -380,7 +380,7 @@ class MoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests with Be
     }
 
     val result = g.timeout(1500 millis)()
-    globalErrorLog.exists(_.contains("Message: crash! (it's OK, ignore this)"))
+    globalErrorLog.exists(_.formatted.contains("Message: crash! (it's OK, ignore this)"))
     tp.shutdownNow()
     result shouldEqual Some(())
   }

--- a/lib/src/test/scala/code/chymyst/jc/MoleculesSpec.scala
+++ b/lib/src/test/scala/code/chymyst/jc/MoleculesSpec.scala
@@ -380,7 +380,7 @@ class MoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests with Be
     }
 
     val result = g.timeout(1500 millis)()
-    globalErrorLog.exists(_.message.contains("Message: crash! (it's OK, ignore this)"))
+    globalErrorLog.exists(_.format.contains("Message: crash! (it's OK, ignore this)"))
     tp.shutdownNow()
     result shouldEqual Some(())
   }

--- a/lib/src/test/scala/code/chymyst/jc/MoleculesSpec.scala
+++ b/lib/src/test/scala/code/chymyst/jc/MoleculesSpec.scala
@@ -380,7 +380,7 @@ class MoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests with Be
     }
 
     val result = g.timeout(1500 millis)()
-    globalErrorLog.exists(_.formatted.contains("Message: crash! (it's OK, ignore this)"))
+    globalErrorLog.exists(_.message.contains("Message: crash! (it's OK, ignore this)"))
     tp.shutdownNow()
     result shouldEqual Some(())
   }


### PR DESCRIPTION
This particular commit/PR should serve as opening discussion and is work in progress.

Need to find home for sealed trait and ErrorReport type, not necessarily where it is.
May need to add in error codes specific to each error (makes for quick check in unit tests for example), however one usage concatenates multiple errors, so first/last error may be mapped to an error code. Centralized management of error codes, i.e. defining them in one place, may be a plus or minus depending on perspective.
Eventually some unit tests could depend on this and we might want them not to look at formatted strings.

Rebase apparently worked, I think.