### PR TITLE
Rewrite blocking reply code using semaphores

### DIFF
--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -67,7 +67,8 @@ Arbitrary acyclic dataflow can be implemented only if `Stream[T]` is a monadic f
 Accordingly, most streaming frameworks provide a `flatMap` operation for streams.
 
 A monadic functor is strictly more powerful than an applicative functor, and accordingly the user has more power in implementing the processing pipeline,
-in which the next steps can depend in arbitrary ways on other steps.
+in which the next steps can depend in arbitrary ways on other steps
+and on previous data chunks in the stream.
 However, a monadic computation is difficult to parallelize automatically.
 Therefore, it is the user who now needs to specify which steps of the pipeline should be parallelized, and which should be separated by an asynchronous "boundary" from other steps.
 

--- a/lib/src/main/scala/code/chymyst/jc/Core.scala
+++ b/lib/src/main/scala/code/chymyst/jc/Core.scala
@@ -37,12 +37,12 @@ object Core {
     def shuffle: Seq[T] = scala.util.Random.shuffle(a)
   }
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
-  implicit final class AnyOpsEquals[A](self: A) {
+  implicit final class AnyOpsEquals[@specialized A](self: A) {
     def ===(other: A): Boolean = self == other
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Equals"))
-  implicit final class AnyOpsNotEquals[A](self: A) {
+  implicit final class AnyOpsNotEquals[@specialized A](self: A) {
     def =!=(other: A): Boolean = self != other
   }
 

--- a/lib/src/main/scala/code/chymyst/jc/Molecules.scala
+++ b/lib/src/main/scala/code/chymyst/jc/Molecules.scala
@@ -348,7 +348,7 @@ private[jc] trait AbsReplyValue[T, R] {
 
   private[jc] def isTimedOut = hasTimedOut.get
 
-  private[jc] def noReplyAttemptedYet = numberOfReplies.get == 0
+  private[jc] def noReplyAttemptedYet = numberOfReplies.get === 0
 
   private[jc] def replyWasRepeated = numberOfReplies.get >= 2
 
@@ -388,7 +388,7 @@ private[jc] trait AbsReplyValue[T, R] {
     */
   protected def performReplyAction(x: R): Boolean = {
 
-    val replyWasNotRepeated = numberOfReplies.incrementAndGet == 1
+    val replyWasNotRepeated = numberOfReplies.getAndIncrement() === 0
 
     val status = if (replyWasNotRepeated) {
       // We have not yet tried to reply.

--- a/lib/src/main/scala/code/chymyst/jc/Pool.scala
+++ b/lib/src/main/scala/code/chymyst/jc/Pool.scala
@@ -3,9 +3,6 @@ package code.chymyst.jc
 
 import java.util.concurrent._
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.language.reflectiveCalls
-
 class FixedPool(threads: Int) extends PoolExecutor(threads,
   t => new ThreadPoolExecutor(t, t, 0L, TimeUnit.SECONDS, new LinkedBlockingQueue[Runnable], new ThreadFactoryWithInfo)
 )
@@ -48,7 +45,10 @@ private[jc] class PoolExecutor(threads: Int = 8, execFactory: Int => ExecutorSer
 /** Create a pool from a Handler interface. The pool will submit tasks using a Handler.post() method.
   *
   * This is useful for Android and JavaFX environments. Not yet tested. Behavior with singletons will be probably wrong.
+  *
+  * Note: the structural type for `handler` should not be used. Here it is used only as an illustration.
   */
+/*
 class HandlerPool(handler: { def post(r: Runnable): Unit }) extends Pool {
   override def shutdownNow(): Unit = ()
 
@@ -57,3 +57,4 @@ class HandlerPool(handler: { def post(r: Runnable): Unit }) extends Pool {
 
   override def isInactive: Boolean = false
 }
+*/

--- a/lib/src/main/scala/code/chymyst/jc/Pool.scala
+++ b/lib/src/main/scala/code/chymyst/jc/Pool.scala
@@ -45,16 +45,6 @@ private[jc] class PoolExecutor(threads: Int = 8, execFactory: Int => ExecutorSer
   override def isInactive: Boolean = execService.isShutdown || execService.isTerminated
 }
 
-// Not used now.
-private[jc] class PoolFutureExecutor(threads: Int = 8, execFactory: Int => ExecutorService) extends PoolExecutor(threads, execFactory) {
-  private val execContext = ExecutionContext.fromExecutor(execService)
-
-  override def runClosure(closure: => Unit, info: ReactionInfo): Unit = {
-    Future { closure }(execContext)
-    ()
-  }
-}
-
 /** Create a pool from a Handler interface. The pool will submit tasks using a Handler.post() method.
   *
   * This is useful for Android and JavaFX environments. Not yet tested. Behavior with singletons will be probably wrong.

--- a/lib/src/main/scala/code/chymyst/jc/ReactionSite.scala
+++ b/lib/src/main/scala/code/chymyst/jc/ReactionSite.scala
@@ -438,5 +438,4 @@ private[jc] final class ExceptionEmittingSingleton(message: String) extends Exce
 private[jc] final class ExceptionNoReactionPool(message: String) extends ExceptionInJoinRun(message)
 private[jc] final class ExceptionNoWrapper(message: String) extends ExceptionInJoinRun(message)
 private[jc] final class ExceptionWrongInputs(message: String) extends ExceptionInJoinRun(message)
-private[jc] final class ExceptionEmptyReply(message: String) extends ExceptionInJoinRun(message)
 private[jc] final class ExceptionNoSingleton(message: String) extends ExceptionInJoinRun(message)

--- a/lib/src/main/scala/code/chymyst/jc/ReactionSite.scala
+++ b/lib/src/main/scala/code/chymyst/jc/ReactionSite.scala
@@ -155,7 +155,7 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
     usedInputs.foreach {
       case (_, bm@BlockingMolValue(_, replyValue)) =>
         if (haveErrorsWithBlockingMolecules && bm.reactionSentNoReply) { // Do not send error messages to molecules that already got a reply - this is pointless and may lead to errors.
-          replyValue.result = ErrorNoReply(errorMessage)
+          replyValue.replyStatus = ErrorNoReply(errorMessage)
         }
         if (notFailedWithRetry) replyValue.releaseSemaphore()
 
@@ -287,7 +287,7 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
       moleculesPresent.removeFromBag(bm, blockingMolValue)
       if (logLevel > 0) println(s"Debug: $this removed $bm($blockingMolValue) on thread pool $sitePool, now have molecules [${moleculeBagToString(moleculesPresent)}]")
     }
-    if (hadTimeout) blockingMolValue.replyValue.result = ReplyTimedOut
+    if (hadTimeout) blockingMolValue.replyValue.replyStatus = ReplyTimedOut
 
   }
 
@@ -313,7 +313,7 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
     // We might have timed out, in which case we need to forcibly remove the blocking molecule from the soup.
     removeBlockingMolecule(bm, blockingMolValue, !success)
 
-    val result = replyValueWrapper.result
+    val result = replyValueWrapper.replyStatus
     replyValueWrapper.releaseSemaphoreForReply()
 
     result

--- a/lib/src/test/scala/code/chymyst/jc/BlockingMoleculesSpec.scala
+++ b/lib/src/test/scala/code/chymyst/jc/BlockingMoleculesSpec.scala
@@ -303,7 +303,7 @@ class BlockingMoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests
     val d = new E("d")
     val g = new EB[Int]("g")
     val g2 = new EB[Int]("g2")
-    val tp = new FixedPool(4)
+    val tp = new FixedPool(2)
     site(tp)(
       _go { case d(_) => g() }, // this will be used to emit g() and blocked
       _go { case c(_) + g(_,r) => r(0) }, // this will not start because we have no c()

--- a/lib/src/test/scala/code/chymyst/jc/BlockingMoleculesSpec.scala
+++ b/lib/src/test/scala/code/chymyst/jc/BlockingMoleculesSpec.scala
@@ -148,6 +148,8 @@ class BlockingMoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests
 
   it should "get all errors when a reaction attempts to reply twice to more than one molecule" in {
 
+    val iterations = 100
+
     def check(i: Int) = {
       val c = new E("c")
       val d = new E("d")
@@ -175,7 +177,42 @@ class BlockingMoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests
       tp1.shutdownNow()
     }
 
-    (1 to 100).foreach(check) // Make sure there is no race condition.
+    (1 to iterations).foreach(check) // Make sure there is no race condition.
+  }
+
+  it should "get all errors when a reaction attempts to reply many times to more than one molecule" in {
+
+    val replies = 20
+    val iterations = 100
+
+    def check(i: Int) = {
+      val c = new E("c")
+      val d = new E("d")
+      val d2 = new M[Int]("d2")
+      val e = new EB[Int]("e")
+      val g = new EB[Int]("g")
+      val g2 = new EB[Int]("g2")
+      val h = new EE("h")
+      val tp1 = new FixedPool(4)
+      site(tp1)(
+        _go { case c(_) => h() },
+        _go { case d(_) => d2(g()) },
+        _go { case d2(x) + e(_, r) => r(x) },
+        _go { case g(_, r) + g2(_, r2) + h(_, r3) => (1 to replies).foreach{ _ => r(123); r3() } } // no answer to g2, many answers to g and h
+      )
+      c() + d()
+
+      val thrown = intercept[Exception] {
+        val res = g2()
+        println(s"Iteration $i: got result $res but should not have printed this!")
+      }
+      thrown.getMessage shouldEqual "Error: In Site{c => ...; d => ...; d2 + e/B => ...; g/B + g2/B + h/B => ...}: Reaction {g/B(?) + g2/B(?) + h/B(?) ? => ?} with inputs [g/B(), g2/B(), h/B()] finished without replying to g2/B; Error: In Site{c => ...; d => ...; d2 + e/B => ...; g/B + g2/B + h/B => ...}: Reaction {g/B(?) + g2/B(?) + h/B(?) ? => ?} with inputs [g/B(), g2/B(), h/B()] replied to g/B, h/B more than once"
+
+      e() shouldEqual 123
+      tp1.shutdownNow()
+    }
+
+    (1 to iterations).foreach(check) // Make sure there is no race condition.
   }
 
   it should "throw exception when a reaction does not reply to one blocking molecule" in {


### PR DESCRIPTION
When a reaction consumes a blocking molecule, four things could happen:
1. The blocking call times out before the reaction replies. The `reply()` call will then return `false`. (This functionality is currently broken: it will on an occasion return `true`, due to a rare race condition, as explained below.)
2. The reaction replies to the blocking molecule with a value. This is the normal situation.
3. The reaction replies to the blocking molecule more than once. The first reply is accepted, all subsequent replies are ignored, but the error is noted when the reaction body is finished with its computations.
4. The reaction does not reply at all. This is an error situation, which is noted when the reaction body is finished with its computations.

When errors occur in (3) and (4), these errors can apply to more than one molecule.
In this case, the error message will list all molecules to which (3) or (4) applies.

Suppose there is one or more molecules with errors (e.g. several that were not replied to, and several others that were twice replied to).
It's too late to send any errors to molecules that already got replies because their reactions have been already unblocked and continue executing concurrently.
However, if there are some reactions that are still blocked and waiting for a reply, we send the error message to those reactions.
This message will describe all the errors of (3) or (4) for all molecules to which these apply.

The blocking reply code needed to be rewritten using a cleaner approach with semaphores.

- Eliminate `synchronized` in favor of explicit semaphores.
- Represent the state of the reply process as a 5-value case class: 
  1. waiting for reply
  2. reply received normally, have a reply value of type `R`
  3. reply timed out, emitting reaction gives up
  4. reaction finished without sending a reply: error is reported as `String` (exception is thrown)
  5. reaction sent a reply twice: error will be reported to other molecules to which the reaction failed to reply
- Eliminate the race condition where the reply times out exactly at the moment the replying reaction is about to reply, and the emitting reaction assigns the timeout status only to be overwritten by the reply value.