### PR TITLE
Feature/fix cross guards

### DIFF
--- a/macros/src/main/scala/code/chymyst/jc/Macros.scala
+++ b/macros/src/main/scala/code/chymyst/jc/Macros.scala
@@ -345,8 +345,14 @@ object Macros {
         case Bind(t@TermName(name), Ident(termNames.WILDCARD)) =>
           val newIdentOpt = replacingIdents.find( _.name.toTermName.decodedName.toString === name )
           newIdentOpt.map { newIdent =>
-            val newIdentType = newIdent.symbol.info.typeSymbol
-            pq"$t : $newIdentType"
+            val newIdentType = newIdent.symbol.info.dealias
+            val typeParams = newIdentType.typeArgs
+            if (typeParams.isEmpty)
+              pq"$t : $newIdentType"
+            else {
+              val typeApplication = tq"$newIdentType[..$typeParams]"
+              pq"$t : $typeApplication"
+            }
           }.getOrElse(tree)
         case _ => super.transform(tree)
       } else tree match {

--- a/macros/src/main/scala/code/chymyst/jc/Macros.scala
+++ b/macros/src/main/scala/code/chymyst/jc/Macros.scala
@@ -314,7 +314,7 @@ object Macros {
       if (guardTree.isEmpty)
         q"{ case $binderTerm => () }" // This should not be untypechecked!! Why?
       else {
-        c.untypecheck(q"{ case $binderTerm if $guardTree => () } : PartialFunction[Any, Unit]")
+        c.untypecheck(q"{ case $binderTerm if $guardTree => () }")
       }
     }
 
@@ -624,6 +624,7 @@ object Macros {
         val partialFunctionTree = q"{ case ..$caseDefs }"
 //        val pfTree = c.parse(showCode(partialFunctionTree))
         val pfTree = c.untypecheck(partialFunctionTree)
+//        println(s"debug: returning pfTree = ${show(pfTree)}")
         (vars.map(identToScalaSymbol), pfTree)
     }
 

--- a/macros/src/test/scala/code/chymyst/jc/GuardsSpec.scala
+++ b/macros/src/test/scala/code/chymyst/jc/GuardsSpec.scala
@@ -151,13 +151,27 @@ class GuardsSpec extends FlatSpec with Matchers {
 
   behavior of "cross-molecule guards"
 
+  it should "handle a cross-molecule guard condition with missing types" in {
+    val a = m[Int]
+
+    val result = go { case a(x) + a(y) if x > y => }
+
+    (result.info.guardPresence match {
+      case GuardPresent(List(List('x, 'y)), None, List((List('x, 'y), guard_x_y))) =>
+        guard_x_y.isDefinedAt(List(0, 0)) shouldEqual false
+        guard_x_y.isDefinedAt(List(1, 0)) shouldEqual true
+        true
+      case _ => false
+    }) shouldEqual true
+
+  }
+
   it should "handle a guard condition with cross dependency that cannot be eliminated by Boolean transformations" in {
     val a = m[Int]
 
     val n = 10
 
-    // TODO: remove `: Int` type annotations
-    val result = go { case a(x) + a(y: Int) if x > n + y => }
+    val result = go { case a(x) + a(y) if x > n + y => }
 
     (result.info.guardPresence match {
       case GuardPresent(List(List('x, 'y)), None, List((List('x, 'y), guard_x_y))) =>
@@ -177,9 +191,8 @@ class GuardsSpec extends FlatSpec with Matchers {
     val k = 5
     val n = 10
 
-    // TODO: remove `: Int` type annotations
     val result = go {
-      case a(p: Int) + a(y: Int) + a(1) + bb((1, z)) + bb((t: Int, Some(qwerty))) + f(_, r) if y > 0 && n == 10 && qwerty == n && t > p && k < n => r()
+      case a(p) + a(y) + a(1) + bb((1, z)) + bb((t, Some(qwerty))) + f(_, r) if y > 0 && n == 10 && qwerty == n && t > p && k < n => r()
     }
     (result.info.guardPresence match {
       case GuardPresent(List(List('y), List('qwerty), List('t, 'p)), Some(staticGuard), List((List('t, 'p), guard_t_p))) =>
@@ -193,16 +206,13 @@ class GuardsSpec extends FlatSpec with Matchers {
     val a = m[Int]
     val bb = m[(Int, Option[Int])]
 
-    // TODO: remove `: Int` type annotations
+    // TODO: Remove `: Int` type annotations from compound types.
     val result = go {
-      case a(p: Int) + a(y: Int) + a(1) + bb((1, z)) + bb((t: Int, Some(q: Int))) if p == 3 && ((t == q && y > 0) && q > 0) && (t == p && y == q) =>
+      case a(p) + a(y) + a(1) + bb((1, z)) + bb((t: Int, Some(q: Int))) if p == 3 && ((t == q && y > 0) && q > 0) && (t == p && y == q) =>
     }
-    (result.info.guardPresence match {
+    result.info.guardPresence should matchPattern {
       case GuardPresent(List(List('p), List('t, 'q), List('y), List('q), List('t, 'p), List('y, 'q)), None, List((List('t, 'p), guard_t_p), (List('y, 'q), guard_y_q))) =>
-
-        true
-      case _ => false
-    }) shouldEqual true
+    }
   }
 
 }

--- a/macros/src/test/scala/code/chymyst/jc/GuardsSpec.scala
+++ b/macros/src/test/scala/code/chymyst/jc/GuardsSpec.scala
@@ -141,12 +141,11 @@ class GuardsSpec extends FlatSpec with Matchers {
   it should "correctly handle a guard condition with nontrivial unapply matcher" in {
     val a = m[(Int, Int, Int)]
 
-    // TODO: remove `: Int` type annotations
+    // TODO: remove `: Int` type annotations from compound types.
     val result = go { case a((x: Int, y: Int, z: Int)) if x > y => }
 
     result.info.guardPresence shouldEqual GuardPresent(List(List('x, 'y)), None, List())
     result.info.toString should fullyMatch regex "a\\(<[A-F0-9]{4}\\.\\.\\.>\\) => "
-
   }
 
   behavior of "cross-molecule guards"


### PR DESCRIPTION
Cross guards caused typing errors. Many of these errors are now removed. There are still problems when tuples are used as molecule types, together with guards.