### PR TITLE
crossCompilation working to 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,10 +25,9 @@ val commonSettings = Defaults.coreDefaultSettings ++ Seq(
   resolvers += "Typesafe releases" at "http://repo.typesafe.com/typesafe/releases",
 
   scalacOptions ++= Seq( // https://tpolecat.github.io/2014/04/11/scalac-flags.html
-    "-target:jvm-1.8",
     "-deprecation",
     "-unchecked",
-    "-encoding", "UTF-8", // yes, this is 2 args
+    "-encoding", "UTF-8",
     "-feature",
 //    "-language:existentials",
     "-language:higherKinds",
@@ -40,9 +39,24 @@ val commonSettings = Defaults.coreDefaultSettings ++ Seq(
     "-Ywarn-numeric-widen",
     "-Ywarn-value-discard",
     "-Xfuture",
-    "-Ywarn-unused",
-    "-Ywarn-unused-import" // 2.11 only
-  )
+    "-Ywarn-unused"
+  ) ++ ( //target:jvm-1.8 supported from 2.11.5, warn-unused-import deprecated in 2.12
+        if (scalaVersion.value startsWith "2.11") {
+          val revision = scalaVersion.value.split('.').last.toInt
+          Seq("-Ywarn-unused-import") ++ (
+            if (revision >= 5) {
+              Seq("-target:jvm-1.8")
+            }
+            else {
+              Nil
+            })
+        }
+        else Nil
+    )
+    ++ (
+        if (scalaVersion.value startsWith "2.12") Seq("-target:jvm-1.8") // what about "-Ypartial-unification" (SI-2712)?
+        else Nil
+    )
 )
 
 tutSettings

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ val commonSettings = Defaults.coreDefaultSettings ++ Seq(
         else Nil
     )
     ++ (
-        if (scalaVersion.value startsWith "2.12") Seq("-target:jvm-1.8") // what about "-Ypartial-unification" (SI-2712)?
+        if (scalaVersion.value startsWith "2.12") Seq("-target:jvm-1.8","-Ypartial-unification") // (SI-2712 pertains to partial-unification)
         else Nil
     )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -20,9 +20,10 @@ val commonSettings = Defaults.coreDefaultSettings ++ Seq(
   version := "0.1.4",
   scalaVersion := "2.11.8",
   crossScalaVersions := Seq("2.11.0", "2.11.1", "2.11.2", "2.11.3", "2.11.4", "2.11.5", "2.11.6", "2.11.7", "2.11.8", "2.12.0", "2.12.1"),
-  resolvers += Resolver.sonatypeRepo("snapshots"),
-  resolvers += Resolver.sonatypeRepo("releases"),
-  resolvers += "Typesafe releases" at "http://repo.typesafe.com/typesafe/releases",
+  resolvers ++= Seq(
+    Resolver.sonatypeRepo("snapshots"),
+    Resolver.sonatypeRepo("releases"),
+    "Typesafe releases" at "http://repo.typesafe.com/typesafe/releases"),
 
   scalacOptions ++= Seq( // https://tpolecat.github.io/2014/04/11/scalac-flags.html
     "-deprecation",

--- a/joinrun/src/test/scala/code/chymyst/test/StaticAnalysisSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/test/StaticAnalysisSpec.scala
@@ -15,6 +15,9 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
   behavior of "analysis of reaction shadowing"
 
+  val hash211 = "4BE5"
+  val hash212 = "B07E"
+
   it should "detect shadowing of simplest reactions" in {
     val thrown = intercept[Exception] {
       val a = m[Unit]
@@ -92,7 +95,14 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
         go { case a(Some(1)) + b(2) => }
       )
     }
-    thrown.getMessage shouldEqual "In Site{a + b => ...; a => ...}: Unavoidable nondeterminism: reaction {a(<4BE5...>) + b(2) => } is shadowed by {a(<4BE5...>) => }"
+
+    def expectsFromHash(hash: String) =
+      s"In Site{a + b => ...; a => ...}: Unavoidable nondeterminism: reaction {a(<$hash...>) + b(2) => } is " +
+      s"shadowed by {a(<$hash...>) => }"
+    val expected211 = expectsFromHash(hash211)
+    val expected212 = expectsFromHash(hash212)
+
+    Set(expected211, expected212) should contain oneElementOf List(thrown.getMessage)
   }
 
   it should "fail to detect shadowing of reactions with non-identical non-constant matchers" in {
@@ -114,7 +124,12 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
         go { case a(Some(1)) + b(2) => }
       )
     }
-    thrown.getMessage shouldEqual "In Site{a + b => ...; a + b => ...}: Unavoidable nondeterminism: reaction {a(<4BE5...>) + b(2) => } is shadowed by {a(<4BE5...>) + b(_) => }"
+    def expectsFromHash(hash: String) =
+      s"In Site{a + b => ...; a + b => ...}: Unavoidable nondeterminism: reaction {a(<$hash...>) + b(2) => } is shadowed by {a(<$hash...>) + b(_) => }"
+    val expected211 = expectsFromHash(hash211)
+    val expected212 = expectsFromHash(hash212)
+
+    Set(expected211, expected212) should contain oneElementOf List(thrown.getMessage)
   }
 
   object IsEven {
@@ -153,7 +168,14 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
         go { case a(Some(1)) + b(2) + a(Some(2)) + a(Some(3)) + b(1) + b(_) + b(1) => }
       )
     }
-    thrown.getMessage shouldEqual "In Site{a + a + a + b + b + b + b => ...; a + a + a + b + b + b => ...}: Unavoidable nondeterminism: reaction {a(<45EA...>) + a(<465D...>) + a(<4BE5...>) + b(1) + b(1) + b(2) + b(_) => } is shadowed by {a(<465D...>) + a(_) + a(.) + b(1) + b(1) + b(_) => }"
+    def expectsFromHash(hashA: String, hashB: String, hashC: String, hashD: String) =
+      s"In Site{a + a + a + b + b + b + b => ...; a + a + a + b + b + b => ...}: Unavoidable nondeterminism: reaction"+
+        s" {a(<$hashA...>) + a(<$hashB...>) + a(<$hashC...>) + b(1) + b(1) + b(2) + b(_) => }" +
+        s" is shadowed by {a(<$hashD...>) + a(_) + a(.) + b(1) + b(1) + b(_) => }"
+    val expected211 = expectsFromHash("45EA", "465D", "4BE5", "465D")  // note 4th arg is 2nd
+    val expected212 = expectsFromHash("4AEA", "A89F", "B07E", "4AEA") // note 4th arg is first
+
+    Set(expected211, expected212) should contain oneElementOf List(thrown.getMessage)
   }
 
   it should "detect shadowing of reactions with several wildcards" in {
@@ -165,7 +187,14 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
         go { case a(Some(1)) + b(2) + a(Some(2)) + a(Some(3)) + b(1) + b(_) + b(1) + a(x) => }
       )
     }
-    thrown.getMessage shouldEqual "In Site{a + a + a + a + b + b + b + b => ...; a + a + a + a + b => ...}: Unavoidable nondeterminism: reaction {a(<45EA...>) + a(<465D...>) + a(<4BE5...>) + a(.) + b(1) + b(1) + b(2) + b(_) => } is shadowed by {a(<465D...>) + a(_) + a(_) + a(.) + b(1) => }"
+    def expectsFromHash(hashA: String, hashB: String, hashC: String, hashD: String) =
+      s"In Site{a + a + a + a + b + b + b + b => ...; a + a + a + a + b => ...}: Unavoidable nondeterminism: reaction"+
+        s" {a(<$hashA...>) + a(<$hashB...>) + a(<$hashC...>) + a(.) + b(1) + b(1) + b(2) + b(_) => }" +
+        s" is shadowed by {a(<$hashD...>) + a(_) + a(_) + a(.) + b(1) => }"
+    val expected211 = expectsFromHash("45EA", "465D", "4BE5", "465D")  // note 4th arg is 2nd
+    val expected212 = expectsFromHash("4AEA", "A89F", "B07E", "4AEA") // note 4th arg is first
+
+    Set(expected211, expected212) should contain oneElementOf List(thrown.getMessage)
   }
 
   behavior of "analysis of livelock"

--- a/joinrun/src/test/scala/code/chymyst/test/StaticAnalysisSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/test/StaticAnalysisSpec.scala
@@ -96,13 +96,11 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
       )
     }
 
-    def expectsFromHash(hash: String) =
-      s"In Site{a + b => ...; a => ...}: Unavoidable nondeterminism: reaction {a(<$hash...>) + b(2) => } is " +
-      s"shadowed by {a(<$hash...>) => }"
-    val expected211 = expectsFromHash(hash211)
-    val expected212 = expectsFromHash(hash212)
-
-    Set(expected211, expected212) should contain oneElementOf List(thrown.getMessage)
+    val possibleErrors = Set(hash211, hash212).map(h =>
+      s"In Site{a + b => ...; a => ...}: Unavoidable nondeterminism: reaction {a(<$h...>) + b(2) => } is " +
+        s"shadowed by {a(<$h...>) => }"
+    )
+    possibleErrors should contain oneElementOf List(thrown.getMessage)
   }
 
   it should "fail to detect shadowing of reactions with non-identical non-constant matchers" in {
@@ -124,12 +122,11 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
         go { case a(Some(1)) + b(2) => }
       )
     }
-    def expectsFromHash(hash: String) =
-      s"In Site{a + b => ...; a + b => ...}: Unavoidable nondeterminism: reaction {a(<$hash...>) + b(2) => } is shadowed by {a(<$hash...>) + b(_) => }"
-    val expected211 = expectsFromHash(hash211)
-    val expected212 = expectsFromHash(hash212)
 
-    Set(expected211, expected212) should contain oneElementOf List(thrown.getMessage)
+    val possibleErrors = Set(hash211, hash212).map(h =>
+      s"In Site{a + b => ...; a + b => ...}: Unavoidable nondeterminism: reaction {a(<$h...>) + b(2) => } is shadowed by {a(<$h...>) + b(_) => }"
+    )
+    possibleErrors should contain oneElementOf List(thrown.getMessage)
   }
 
   object IsEven {
@@ -168,14 +165,12 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
         go { case a(Some(1)) + b(2) + a(Some(2)) + a(Some(3)) + b(1) + b(_) + b(1) => }
       )
     }
-    def expectsFromHash(hashA: String, hashB: String, hashC: String, hashD: String) =
-      s"In Site{a + a + a + b + b + b + b => ...; a + a + a + b + b + b => ...}: Unavoidable nondeterminism: reaction"+
-        s" {a(<$hashA...>) + a(<$hashB...>) + a(<$hashC...>) + b(1) + b(1) + b(2) + b(_) => }" +
-        s" is shadowed by {a(<$hashD...>) + a(_) + a(.) + b(1) + b(1) + b(_) => }"
-    val expected211 = expectsFromHash("45EA", "465D", "4BE5", "465D")  // note 4th arg is 2nd
-    val expected212 = expectsFromHash("4AEA", "A89F", "B07E", "4AEA") // note 4th arg is first
 
-    Set(expected211, expected212) should contain oneElementOf List(thrown.getMessage)
+    val possibleErrors = Set(("45EA", "465D", "4BE5", "465D"), ("4AEA", "A89F", "B07E", "4AEA")).map(tup4 =>
+      s"In Site{a + a + a + b + b + b + b => ...; a + a + a + b + b + b => ...}: Unavoidable nondeterminism: reaction"+
+        s" {a(<${tup4._1}...>) + a(<${tup4._2}...>) + a(<${tup4._3}...>) + b(1) + b(1) + b(2) + b(_) => }" +
+        s" is shadowed by {a(<${tup4._4}...>) + a(_) + a(.) + b(1) + b(1) + b(_) => }")
+    possibleErrors should contain oneElementOf List(thrown.getMessage)
   }
 
   it should "detect shadowing of reactions with several wildcards" in {
@@ -187,14 +182,12 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
         go { case a(Some(1)) + b(2) + a(Some(2)) + a(Some(3)) + b(1) + b(_) + b(1) + a(x) => }
       )
     }
-    def expectsFromHash(hashA: String, hashB: String, hashC: String, hashD: String) =
-      s"In Site{a + a + a + a + b + b + b + b => ...; a + a + a + a + b => ...}: Unavoidable nondeterminism: reaction"+
-        s" {a(<$hashA...>) + a(<$hashB...>) + a(<$hashC...>) + a(.) + b(1) + b(1) + b(2) + b(_) => }" +
-        s" is shadowed by {a(<$hashD...>) + a(_) + a(_) + a(.) + b(1) => }"
-    val expected211 = expectsFromHash("45EA", "465D", "4BE5", "465D")  // note 4th arg is 2nd
-    val expected212 = expectsFromHash("4AEA", "A89F", "B07E", "4AEA") // note 4th arg is first
 
-    Set(expected211, expected212) should contain oneElementOf List(thrown.getMessage)
+    val possibleErrors = Set(("45EA", "465D", "4BE5", "465D"), ("4AEA", "A89F", "B07E", "4AEA")).map(tup4 =>
+      s"In Site{a + a + a + a + b + b + b + b => ...; a + a + a + a + b => ...}: Unavoidable nondeterminism: reaction"+
+        s" {a(<${tup4._1}...>) + a(<${tup4._2}...>) + a(<${tup4._3}...>) + a(.) + b(1) + b(1) + b(2) + b(_) => }" +
+        s" is shadowed by {a(<${tup4._4}...>) + a(_) + a(_) + a(.) + b(1) => }")
+    possibleErrors should contain oneElementOf List(thrown.getMessage)
   }
 
   behavior of "analysis of livelock"

--- a/macros/src/test/scala/code/chymyst/jc/MacrosSpec.scala
+++ b/macros/src/test/scala/code/chymyst/jc/MacrosSpec.scala
@@ -378,7 +378,8 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
 
     // Note: Scala 2.11 and Scala 2.12 have different syntax trees for Some(1)?
     val shaScala211 = "9F8D8B42C1DB096EEFC80052E603562ECAD0FA29"
-    Set(shaScala211) should contain oneElementOf List(r.info.sha1)
+    val shaScala212 = "03F87012279F4B6170E04DB7EBE0816CE1F48FFA"
+    Set(shaScala211, shaScala212) should contain oneElementOf List(r.info.sha1)
   }
 
   it should "fail to compile reactions with detectable compile-time errors" in {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 logLevel := Level.Warn
 addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.7")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "1.2.1")


### PR DESCRIPTION
A few tests dependent on specific values of hashing were specific enough on 2.11 that they failed on 2.12. Now these tests were modified so that the expected messages from exceptions can be either a  2.11 message or 2.12 message (no pattern match).

Target jvm1.8 was not working below 2.11.5.

Recommendations
1) get Travis CI to do a sbt + package and if it fails, fail a PR.
2) revisit set of scala compiler versions needed to support for this project, including default such as 2.11.8.