### PR TITLE
code cleanups and refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,31 @@ Here is a dictionary:
 | emitting a blocking molecule | sending a synchronous message | `q()` _// returns Int_ |
 | reaction site | join definition | `site(r1, r2, ...)` |
 
+As another comparison, here is some code in academic Join Calculus, taken from [this tutorial](http://research.microsoft.com/en-us/um/people/fournet/papers/join-tutorial.pdf):
+
+<img alt="def newVar(v0) def put(w) etc." src="docs/academic_join_calculus_2.png" width="400" />
+
+This code creates a shared value container `val` with synchronized single access.
+
+The equivalent `Chymyst` code looks like this:
+
+```scala
+def newVar[T](v0: T): (B[T, Unit], B[Unit, T]) = {
+  val put = b[T, Unit] 
+  val get = b[Unit, T]
+  val _val = m[T] // have to use `_val` since `val` is a Scala keyword
+  
+  site(
+    go { case put(w, ret) + _val(v) => _val(w); ret() },
+    go { case get(_, ret) + _val(v) => _val(v); ret(v) }
+  )
+  _val(v0)
+  
+  (put, get)
+}
+
+```
+
 ## Comparison: chemical machine vs. CSP
 
 CSP (Communicating Sequential Processes) is another approach to declarative concurrency, used today in the Go programming language.

--- a/benchmark/src/test/scala/code/chymyst/benchmark/MultithreadSpec.scala
+++ b/benchmark/src/test/scala/code/chymyst/benchmark/MultithreadSpec.scala
@@ -11,9 +11,9 @@ class MultithreadSpec extends FlatSpec with Matchers {
     def runWork(threads: Int) = {
 
       def performWork(): Unit = {
-        val n = 200
+        val n = 300
         // load the CPU with some work:
-        (1 to n).foreach(i => (1 to i).foreach(j => (1 to j).foreach(k => math.cos(10000.0))))
+        (1 to n).foreach(i => (1 to i).foreach(j => (1 to j).foreach(k => math.cos(1.0))))
       }
 
 
@@ -36,8 +36,8 @@ class MultithreadSpec extends FlatSpec with Matchers {
       tp2.shutdownNow()
     }
 
-    val result8 = timeWithPriming{runWork(8)}
     val result1 = timeWithPriming{runWork(1)}
+    val result8 = timeWithPriming{runWork(8)}
 
     println(s"with 1 thread $result1 ms, with 8 threads $result8 ms")
 

--- a/docs/other_work.md
+++ b/docs/other_work.md
@@ -35,7 +35,7 @@ Do not start by reading academic papers if you are a beginner in Join Calculus -
 
 As another comparison, here is some code in academic Join Calculus, taken from [this tutorial](http://research.microsoft.com/en-us/um/people/fournet/papers/join-tutorial.pdf):
 
-<img alt="def newVar(v0) def put(w) etc." src="academic_join_calculus_2.png" width="200" />
+<img alt="def newVar(v0) def put(w) etc." src="academic_join_calculus_2.png" width="400" />
 
 This code creates a shared value container `val` with synchronized single access.
 

--- a/docs/tables.css
+++ b/docs/tables.css
@@ -50,7 +50,7 @@ ul, ol {
 
 body blockquote {
     padding: 0 1em;
-    color: #bbb;
+    color: #777;
     border-left: 0.25em solid #ddd;
-    margin: 0 40px;
+    margin: 0;
 }

--- a/joinrun/src/main/scala/code/chymyst/jc/package.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/package.scala
@@ -1,7 +1,5 @@
 package code.chymyst
 
-import code.chymyst.jc.Macros._
-
 import scala.language.experimental.macros
 
 package object jc {
@@ -32,7 +30,7 @@ package object jc {
     * @param reactionBody The body of the reaction. This must be a partial function with pattern-matching on molecules.
     * @return A reaction value, to be used later in [[site]].
     */
-  def go(reactionBody: Core.ReactionBody): Reaction = macro buildReactionImpl
+  def go(reactionBody: Core.ReactionBody): Reaction = macro BlackboxMacros.buildReactionImpl
 
   /**
     * Convenience syntax: users can write a(x)+b(y) to emit several molecules at once.
@@ -51,7 +49,7 @@ package object jc {
     * @tparam T Type of the value carried by the molecule.
     * @return A new instance of class [[M]]{{{[T]}}} if {{{T}}} is not {{{Unit}}}, or of class [[E]] if {{{T}}} is {{{Unit}}}.
     */
-  def m[T]: M[T] = macro mImpl[T]
+  def m[T]: M[T] = macro WhiteboxMacros.mImpl[T]
 
   /** Declare a new blocking molecule emitter.
     * The name of the molecule will be automatically assigned (via macro) to the name of the enclosing variable.
@@ -59,9 +57,9 @@ package object jc {
     * @tparam T Type of the value carried by the molecule.
     * @tparam R Type of the reply value.
     * @return A new instance of class [[B]]{{{[T,R]}}} if both {{{T}}} and {{{R}}} are not {{{Unit}}}.
-    *         Otherwise will return a new instance of one of the subclasses: [[EF]]{[R]}, [[FE]]{{{[T]}}, or [[EE]].
+    *         Otherwise will return a new instance of one of the subclasses: [[EB]]{[R]}, [[BE]]{{{[T]}}, or [[EE]].
     */
-  def b[T, R]: B[T,R] = macro bImpl[T, R]
+  def b[T, R]: B[T,R] = macro WhiteboxMacros.bImpl[T, R]
 
   val defaultSitePool: Pool = Core.defaultSitePool
   val defaultReactionPool: Pool = Core.defaultReactionPool

--- a/joinrun/src/test/scala/code/chymyst/test/MoreBlockingSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/test/MoreBlockingSpec.scala
@@ -1,8 +1,5 @@
 package code.chymyst.test
 
-import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
-
 import code.chymyst.jc._
 import org.scalatest.{Args, FlatSpec, Matchers, Status}
 import org.scalatest.concurrent.TimeLimitedTests
@@ -11,7 +8,6 @@ import org.scalatest.time.{Millis, Span}
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
-import scala.util.Random.nextInt
 
 class MoreBlockingSpec extends FlatSpec with Matchers with TimeLimitedTests {
 

--- a/joinrun/src/test/scala/code/chymyst/test/ReactionDelaySpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/test/ReactionDelaySpec.scala
@@ -7,7 +7,6 @@ import code.chymyst.jc._
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.duration._
-import scala.language.postfixOps
 import scala.util.Random.nextInt
 
 class ReactionDelaySpec extends FlatSpec with Matchers {

--- a/joinrun/src/test/scala/code/chymyst/test/ReactionDelaySpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/test/ReactionDelaySpec.scala
@@ -30,6 +30,7 @@ class ReactionDelaySpec extends FlatSpec with Matchers {
     val timeElapsed = timeInit.until(LocalDateTime.now, ChronoUnit.MILLIS)
     val meanReplyDelay = results.sum / safeSize(results.size) / 1000 - 1
     println(s"Sequential test: Mean reply delay is $meanReplyDelay ms out of $trials trials; the test took $timeElapsed ms")
+    tp.shutdownNow()
   }
 
   it should "measure simple statistics on reaction delay in parallel" in {
@@ -63,6 +64,7 @@ class ReactionDelaySpec extends FlatSpec with Matchers {
     val result = all_done()
     val meanReplyDelay = result.sum / safeSize(result.size) / 1000 - 1
     println(s"Parallel test: Mean reply delay is $meanReplyDelay ms out of $trials trials; the test took $timeElapsed ms")
+    tp.shutdownNow()
   }
 
   type Result = (Int, Int, Long, Boolean)

--- a/joinrun/src/test/scala/code/chymyst/test/SingletonMoleculeSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/test/SingletonMoleculeSpec.scala
@@ -47,7 +47,8 @@ class SingletonMoleculeSpec extends FlatSpec with Matchers with TimeLimitedTests
         go { case _ => d("ok") } // singleton
       )
 
-      (1 to 100).foreach { j =>
+      // Warning: the timeouts might fail the test due to timed tests.
+      (1 to 20).foreach { j =>
         d(s"bad $i $j") // this "d" should not be emitted, even though we are immediately after a reaction site,
         // and even if the initial d() emission was done late
         f.timeout(500 millis)() shouldEqual Some("ok")

--- a/lib/src/main/scala/code/chymyst/jc/Core.scala
+++ b/lib/src/main/scala/code/chymyst/jc/Core.scala
@@ -90,7 +90,7 @@ object Core {
     val inputMoleculesUsed = moleculesInThisReaction.inputMolecules.toList
     val inputMoleculeInfo = inputMoleculesUsed.map(m => InputMoleculeInfo(m, UnknownInputPattern, UUID.randomUUID().toString))
     val simpleInfo = ReactionInfo(inputMoleculeInfo, None, GuardPresenceUnknown, UUID.randomUUID().toString)
-    Reaction(simpleInfo, body, retry = false)
+    Reaction(simpleInfo, body, { case _ if false => () }, retry = false)
   }
 
   /**

--- a/lib/src/main/scala/code/chymyst/jc/Core.scala
+++ b/lib/src/main/scala/code/chymyst/jc/Core.scala
@@ -90,7 +90,7 @@ object Core {
     val inputMoleculesUsed = moleculesInThisReaction.inputMolecules.toList
     val inputMoleculeInfo = inputMoleculesUsed.map(m => InputMoleculeInfo(m, UnknownInputPattern, UUID.randomUUID().toString))
     val simpleInfo = ReactionInfo(inputMoleculeInfo, None, GuardPresenceUnknown, UUID.randomUUID().toString)
-    Reaction(simpleInfo, body, { case _ if false => () }, retry = false)
+    Reaction(simpleInfo, body, threadPool = None, retry = false)
   }
 
   /**

--- a/lib/src/main/scala/code/chymyst/jc/Molecules.scala
+++ b/lib/src/main/scala/code/chymyst/jc/Molecules.scala
@@ -20,7 +20,7 @@ private[jc] final case class UnapplyRun(moleculeValues: LinearMoleculeBag) exten
   * @return an unapply operation
   */
 object + {
-  def unapply(attr:Any): Option[(Any, Any)] = Some((attr,attr))
+  def unapply(attr:UnapplyArg): Option[(UnapplyArg, UnapplyArg)] = Some((attr,attr))
 }
 
 /** Abstract container for molecule values. This is a common wrapper for values of blocking and non-blocking molecules.

--- a/lib/src/main/scala/code/chymyst/jc/Reaction.scala
+++ b/lib/src/main/scala/code/chymyst/jc/Reaction.scala
@@ -242,7 +242,7 @@ final case class ReactionInfo(inputs: List[InputMoleculeInfo], outputs: Option[L
   * @param threadPool Thread pool on which this reaction will be scheduled. (By default, the common pool is used.)
   * @param retry      Whether the reaction should be run again when an exception occurs in its body. Default is false.
   */
-final case class Reaction(info: ReactionInfo, body: ReactionBody, leanBody: ReactionBody, threadPool: Option[Pool] = None, retry: Boolean) {
+final case class Reaction(info: ReactionInfo, body: ReactionBody, threadPool: Option[Pool], retry: Boolean) {
 
   /** Convenience method to specify thread pools per reaction.
     *

--- a/lib/src/main/scala/code/chymyst/jc/Reaction.scala
+++ b/lib/src/main/scala/code/chymyst/jc/Reaction.scala
@@ -227,11 +227,11 @@ final case class ReactionInfo(inputs: List[InputMoleculeInfo], outputs: Option[L
 
 /** Represents a reaction body. This class is immutable.
   *
-  * @param body       Partial function of type {{{ UnapplyArg => Unit }}}
+  * @param body       Partial function of type {{{ UnapplyArg => Any }}}
   * @param threadPool Thread pool on which this reaction will be scheduled. (By default, the common pool is used.)
   * @param retry      Whether the reaction should be run again when an exception occurs in its body. Default is false.
   */
-final case class Reaction(info: ReactionInfo, body: ReactionBody, leanBody: PartialFunction[List[Any], Any], threadPool: Option[Pool] = None, retry: Boolean) {
+final case class Reaction(info: ReactionInfo, body: ReactionBody, leanBody: ReactionBody, threadPool: Option[Pool] = None, retry: Boolean) {
 
   /** Convenience method to specify thread pools per reaction.
     *

--- a/lib/src/main/scala/code/chymyst/jc/Reaction.scala
+++ b/lib/src/main/scala/code/chymyst/jc/Reaction.scala
@@ -33,7 +33,7 @@ case object OtherOutputPattern extends OutputPatternType
 /** Indicates whether a reaction has a guard condition.
   *
   */
-sealed trait GuardPresenceType {
+sealed trait GuardPresenceFlag {
   /** Checks whether the reaction has no cross-molecule guard conditions.
     * For example, {{{go { case a(x) + b(y) if x > y => } }}} has a cross-molecule guard condition,
     * whereas {{{go { case a(x) + b(y) if x == 1 && y == 2 => } }}} has no cross-guard conditions because its guard condition
@@ -61,16 +61,16 @@ sealed trait GuardPresenceType {
   * @param crossGuards A list of functions that represent the clauses of the guard that relate values of different molecules. The partial function `Any => Unit` should be called with the arguments representing the tuples of pattern variables from each molecule used by the cross guard.
   *                    In the present example, {{{crossGuards}}} will be {{{List((List('y, 'z), { case List(y, z) if y > z => () }))}}}.
   */
-final case class GuardPresent(vars: List[List[ScalaSymbol]], staticGuard: Option[() => Boolean], crossGuards: List[(List[ScalaSymbol], PartialFunction[List[Any], Unit])]) extends GuardPresenceType
+final case class GuardPresent(vars: List[List[ScalaSymbol]], staticGuard: Option[() => Boolean], crossGuards: List[(List[ScalaSymbol], PartialFunction[List[Any], Unit])]) extends GuardPresenceFlag
 
-case object GuardAbsent extends GuardPresenceType
+case object GuardAbsent extends GuardPresenceFlag
 
-case object AllMatchersAreTrivial extends GuardPresenceType
+case object AllMatchersAreTrivial extends GuardPresenceFlag
 
 /** Indicates that there is no information about the presence of the guard.
   * This happens only with reactions that
   */
-case object GuardPresenceUnknown extends GuardPresenceType
+case object GuardPresenceUnknown extends GuardPresenceFlag
 
 /** Compile-time information about an input molecule pattern in a reaction.
   * This class is immutable.
@@ -188,7 +188,7 @@ final case class OutputMoleculeInfo(molecule: Molecule, flag: OutputPatternType)
 }
 
 // This class is immutable.
-final case class ReactionInfo(inputs: List[InputMoleculeInfo], outputs: Option[List[OutputMoleculeInfo]], guardPresence: GuardPresenceType, sha1: String) {
+final case class ReactionInfo(inputs: List[InputMoleculeInfo], outputs: Option[List[OutputMoleculeInfo]], guardPresence: GuardPresenceFlag, sha1: String) {
 
   // The input pattern sequence is pre-sorted for further use.
   private[jc] val inputsSorted: List[InputMoleculeInfo] = inputs.sortBy { case InputMoleculeInfo(mol, flag, sha) =>

--- a/lib/src/main/scala/code/chymyst/jc/Reaction.scala
+++ b/lib/src/main/scala/code/chymyst/jc/Reaction.scala
@@ -239,20 +239,20 @@ final case class Reaction(info: ReactionInfo, body: ReactionBody, threadPool: Op
     * @param newThreadPool A custom thread pool on which this reaction will be scheduled.
     * @return New reaction value with the thread pool set.
     */
-  def onThreads(newThreadPool: Pool): Reaction = Reaction(info, body, Some(newThreadPool), retry)
+  def onThreads(newThreadPool: Pool): Reaction = copy(threadPool = Some(newThreadPool))
 
   /** Convenience method to specify the "retry" option for a reaction.
     *
     * @return New reaction value with the "retry" flag set.
     */
-  def withRetry: Reaction = Reaction(info, body, threadPool, retry = true)
+  def withRetry: Reaction = copy(retry = true)
 
   /** Convenience method to specify the "no retry" option for a reaction.
     * (This option is the default.)
     *
     * @return New reaction value with the "retry" flag unset.
     */
-  def noRetry: Reaction = Reaction(info, body, threadPool, retry = false)
+  def noRetry: Reaction = copy(retry = false)
 
   // Optimization: this is used often.
   val inputMolecules: Seq[Molecule] = info.inputs.map(_.molecule).sortBy(_.toString)

--- a/lib/src/main/scala/code/chymyst/jc/Reaction.scala
+++ b/lib/src/main/scala/code/chymyst/jc/Reaction.scala
@@ -8,9 +8,9 @@ import scala.{Symbol => ScalaSymbol}
   * {{{a(_)}}} is represented by [[Wildcard]]
   * {{{a(x)}}} is represented by [[SimpleVar]] with value {{{SimpleVar(v = 'x, cond = None)}}}
   * {{{a(x) if x > 0}}} is represented by [[SimpleVar]] with value {{{SimpleVar(v = 'x, cond = Some({ case x if x > 0 => }))}}}
-  * {{{a(1)}}} is represented by [[SimpleConst]] with value {{{SimpleConst(v = 1)}}}
+  * {{{a(Some(1))}}} is represented by [[SimpleConst]] with value {{{SimpleConst(v = Some(1))}}}
   * {{{a( (x, Some((y,z)))) ) if x > y}}} is represented by [[OtherInputPattern]] with value {{{OtherInputPattern(matcher = { case (x, Some((y,z)))) if x > y => }, vars = List('x, 'y, 'z))}}}
-  * [[UnknownInputPattern]] is used for reactions defined with [[_go]], which do not have this compile-time information.
+  * [[UnknownInputPattern]] is used for reactions defined using the non-macro call [[_go]], which does not provide detailed compile-time information about reactions.
   */
 sealed trait InputPatternType
 
@@ -18,6 +18,11 @@ case object Wildcard extends InputPatternType
 
 final case class SimpleVar(v: ScalaSymbol, cond: Option[PartialFunction[Any, Unit]]) extends InputPatternType
 
+/** Represents molecules that have constant pattern matchers, such as {{{a(1)}}}.
+  * Literal values (Int, String, Unit etc.) as well as tuples and {{{Option}}} of constants are also considered constants.
+  *
+  * @param v Value of the constant. This is nominally of type {{{Any}}} but actually is of the molecule value type {{{T}}}.
+  */
 final case class SimpleConst(v: Any) extends InputPatternType
 
 final case class OtherInputPattern(matcher: PartialFunction[Any, Unit], vars: List[ScalaSymbol]) extends InputPatternType
@@ -48,27 +53,33 @@ sealed trait GuardPresenceFlag {
   }
 }
 
-/** Indicates the presence of a guard condition.
+/** Indicates whether guard conditions are required for this reaction to start.
   * The guard is parsed into a flat conjunction of guard clauses, which are then analyzed for cross-dependencies between molecules.
   *
   * For example, consider the reaction {{{go { case a(x) + b(y) + c(z) if x > n && y > 0 && y > z && n > 1 => ...} }}}. Here {{{n}}} is an integer constant defined outside the reaction.
   * The conditions for starting this reaction is that a(x) has value x > n; that b(y) has value y > 0; that c(z) has value such that y > z; and finally that n > 1, independently of any molecule values.
-  * The condition n > 1 is a static guard. The condition x > n pertains only to the molecule a(x) and therefore can be moved out of the guard into the InputMoleculeInfo for that molecule. Similarly, the condition y > 0 can be moved out of the guard.
+  * The condition n > 1 is a static guard. The condition x > n restricts only the molecule a(x) and therefore can be moved out of the guard into the InputMoleculeInfo for that molecule. Similarly, the condition y > 0 can be moved out of the guard.
   * However, the condition y > z relates two different molecule values; it is a cross guard.
   *
   * @param vars        The list of all pattern variables used by the guard condition. Each element of this list is a list of variables used by one guard clause. In the example shown above, this will be {{{List(List('y, 'z))}}} because all other conditions are moved out of the guard.
   * @param staticGuard The conjunction of all the clauses of the guard that are independent of pattern variables. This closure can be called in order to determine whether the reaction should even be considered to start, regardless of the presence of molecules. In this example, the value of {{{staticGuard}}} will be {{{Some(() => n > 1)}}}.
   * @param crossGuards A list of functions that represent the clauses of the guard that relate values of different molecules. The partial function `Any => Unit` should be called with the arguments representing the tuples of pattern variables from each molecule used by the cross guard.
-  *                    In the present example, {{{crossGuards}}} will be {{{List((List('y, 'z), { case List(y, z) if y > z => () }))}}}.
+  *                    In the present example, the value of {{{crossGuards}}} will be {{{List((List('y, 'z), { case List(y: Int, z: Int) if y > z => () }))}}}.
   */
 final case class GuardPresent(vars: List[List[ScalaSymbol]], staticGuard: Option[() => Boolean], crossGuards: List[(List[ScalaSymbol], PartialFunction[List[Any], Unit])]) extends GuardPresenceFlag
 
+/** Indicates that a guard was initially present but has been simplified, or it was absent but some molecules have nontrivial pattern matchers (not a wildcard and not a simple variable).
+  * Nevertheless, no cross-molecule guard conditions need to be checked for this reaction to start.
+  */
 case object GuardAbsent extends GuardPresenceFlag
 
+/** Indicates that a guard was initially absent and, in addition, all molecules have trivial matchers - this reaction can start with any molecule values.
+  *
+  */
 case object AllMatchersAreTrivial extends GuardPresenceFlag
 
 /** Indicates that there is no information about the presence of the guard.
-  * This happens only with reactions that
+  * This happens only with reactions that were defined using the non-macro call [[_go]].
   */
 case object GuardPresenceUnknown extends GuardPresenceFlag
 

--- a/macros/src/main/scala/code/chymyst/jc/Macros.scala
+++ b/macros/src/main/scala/code/chymyst/jc/Macros.scala
@@ -284,6 +284,7 @@ object Macros {
       def normalize(a: Trees#Tree): List[List[Tree]] = convertToCNF(a.asInstanceOf[Tree])
 
       term match {
+        case EmptyTree => List()
         case q"$a && $b" =>
           val aN = normalize(a)
           val bN = normalize(b)
@@ -559,10 +560,11 @@ object Macros {
     }
 
     // If the CNF is empty, the entire guard is identically `true`. We can remove it altogether.
-    val isGuardAbsent = guardCNF.isEmpty || (guard match {
-      case EmptyTree => true;
-      case _ => false
-    })
+    val isGuardAbsent = guardCNF.isEmpty
+//    || (guard match {
+//      case EmptyTree => true;
+//      case _ => false
+//    })
 
     val guardVarsSeq: List[(Tree, List[Ident])] = guardCNF.map {
       guardDisjunctions =>

--- a/macros/src/main/scala/code/chymyst/jc/Macros.scala
+++ b/macros/src/main/scala/code/chymyst/jc/Macros.scala
@@ -199,7 +199,7 @@ object Macros {
         case Block(List(t), r) => t.symbol.owner
       }
     }
-
+/*
     object RemoveReactionGuardTransformer extends Transformer {
       override def transform(tree: Tree): Tree = tree match {
         case CaseDef(aPattern, aGuard, aBody) => CaseDef(aPattern, EmptyTree, aBody)
@@ -232,7 +232,7 @@ object Macros {
 
     def removeReactionGuard(tree: Tree): Tree =
       LocateAndTransformReactionInput.withMap(l => RemoveReactionGuardTransformer.transform(l))(tree)
-
+*/
     /** Obtain the list of `case` expressions in a reaction.
       * There should be only one `case` expression.
       */
@@ -732,7 +732,7 @@ object Macros {
       q"GuardPresent(${guardVarsSeq.map(_._2.map(identToScalaSymbol)).filter(_.nonEmpty)}, $staticGuardTree, $crossGuards)"
 
     // Prepare the "lean" reaction body: omit the guard and omit molecules without pattern variables.
-    val leanReactionBody = removeReactionGuard(reactionBody.tree)
+//    val leanReactionBody = removeReactionGuard(reactionBody.tree)
 
 //    {
 //      val bindersWithVars = patternInWithMergedGuards.flatMap { case (_, flag, replyFlag) =>
@@ -789,19 +789,18 @@ object Macros {
       maybeError("Unconditional livelock: Input molecules", "output molecules, with all trivial matchers for", patternIn.map(_._1.asTerm.name.decodedName), "not be a subset of")
     }
 
-    def removeGuard(tree: Tree): Tree = tree match {
-      case q"{case ..$cases }" =>
-        val newCases = cases.map {
-        case cq"$pat if $guard => $body" => cq"$pat => $body"
-        case _ => tree
-      }
-        q"{case ..$newCases}"
-      case _ => tree
-    }
+//    def removeGuard(tree: Tree): Tree = tree match {
+//      case q"{case ..$cases }" =>
+//        val newCases = cases.map {
+//        case cq"$pat if $guard => $body" => cq"$pat => $body"
+//        case _ => tree
+//      }
+//        q"{case ..$newCases}"
+//      case _ => tree
+//    }
 
     // Prepare the ReactionInfo structure.
-    val dummy = q"{ case _ if false => () }"
-    val result = q"Reaction(ReactionInfo($inputMolecules, Some(List(..$outputMolecules)), $guardPresenceFlag, $reactionSha1), ${removeGuard(reactionBody.tree)}, $dummy, None, false)"
+    val result = q"Reaction(ReactionInfo($inputMolecules, Some(List(..$outputMolecules)), $guardPresenceFlag, $reactionSha1), ${reactionBody.tree}, None, false)"
     //    println(s"debug: ${showCode(result)}")
     //    println(s"debug raw: ${showRaw(result)}")
     //    c.untypecheck(result) // this fails

--- a/macros/src/main/scala/code/chymyst/jc/Macros.scala
+++ b/macros/src/main/scala/code/chymyst/jc/Macros.scala
@@ -723,12 +723,10 @@ object Macros {
         (vars.map(identToScalaSymbol), pfTree)
     }
 
-    // We lift the GuardPresenceType values explicitly through q"" here, so we don't need an implicit Liftable[GuardPresenceType].
+    // We lift the GuardPresenceFlag values explicitly through q"" here, so we don't need an implicit Liftable[GuardPresenceFlag].
     val guardPresenceFlag = if (isGuardAbsent) {
-      if (allInputMatchersAreTrivial)
-        q"AllMatchersAreTrivial"
-      else
-        q"GuardAbsent"
+      if (allInputMatchersAreTrivial) q"AllMatchersAreTrivial"
+      else q"GuardAbsent"
     } else
       q"GuardPresent(${guardVarsSeq.map(_._2.map(identToScalaSymbol)).filter(_.nonEmpty)}, $staticGuardTree, $crossGuards)"
 

--- a/macros/src/main/scala/code/chymyst/jc/Macros.scala
+++ b/macros/src/main/scala/code/chymyst/jc/Macros.scala
@@ -709,7 +709,7 @@ class BlackboxMacros(override val c: blackbox.Context) extends CommonMacros(c) {
         val partialFunctionTree = q"{ case ..$caseDefs }"
         //        val pfTree = c.parse(showCode(partialFunctionTree)) // This works but it's an overkill.
         val pfTree = c.untypecheck(partialFunctionTree)
-        (vars.map(identToScalaSymbol), pfTree)
+        (vars.map(identToScalaSymbol).distinct, pfTree)
     }
 
     // We lift the GuardPresenceFlag values explicitly through q"" here, so we don't need an implicit Liftable[GuardPresenceFlag].
@@ -717,7 +717,7 @@ class BlackboxMacros(override val c: blackbox.Context) extends CommonMacros(c) {
       if (allInputMatchersAreTrivial) q"AllMatchersAreTrivial"
       else q"GuardAbsent"
     } else
-      q"GuardPresent(${guardVarsSeq.map(_._2.map(identToScalaSymbol)).filter(_.nonEmpty)}, $staticGuardTree, $crossGuards)"
+      q"GuardPresent(${guardVarsSeq.map(_._2.map(identToScalaSymbol).distinct).filter(_.nonEmpty)}, $staticGuardTree, $crossGuards)"
 
     val blockingMolecules = patternIn.filter(_._3.nonEmpty)
     // It is an error to have reply molecules that do not match on a simple variable.

--- a/macros/src/main/scala/code/chymyst/jc/Macros.scala
+++ b/macros/src/main/scala/code/chymyst/jc/Macros.scala
@@ -205,17 +205,20 @@ object Macros {
       */
     object ReactionCases extends Traverser {
       private var info: List[CaseDef] = List()
+      private var isFirst: Boolean = true
 
       override def traverse(tree: Tree): Unit =
         tree match {
           // this is matched by the partial function of type ReactionBody
-          case DefDef(_, TermName("applyOrElse"), _, _, _, Match(_, list)) =>
+          case DefDef(_, TermName("applyOrElse"), _, _, _, Match(_, list)) if isFirst =>
             info = list
+            isFirst = false
 
           // this is matched by a closure which is not a partial function. Not used now.
           /*
-          case Function(List(ValDef(_, TermName(_), TypeTree(), EmptyTree)), Match(Ident(TermName(_)), list)) =>
+          case Function(List(ValDef(_, TermName(_), TypeTree(), EmptyTree)), Match(Ident(TermName(_)), list)) if isFirst =>
            info = list
+           isFirst = false
           */
           case _ => super.traverse(tree)
         }
@@ -464,8 +467,8 @@ object Macros {
       override def traverse(tree: Tree): Unit = {
         tree match {
           // avoid traversing nested reactions: check whether this subtree is a Reaction() value
-          case q"code.chymyst.jc.Reaction.apply($_,$_,$_,$_)" => ()
-          case q"Reaction.apply($_,$_,$_,$_)" => ()
+          case q"code.chymyst.jc.Reaction.apply(..$_)" => ()
+          case q"Reaction.apply(..$_)" => ()
 
           // matcher with a single argument: a(x)
           case UnApply(Apply(Select(t@Ident(TermName(_)), TermName("unapply")), List(Ident(TermName("<unapply-selector>")))), List(binder)) if t.tpe <:< typeOf[Molecule] =>

--- a/macros/src/test/scala/code/chymyst/jc/GuardsSpec.scala
+++ b/macros/src/test/scala/code/chymyst/jc/GuardsSpec.scala
@@ -9,16 +9,16 @@ class GuardsSpec extends FlatSpec with Matchers {
 
   it should "correctly recognize a trivial true guard condition" in {
     val a = m[Option[Int]]
-    val bb = m[(Int,Option[Int])]
+    val bb = m[(Int, Option[Int])]
 
-    val result = go { case a(Some(1)) + a(None) + bb( (2, Some(3)) ) if true => a(Some(1)) }
+    val result = go { case a(Some(1)) + a(None) + bb((2, Some(3))) if true => a(Some(1)) }
     result.info.guardPresence shouldEqual GuardAbsent
 
     result.info.inputs should matchPattern {
       case List(
-        InputMoleculeInfo(`a`, SimpleConst(Some(1)), _),
-        InputMoleculeInfo(`a`, SimpleConst(None), _),
-        InputMoleculeInfo(`bb`, SimpleConst((2, Some(3))), _)
+      InputMoleculeInfo(`a`, SimpleConst(Some(1)), _),
+      InputMoleculeInfo(`a`, SimpleConst(None), _),
+      InputMoleculeInfo(`bb`, SimpleConst((2, Some(3))), _)
       ) =>
     }
     result.info.toString shouldEqual "a(None) + a(Some(1)) + bb((2,Some(3))) => a(Some(1))"
@@ -30,7 +30,7 @@ class GuardsSpec extends FlatSpec with Matchers {
 
     val result = go { case a(xOpt) + bb(y) if xOpt.isEmpty && y._2.isEmpty => }
     result.info.guardPresence.effectivelyAbsent shouldEqual true
-    result.info.guardPresence should matchPattern { case GuardPresent(List(List('xOpt), List('y)),None,List()) => }
+    result.info.guardPresence should matchPattern { case GuardPresent(List(List('xOpt), List('y)), None, List()) => }
 
     result.info.inputs should matchPattern {
       case List(
@@ -60,9 +60,9 @@ class GuardsSpec extends FlatSpec with Matchers {
 
   it should "use parameterized types in cross-guard condition" in {
     val a = m[Option[Int]]
-    val bb = m[(Int,Option[String])]
+    val bb = m[(Int, Option[String])]
 
-    val result = go { case a(xOpt) + bb( y ) if xOpt.isEmpty || y._2.isEmpty => }
+    val result = go { case a(xOpt) + bb(y) if xOpt.isEmpty || y._2.isEmpty => }
     result.info.guardPresence.effectivelyAbsent shouldEqual false
     result.info.guardPresence should matchPattern { case GuardPresent(List(List('xOpt, 'y)), None, List((List('xOpt, 'y), _))) => }
 
@@ -154,7 +154,7 @@ class GuardsSpec extends FlatSpec with Matchers {
 
     val reaction = go { case a((x, y, z, t)) if x > y => }
 
-    reaction.info.guardPresence shouldEqual GuardPresent(List(List('x, 'y)),None,List())
+    reaction.info.guardPresence shouldEqual GuardPresent(List(List('x, 'y)), None, List())
 
     (reaction.info.inputs.head.flag match {
       case OtherInputPattern(cond, vars) =>
@@ -300,6 +300,17 @@ class GuardsSpec extends FlatSpec with Matchers {
       case GuardPresent(List(List('p), List('t, 'q), List('y), List('q), List('t, 'p), List('y, 'q)), None, List((List('t, 'p), guard_t_p), (List('y, 'q), guard_y_q))) =>
     }
     result.info.toString shouldEqual "a(1) + a(p if ?) + a(y if ?) + bb(<26CD...>) + bb(<E0BD...>) if(t,p,y,q) => "
+  }
+
+  it should "simplify a guard with an if clause and a negation of one term" in {
+    val a = m[Int]
+
+    val n = 10
+
+    val result = go { case a(x) + a(y) if x > n && (if (y > n) 1 > n else !(x == y)) => }
+
+    result.info.guardPresence should matchPattern { case GuardPresent(List(List('x), List('y), List('y, 'x)), None, List((List('y, 'x), _))) => }
+    result.info.toString shouldEqual "a(x if ?) + a(y if ?) if(y,x) => "
   }
 
 }

--- a/macros/src/test/scala/code/chymyst/jc/GuardsSpec.scala
+++ b/macros/src/test/scala/code/chymyst/jc/GuardsSpec.scala
@@ -267,7 +267,7 @@ class GuardsSpec extends FlatSpec with Matchers {
 
     result.info.toString shouldEqual "a(x) + a(y) if(x,y) => "
   }
-
+/*
   it should "correctly split a guard condition when some clauses contain no pattern variables" in {
     val a = m[Int]
     val bb = m[(Int, Option[Int])]
@@ -278,6 +278,27 @@ class GuardsSpec extends FlatSpec with Matchers {
 
     val result = go {
       case a(p) + a(y) + a(1) + bb((1, z)) + bb((t, Some(qwerty))) + f(_, r) if y > 0 && n == 10 && qwerty == n && t > p && k < n => r()
+    }
+    (result.info.guardPresence match {
+      case GuardPresent(List(List('y), List('qwerty), List('t, 'p)), Some(staticGuard), List((List('t, 'p), guard_t_p))) =>
+        staticGuard() shouldEqual true
+        true
+      case _ => false
+    }) shouldEqual true
+
+    result.info.toString shouldEqual "a(1) + a(y if ?) + a(p) + bb(<26CD...>) + bb(<85B4...>) + f/B(_) if(t,p) => "
+  }
+*/
+  it should "correctly split a simpler guard condition when some clauses contain no pattern variables" in {
+
+    val bb = m[(Int, Option[Int])]
+
+
+    val k = 5
+    val n = 10
+
+    val result = go {
+      case bb((x, Some(2))) + bb((3, Some(4)))   => x
     }
     (result.info.guardPresence match {
       case GuardPresent(List(List('y), List('qwerty), List('t, 'p)), Some(staticGuard), List((List('t, 'p), guard_t_p))) =>

--- a/macros/src/test/scala/code/chymyst/jc/GuardsSpec.scala
+++ b/macros/src/test/scala/code/chymyst/jc/GuardsSpec.scala
@@ -313,4 +313,15 @@ class GuardsSpec extends FlatSpec with Matchers {
     result.info.toString shouldEqual "a(x if ?) + a(y if ?) if(y,x) => "
   }
 
+  it should "simplify a guard with an if clause into no cross guard" in {
+    val a = m[Int]
+
+    val n = 10
+
+    val result = go { case a(x) + a(y) if x > n || (if (!false) 1 > n else x == y) => }
+
+    result.info.guardPresence should matchPattern { case GuardPresent(List(List('x)), None, List()) => }
+    result.info.toString shouldEqual "a(x if ?) + a(y) => "
+  }
+
 }

--- a/macros/src/test/scala/code/chymyst/jc/GuardsSpec.scala
+++ b/macros/src/test/scala/code/chymyst/jc/GuardsSpec.scala
@@ -267,7 +267,7 @@ class GuardsSpec extends FlatSpec with Matchers {
 
     result.info.toString shouldEqual "a(x) + a(y) if(x,y) => "
   }
-/*
+
   it should "correctly split a guard condition when some clauses contain no pattern variables" in {
     val a = m[Int]
     val bb = m[(Int, Option[Int])]
@@ -278,27 +278,6 @@ class GuardsSpec extends FlatSpec with Matchers {
 
     val result = go {
       case a(p) + a(y) + a(1) + bb((1, z)) + bb((t, Some(qwerty))) + f(_, r) if y > 0 && n == 10 && qwerty == n && t > p && k < n => r()
-    }
-    (result.info.guardPresence match {
-      case GuardPresent(List(List('y), List('qwerty), List('t, 'p)), Some(staticGuard), List((List('t, 'p), guard_t_p))) =>
-        staticGuard() shouldEqual true
-        true
-      case _ => false
-    }) shouldEqual true
-
-    result.info.toString shouldEqual "a(1) + a(y if ?) + a(p) + bb(<26CD...>) + bb(<85B4...>) + f/B(_) if(t,p) => "
-  }
-*/
-  it should "correctly split a simpler guard condition when some clauses contain no pattern variables" in {
-
-    val bb = m[(Int, Option[Int])]
-
-
-    val k = 5
-    val n = 10
-
-    val result = go {
-      case bb((x, Some(2))) + bb((3, Some(4)))   => x
     }
     (result.info.guardPresence match {
       case GuardPresent(List(List('y), List('qwerty), List('t, 'p)), Some(staticGuard), List((List('t, 'p), guard_t_p))) =>

--- a/macros/src/test/scala/code/chymyst/jc/MacrosSpec.scala
+++ b/macros/src/test/scala/code/chymyst/jc/MacrosSpec.scala
@@ -422,24 +422,28 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
   }
 
   it should "detect output molecules with constant values" in {
-    val bb = m[Int]
+    val c = m[Int]
+    val bb = m[(Int, Int)]
     val bbb = m[Int]
     val cc = m[Option[Int]]
 
-    val r1 = go { case bbb(x) => bb(x) }
-    val r2 = go { case bbb(_) + bb(_) => bbb(0) }
-    val r3 = go { case bbb(x) + bb(_) + bb(_) => bbb(1) + bb(x) + bbb(2) + cc(None) + cc(Some(1)) }
+    val r1 = go { case bbb(x) => c(x) + bb((1, 2)) + bb((3, x)) }
+    val r2 = go { case bbb(_) + c(_) => bbb(0) }
+    val r3 = go { case bbb(x) + c(_) + c(_) => bbb(1) + c(x) + bbb(2) + cc(None) + cc(Some(1)) }
 
-    r1.info.outputs shouldEqual Some(List(OutputMoleculeInfo(bb, OtherOutputPattern)))
+    r1.info.outputs shouldEqual Some(List(
+      OutputMoleculeInfo(c, OtherOutputPattern),
+      OutputMoleculeInfo(bb, SimpleConstOutput((1, 2))),
+      OutputMoleculeInfo(bb, OtherOutputPattern)
+    ))
     r2.info.outputs shouldEqual Some(List(OutputMoleculeInfo(bbb, SimpleConstOutput(0))))
     r3.info.outputs shouldEqual Some(List(
       OutputMoleculeInfo(bbb, SimpleConstOutput(1)),
-      OutputMoleculeInfo(bb, OtherOutputPattern),
+      OutputMoleculeInfo(c, OtherOutputPattern),
       OutputMoleculeInfo(bbb, SimpleConstOutput(2)),
       OutputMoleculeInfo(cc, SimpleConstOutput(None)),
       OutputMoleculeInfo(cc, SimpleConstOutput(Some(1)))
-    )
-    )
+    ))
   }
 
   it should "compute input pattern variables correctly" in {

--- a/macros/src/test/scala/code/chymyst/jc/MacrosSpec.scala
+++ b/macros/src/test/scala/code/chymyst/jc/MacrosSpec.scala
@@ -72,6 +72,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
   it should "fail to compile a reaction with regrouped inputs" in {
     val a = m[Unit]
     a.isInstanceOf[E] shouldEqual true
+
     "val r = go { case a(_) + (a(_) + a(_)) => }" shouldNot compile
     "val r = go { case (a(_) + a(_)) + a(_) => }" should compile
   }

--- a/macros/src/test/scala/code/chymyst/jc/MacrosSpec.scala
+++ b/macros/src/test/scala/code/chymyst/jc/MacrosSpec.scala
@@ -71,7 +71,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
 
   it should "correctly sort input molecules with compound values" in {
     val bb = m[(Int, Option[Int])]
-    val reaction = go { case bb( (1,Some(2)) ) + bb( (0,None) ) => }
+    val reaction = go { case bb((1, Some(2))) + bb((0, None)) => }
     reaction.info.toString shouldEqual "bb((0,None)) + bb((1,Some(2))) => "
   }
 
@@ -307,6 +307,13 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     site(go { case b(_) + a(List()) + c(_) => })
 
     a.logSoup shouldEqual "Site{a + b + c => ...}\nNo molecules"
+  }
+
+  it should "fail to compile a reaction with regrouped inputs" in {
+    val a = m[Unit]
+    a.isInstanceOf[E] shouldEqual true
+    "val r = go { case (a(_) + a(_)) + a(_) => }" should compile
+    "val r = go { case a(_) + (a(_) + a(_)) => }" shouldNot compile
   }
 
   it should "fail to define a simple reaction with correct inputs with empty option pattern-matching at start of reaction" in {
@@ -588,6 +595,12 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
   it should "find expression trees for matchers" in {
 
     rawTree(Some(1) match { case Some(1) => }) shouldEqual "Match(Apply(TypeApply(Select(Select(Ident(scala), scala.Some), TermName(\"apply\")), List(TypeTree())), List(Literal(Constant(1)))), List(CaseDef(Apply(TypeTree().setOriginal(Select(Ident(scala), scala.Some)), List(Literal(Constant(1)))), EmptyTree, Literal(Constant(())))))"
+  }
+
+  it should "find expression tree for reaction" in {
+    val a = m[Unit]
+    a.isInstanceOf[M[Unit]] shouldEqual true
+    rawTree({ case a(_) + (a(_) + a(_)) => } : ReactionBody) shouldEqual """Typed(Typed(Block(List(ClassDef(Modifiers(FINAL | SYNTHETIC), TypeName("$anonfun"), List(), Template(List(TypeTree(), TypeTree()), noSelfType, List(DefDef(Modifiers(), termNames.CONSTRUCTOR, List(), List(List()), TypeTree(), Block(List(Apply(Select(Super(This(TypeName("$anonfun")), typeNames.EMPTY), termNames.CONSTRUCTOR), List())), Literal(Constant(())))), DefDef(Modifiers(OVERRIDE | FINAL | METHOD), TermName("applyOrElse"), List(TypeDef(Modifiers(DEFERRED | PARAM), TypeName("A1"), List(), TypeTree().setOriginal(TypeBoundsTree(TypeTree(), TypeTree()))), TypeDef(Modifiers(DEFERRED | PARAM), TypeName("B1"), List(), TypeTree().setOriginal(TypeBoundsTree(TypeTree(), TypeTree())))), List(List(ValDef(Modifiers(PARAM | SYNTHETIC | TRIEDCOOKING), TermName("x97"), TypeTree().setOriginal(Ident(TypeName("A1"))), EmptyTree), ValDef(Modifiers(PARAM | SYNTHETIC), TermName("default"), TypeTree().setOriginal(AppliedTypeTree(Select(This(TypeName("scala")), scala.Function1), List(TypeTree().setOriginal(Ident(TypeName("A1"))), TypeTree().setOriginal(Ident(TypeName("B1")))))), EmptyTree))), TypeTree(), Match(Typed(Typed(TypeApply(Select(Ident(TermName("x97")), TermName("asInstanceOf")), List(TypeTree())), TypeTree()), TypeTree().setOriginal(Annotated(Apply(Select(New(Select(Ident(scala), scala.unchecked)), termNames.CONSTRUCTOR), List()), Typed(TypeApply(Select(Ident(TermName("x97")), TermName("asInstanceOf")), List(TypeTree())), TypeTree())))), List(CaseDef(UnApply(Apply(Select(Ident(code.chymyst.jc.$plus), TermName("unapply")), List(Ident(TermName("<unapply-selector>")))), List(UnApply(Apply(Select(Ident(TermName("a")), TermName("unapply")), List(Ident(TermName("<unapply-selector>")))), List(Ident(termNames.WILDCARD))), UnApply(Apply(Select(Ident(code.chymyst.jc.$plus), TermName("unapply")), List(Ident(TermName("<unapply-selector>")))), List(UnApply(Apply(Select(Ident(TermName("a")), TermName("unapply")), List(Ident(TermName("<unapply-selector>")))), List(Ident(termNames.WILDCARD))), UnApply(Apply(Select(Ident(TermName("a")), TermName("unapply")), List(Ident(TermName("<unapply-selector>")))), List(Ident(termNames.WILDCARD))))))), EmptyTree, Literal(Constant(()))), CaseDef(Bind(TermName("defaultCase$"), Ident(termNames.WILDCARD)), EmptyTree, Apply(Select(Ident(TermName("default")), TermName("apply")), List(Ident(TermName("x97")))))))), DefDef(Modifiers(FINAL | METHOD), TermName("isDefinedAt"), List(), List(List(ValDef(Modifiers(PARAM | SYNTHETIC | TRIEDCOOKING), TermName("x97"), TypeTree(), EmptyTree))), TypeTree(), Match(Typed(Typed(TypeApply(Select(Ident(TermName("x97")), TermName("asInstanceOf")), List(TypeTree())), TypeTree()), TypeTree().setOriginal(Annotated(Apply(Select(New(Select(Ident(scala), scala.unchecked)), termNames.CONSTRUCTOR), List()), Typed(TypeApply(Select(Ident(TermName("x97")), TermName("asInstanceOf")), List(TypeTree())), TypeTree())))), List(CaseDef(UnApply(Apply(Select(Ident(code.chymyst.jc.$plus), TermName("unapply")), List(Ident(TermName("<unapply-selector>")))), List(UnApply(Apply(Select(Ident(TermName("a")), TermName("unapply")), List(Ident(TermName("<unapply-selector>")))), List(Ident(termNames.WILDCARD))), UnApply(Apply(Select(Ident(code.chymyst.jc.$plus), TermName("unapply")), List(Ident(TermName("<unapply-selector>")))), List(UnApply(Apply(Select(Ident(TermName("a")), TermName("unapply")), List(Ident(TermName("<unapply-selector>")))), List(Ident(termNames.WILDCARD))), UnApply(Apply(Select(Ident(TermName("a")), TermName("unapply")), List(Ident(TermName("<unapply-selector>")))), List(Ident(termNames.WILDCARD))))))), EmptyTree, Literal(Constant(true))), CaseDef(Bind(TermName("defaultCase$"), Ident(termNames.WILDCARD)), EmptyTree, Literal(Constant(false)))))))))), Apply(Select(New(Ident(TypeName("$anonfun"))), termNames.CONSTRUCTOR), List())), TypeTree()), TypeTree().setOriginal(Select(Ident(code.chymyst.jc.Core), TypeName("ReactionBody"))))"""
   }
 
   it should "find enclosing symbol names with correct scopes" in {

--- a/macros/src/test/scala/code/chymyst/jc/MacrosSpec.scala
+++ b/macros/src/test/scala/code/chymyst/jc/MacrosSpec.scala
@@ -69,6 +69,13 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
 
   behavior of "macros for inspecting a reaction body"
 
+  it should "fail to compile a reaction with regrouped inputs" in {
+    val a = m[Unit]
+    a.isInstanceOf[E] shouldEqual true
+    "val r = go { case a(_) + (a(_) + a(_)) => }" shouldNot compile
+    "val r = go { case (a(_) + a(_)) + a(_) => }" should compile
+  }
+
   it should "correctly sort input molecules with compound values" in {
     val bb = m[(Int, Option[Int])]
     val reaction = go { case bb((1, Some(2))) + bb((0, None)) => }
@@ -307,13 +314,6 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     site(go { case b(_) + a(List()) + c(_) => })
 
     a.logSoup shouldEqual "Site{a + b + c => ...}\nNo molecules"
-  }
-
-  it should "fail to compile a reaction with regrouped inputs" in {
-    val a = m[Unit]
-    a.isInstanceOf[E] shouldEqual true
-    "val r = go { case (a(_) + a(_)) + a(_) => }" should compile
-    "val r = go { case a(_) + (a(_) + a(_)) => }" shouldNot compile
   }
 
   it should "fail to define a simple reaction with correct inputs with empty option pattern-matching at start of reaction" in {

--- a/macros/src/test/scala/code/chymyst/jc/MacrosSpec.scala
+++ b/macros/src/test/scala/code/chymyst/jc/MacrosSpec.scala
@@ -112,7 +112,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
       }
     )
     a(1)
-    f.timeout(500 millis)() shouldEqual Some(2)
+    f.timeout(1000 millis)() shouldEqual Some(2)
   }
 
   it should "inspect reaction body with embedded join and _go" in {
@@ -128,7 +128,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
       }
     )
     a(1)
-    f.timeout(500 millis)() shouldEqual Some(2)
+    f.timeout(1000 millis)() shouldEqual Some(2)
   }
 
   val simpleVarXSha1 = ""


### PR DESCRIPTION
An attempt to remove guards from reaction body was abandoned due to macro issues.
I will have to revisit macros in more depth later. For now, the reaction site can do everything with the static information collected by the macros. The reaction code is not modified by macros in any way; modifying a syntax tree seems to be quite error-prone.

On the positive side:

- Reaction sha1 is now independent of input order and guard condition order
- Reaction inputs are now required to be left-associative, so no `a + (b + c)` reactions.
This opens up possibilities for some pattern-matching optimization.
- Macro code is now less monolithic and refactored using macro bundles.