### PR TITLE
refactor volatile readers to avoid using a value map

### DIFF
--- a/joinrun/src/test/scala/code/chymyst/test/SingletonMoleculeSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/test/SingletonMoleculeSpec.scala
@@ -177,7 +177,7 @@ class SingletonMoleculeSpec extends FlatSpec with Matchers with TimeLimitedTests
     val c = m[Int]
 
     val thrown = intercept[Exception] {
-      c.volatileValue
+      c.volatileValue shouldEqual null.asInstanceOf[Int] // If this passes, we are not detecting the fact that c is not bound.
     }
 
     thrown.getMessage shouldEqual "Molecule c is not bound to any reaction site"
@@ -255,7 +255,7 @@ class SingletonMoleculeSpec extends FlatSpec with Matchers with TimeLimitedTests
         go { case _ => d(i) }
       )
 
-      if (d.hasVolatileValue) 0 else 1
+      if (d.volatileValue > 0) 0 else 1
     }
 
     val result = (1 to 100).map { i =>
@@ -279,7 +279,6 @@ class SingletonMoleculeSpec extends FlatSpec with Matchers with TimeLimitedTests
       go { case _ => d(123) } // singleton
     )
     stabilize_d()
-    d.hasVolatileValue shouldEqual true
     d.volatileValue shouldEqual 123
 
     tp.shutdownNow()

--- a/lib/src/main/scala/code/chymyst/jc/SmartPool.scala
+++ b/lib/src/main/scala/code/chymyst/jc/SmartPool.scala
@@ -22,16 +22,18 @@ class SmartPool(parallelism: Int) extends Pool {
     override def newThread(r: Runnable): Thread = new SmartThread(r, SmartPool.this)
   }
 
+  // Looks like we will die hard at about 2021 threads...
+  val maxPoolSize = 1000 + 2*parallelism
+
   def currentPoolSize: Int = executor.getCorePoolSize
 
   private[jc] def startedBlockingCall() = synchronized {
-    val maxThreads = 1000 + 2*parallelism // Looks like we will die hard at about 2021 threads...
-    val newPoolSize = math.min(currentPoolSize + 1, maxThreads)
+    val newPoolSize = math.min(currentPoolSize + 1, maxPoolSize)
     if (newPoolSize > currentPoolSize) {
       executor.setMaximumPoolSize(newPoolSize)
       executor.setCorePoolSize(newPoolSize)
     } else {
-      println(s"JoinRun warning:In $this: It is dangerous to increase the pool size, which is now $currentPoolSize. Memory is ${Runtime.getRuntime.maxMemory}")
+      println(s"JoinRun warning: In $this: It is dangerous to increase the pool size, which is now $currentPoolSize. Memory is ${Runtime.getRuntime.maxMemory}")
     }
   }
 

--- a/lib/src/test/scala/code/chymyst/jc/PoolSpec.scala
+++ b/lib/src/test/scala/code/chymyst/jc/PoolSpec.scala
@@ -13,7 +13,21 @@ class PoolSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
   val patienceConfig = PatienceConfig(timeout = Span(500, Millis))
 
-  behavior of "thread with info"
+  behavior of "smart pool"
+
+  it should "refuse to increase the thread pool beyond its limit" in {
+    val n = 1065
+    val tp = new SmartPool(2)
+
+    tp.maxPoolSize should be < n
+    tp.currentPoolSize shouldEqual 2
+
+    (1 to tp.maxPoolSize + 2).foreach (_ => tp.startedBlockingCall())
+
+    tp.currentPoolSize shouldEqual tp.maxPoolSize
+
+    tp.shutdownNow()
+  }
 
   behavior of "fixed thread pool"
 


### PR DESCRIPTION
Volatile readers are per-emitter, so it makes no sense to support more than one volatile value per emitter. This will remove the unnecessary value map that the reaction site maintains for singletons.