### PR TITLE
Detect irrefutable patterns

### DIFF
--- a/benchmark/src/test/scala/code/chymyst/benchmark/MergesortSpec.scala
+++ b/benchmark/src/test/scala/code/chymyst/benchmark/MergesortSpec.scala
@@ -14,7 +14,8 @@ class MergesortSpec extends FlatSpec with Matchers {
 
   // this object is not used now
   object amCounter {
-    var c:Int = 0
+    var c: Int = 0
+
     def inc(): Unit = {
       synchronized {
         c += 1
@@ -24,7 +25,7 @@ class MergesortSpec extends FlatSpec with Matchers {
 
   type Coll[T] = IndexedSeq[T]
 
-  def arrayMerge[T : Ordering](arr1: Coll[T], arr2: Coll[T]): Coll[T] = {
+  def arrayMerge[T: Ordering](arr1: Coll[T], arr2: Coll[T]): Coll[T] = {
     val id = amCounter.c
     //      amCounter.inc() // avoid this for now - this is a debugging tool
     val wantToLog = false // (arr1.length > 20000 && arr1.length < 41000)
@@ -32,32 +33,33 @@ class MergesortSpec extends FlatSpec with Matchers {
 
     val result = new mutable.ArraySeq[T](arr1.length + arr2.length) // just to allocate space
 
-    def isLess(x: T, y: T) = implicitly[Ordering[T]].compare(x,y) < 0
+    def isLess(x: T, y: T) = implicitly[Ordering[T]].compare(x, y) < 0
 
     // will now modify result
     @tailrec
-    def mergeRec(i1 : Int, i2: Int, i: Int): Unit = {
+    def mergeRec(i1: Int, i2: Int, i: Int): Unit = {
       if (i1 == arr1.length && i2 == arr2.length) ()
       else {
         val (x, newI1, newI2) = if (i1 < arr1.length && (i2 == arr2.length || isLess(arr1(i1), arr2(i2))))
-          (arr1(i1), i1+1, i2) else (arr2(i2), i1, i2+1)
+          (arr1(i1), i1 + 1, i2) else (arr2(i2), i1, i2 + 1)
         result(i) = x
-        mergeRec(newI1, newI2, i+1)
+        mergeRec(newI1, newI2, i + 1)
       }
     }
-    mergeRec(0,0,0)
+
+    mergeRec(0, 0, 0)
     if (wantToLog) println(s"${System.currentTimeMillis} finished merging #$id")
     result.toIndexedSeq
   }
 
-  def performMergeSort[T : Ordering](array: Coll[T], threads: Int = 8): Coll[T] = {
+  def performMergeSort[T: Ordering](array: Coll[T], threads: Int = 8): Coll[T] = {
 
     val finalResult = m[Coll[T]]
     val getFinalResult = b[Unit, Coll[T]]
     val reactionPool = new FixedPool(threads)
     val sitePool = new FixedPool(3)
 
-    site(sitePool,sitePool)(
+    site(sitePool, sitePool)(
       go { case finalResult(arr) + getFinalResult(_, r) => r(arr) }
     )
 
@@ -66,22 +68,19 @@ class MergesortSpec extends FlatSpec with Matchers {
     val mergesort = m[(Coll[T], M[Coll[T]])]
 
     site(reactionPool, sitePool)(
-      go {
-        case mergesort((arr, resultToYield)) =>
-          if (arr.length <= 1) resultToYield(arr)
-          else {
-            val (part1, part2) = arr.splitAt(arr.length/2)
-            // "sorted1" and "sorted2" will be the sorted results from the lower level
-            val sorted1 = m[Coll[T]]
-            val sorted2 = m[Coll[T]]
-            site(reactionPool, sitePool)(
-              go { case sorted1(x) + sorted2(y) =>
-                resultToYield(arrayMerge(x,y)) }
-            )
-
-            // emit `mergesort` with the lower-level `sorted` result molecules
-            mergesort((part1, sorted1)) + mergesort((part2, sorted2))
+      go { case mergesort((arr, resultToYield)) if arr.length <= 1 => resultToYield(arr) },
+      go { case mergesort((arr, resultToYield)) if arr.length > 1 =>
+        val (part1, part2) = arr.splitAt(arr.length / 2)
+        // "sorted1" and "sorted2" will be the sorted results from the lower level
+        val sorted1 = m[Coll[T]]
+        val sorted2 = m[Coll[T]]
+        site(reactionPool, sitePool)(
+          go { case sorted1(x) + sorted2(y) =>
+            resultToYield(arrayMerge(x, y))
           }
+        )
+        // emit `mergesort` with the lower-level `sorted` result molecules
+        mergesort((part1, sorted1)) + mergesort((part2, sorted2))
       }
     )
     // sort our array: emit `mergesort` at top level
@@ -94,7 +93,7 @@ class MergesortSpec extends FlatSpec with Matchers {
   }
 
   it should "merge arrays correctly" in {
-    arrayMerge(IndexedSeq(1,2,5), IndexedSeq(3,6)) shouldEqual IndexedSeq(1,2,3,5,6)
+    arrayMerge(IndexedSeq(1, 2, 5), IndexedSeq(3, 6)) shouldEqual IndexedSeq(1, 2, 3, 5, 6)
   }
 
   it should "sort an array using concurrent merge-sort correctly with one thread" in {
@@ -121,15 +120,22 @@ class MergesortSpec extends FlatSpec with Matchers {
 
   it should "sort an array using concurrent merge-sort more quickly with many threads than with one thread" in {
 
-    val count = 20000 // 1000000
+    val count = 20000
+    // 1000000
     val threads = 8 // typical thread utilization at 600%
 
     val arr = Array.fill[Int](count)(scala.util.Random.nextInt(count))
 
-    val result = timeWithPriming{ performMergeSort(arr, threads); () }
+    val result = timeWithPriming {
+      performMergeSort(arr, threads);
+      ()
+    }
     println(s"concurrent merge-sort test with count=$count and $threads threads took $result ms")
 
-    val result1 = timeWithPriming{ performMergeSort(arr, 1); () }
+    val result1 = timeWithPriming {
+      performMergeSort(arr, 1);
+      ()
+    }
     println(s"concurrent merge-sort test with count=$count and 1 threads took $result1 ms")
   }
 

--- a/joinrun/src/main/scala/code/chymyst/jc/Macros.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Macros.scala
@@ -79,12 +79,15 @@ class CommonMacros(val c: blackbox.Context) {
     override def patternSha1(showCode: Tree => String): String = cond.map(c => getSha1String(showCode(c))).getOrElse("")
   }
 
+  /** Represents an error situation.
+    * The reply pseudo-molecule must be bound to a simple variable, but we found another pattern instead.
+    */
   case object WrongReplyVarF extends InputPatternFlag
 
-  // the reply pseudo-molecule must be bound to a simple variable, but we found another pattern
-
-  // the value v represents a value of the [T] type of M[T] or B[T,R]
-  final case class SimpleConstF(v: Tree) extends InputPatternFlag {
+  /** The pattern represents a constant, which can be a literal constant such as "abc" or a compound type such as (2,3) or (Some(2),3,4).
+    * The value v represents a value of the [T] type of M[T] or B[T,R].
+    */
+  final case class ConstantPatternF(v: Tree) extends InputPatternFlag {
     override def patternSha1(showCode: Tree => String): String = getSha1String(showCode(v))
   }
 
@@ -93,21 +96,22 @@ class CommonMacros(val c: blackbox.Context) {
     * In that case, vars = List("z", "x", "y") and matcher = { case z@(x, Some(y)) => (z, x, y) }
     *
     * @param matcher Tree of a partial function of type Any => Any.
+    * @param guard   `None` if the pattern is irrefutable; `Some(guard expression tree)` if the pattern is not irrefutable and potentially requires a guard condition.
     * @param vars    List of pattern variable names in the order of their appearance in the syntax tree.
     */
-  final case class OtherPatternF(matcher: Tree, guard: Tree, vars: List[Ident]) extends InputPatternFlag {
+  final case class OtherInputPatternF(matcher: Tree, guard: Option[Tree], vars: List[Ident]) extends InputPatternFlag {
     override def needTraversing: Boolean = true
 
     override def varNames: List[Ident] = vars
 
-    override def patternSha1(showCode: Tree => String): String = getSha1String(showCode(matcher) + showCode(guard))
+    override def patternSha1(showCode: Tree => String): String = getSha1String(showCode(matcher) + showCode(guard.getOrElse(EmptyTree)))
   }
 
   /** Describes the pattern matcher for output molecules.
     * Possible values:
-    * ConstOutputPatternF(x): a(123)
-    * EmptyOutputPatternF: a()
-    * OtherOutputPatternF: a(x+y) or anything else
+    * ConstOutputPatternF(x): a(123) or a(Some(4)), etc.
+    * EmptyOutputPatternF: a() - this only happens with `Unit` values.
+    * OtherOutputPatternF: a(x), a(x+y), or any other kind of expression.
     */
   sealed trait OutputPatternFlag {
     def needTraversal: Boolean = false
@@ -260,9 +264,9 @@ final class BlackboxMacros(override val c: blackbox.Context) extends ReactionMac
         val mergedFlag = flag match {
           case SimpleVarF(v, binder, _) =>
             mergedGuardOpt.map(guardTree => SimpleVarF(v, binder, Some(guardTree))).getOrElse(flag) // a(x) if x>0 is replaced with a(x : check if x>0). Let's not replace vars in binder in this case?
-          case OtherPatternF(matcher, _, vars) =>
-            mergedGuardOpt.map(guardTree => OtherPatternF(replaceVarsInBinder(matcher), guardTree, vars)).getOrElse(flag) // We can't have a nontrivial guardTree in patternIn, so we replace it here with the new guardTree.
-          case SimpleConstF(Literal(Constant(()))) =>
+          case OtherInputPatternF(matcher, _, vars) =>
+            mergedGuardOpt.map(guardTree => OtherInputPatternF(replaceVarsInBinder(matcher), Some(guardTree), vars)).getOrElse(flag) // We can't have a nontrivial guardTree in patternIn, so we replace it here with the new guardTree.
+          case ConstantPatternF(Literal(Constant(()))) =>
             WildcardF // Replace Unit constant values with wildcards.
           case _ => flag
         }
@@ -289,14 +293,14 @@ final class BlackboxMacros(override val c: blackbox.Context) extends ReactionMac
           // Find all input molecules that have some pattern variables; omit wildcards and constants here.
           case ((_, flag, _), i) => flag match {
             case SimpleVarF(v, binder, _) => Some((flag, i, binder, List(v)))
-            case OtherPatternF(matcher, _, vs) => Some((flag, i, matcher, vs))
+            case OtherInputPatternF(matcher, _, vs) => Some((flag, i, matcher, vs))
             case _ => None
           }
         } // Find all input molecules constrained by the guard (guardTree, vars) that we are iterating with.
           .filter { case (flag, _, _, _) => guardVarsConstrainThisMolecule(vars, flag) }
           .map { case (_, i, binder, _) => (i, binder) }
 
-        // To avoid problems with macros, we nneed to put types on binder variables and remove owners from guard tree symbols.
+        // To avoid problems with macros, we need to put types on binder variables and remove owners from guard tree symbols.
         val bindersWithTypedVars = indicesAndBinders.map { case (_, b) => replaceVarsInBinder(b) }
         val guardWithReplacedVars = replaceVarsInGuardTree(guardTree)
 

--- a/joinrun/src/main/scala/code/chymyst/jc/Macros.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Macros.scala
@@ -276,7 +276,8 @@ final class BlackboxMacros(override val c: blackbox.Context) extends ReactionMac
 
     val allInputMatchersAreTrivial = patternInWithMergedGuardsAndIndex.forall {
       case (_, _, SimpleVarF(_, _, None), _)
-           | (_, _, WildcardF, _) =>
+           | (_, _, WildcardF, _)
+           | (_, _, OtherInputPatternF(_, None, _), _) =>
         true
       case _ => false
     }

--- a/joinrun/src/main/scala/code/chymyst/jc/Reaction.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Reaction.scala
@@ -406,7 +406,7 @@ final case class Reaction(info: ReactionInfo, private[jc] val body: ReactionBody
               }
           }.map(_._1) // Get rid of BagMap and tuple.
         } else {
-          // TODO: only use flatmap separately for the clusters of interdependent molecules
+          // TODO: only use the `flatMap-fold` separately for the clusters of interdependent molecules
           val found: Stream[Map[Int, AbsMolValue[_]]] =
             inputMoleculeInfos.toStream
               .foldLeft[Stream[(Map[Int, AbsMolValue[_]], BagMap)]](Stream((Map(), initRelevantMap))) { (prev, inputInfo) =>
@@ -443,7 +443,11 @@ final case class Reaction(info: ReactionInfo, private[jc] val body: ReactionBody
               case CrossMoleculeGuard(indices, _, cond) =>
                 cond.isDefinedAt(indices.flatMap(i => inputValues.get(i).map(_.getValue)).toList)
             }
-          } else found
+          } else {
+            // Here, we don't have any cross-molecule guards, but we do have some cross-molecule conditionals.
+            // Those are already taken into account by the `flatMap-fold`. So, we don't need to filter the `found` result any further.
+            found
+          }
 
           // Return result if found something. Assign the found molecule values into the `inputs` array.
           filteredAfterCrossGuards.headOption

--- a/joinrun/src/main/scala/code/chymyst/jc/Reaction.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Reaction.scala
@@ -24,14 +24,16 @@ final case class SimpleVar(v: ScalaSymbol, cond: Option[PartialFunction[Any, Uni
 }
 
 /** Represents molecules that have constant pattern matchers, such as `a(1)`.
-  * Constant pattern matchers are either literal values (Int, String, Sembol, etc.) or special values such as None, Nil, (),
+  * Constant pattern matchers are either literal values (Int, String, Symbol, etc.) or special values such as None, Nil, (),
   * as well as `Some`, `Left`, `Right`, `List`, and tuples of constant matchers.
   *
-  * @param v Value of the constant. This is nominally of type `Any` but actually is of the molecule value type `T`.
+  * @param v Value of the constant. This is nominally of type `Any` but actually is of the molecule's value type `T`.
   */
 final case class SimpleConst(v: Any) extends InputPatternType
 
-final case class OtherInputPattern(matcher: PartialFunction[Any, Unit], vars: List[ScalaSymbol], isIrrefutable: Boolean) extends InputPatternType
+final case class OtherInputPattern(matcher: PartialFunction[Any, Unit], vars: List[ScalaSymbol], isIrrefutable: Boolean) extends InputPatternType {
+  override def isTrivial: Boolean = isIrrefutable
+}
 
 sealed trait OutputPatternType
 

--- a/joinrun/src/main/scala/code/chymyst/jc/ReactionMacros.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/ReactionMacros.scala
@@ -492,7 +492,7 @@ class ReactionMacros(override val c: blackbox.Context) extends CommonMacros(c) {
     * @param patternWhat What was incorrect about the molecule usage.
     * @param molecules   List of molecules (or other objects) that were incorrectly used.
     * @param connector   Phrase connector. By default: `"not contain a pattern that"`.
-    * @param method      How to report the error; by default using [[scala.reflect.macros.blackbox.Context.error]].
+    * @param method      How to report the error; by default using [[scala.reflect.macros.FrontEnds.error]].
     * @tparam T Type of molecule or other object.
     */
   def maybeError[T](what: String, patternWhat: String, molecules: Seq[T], connector: String = "not contain a pattern that", method: (c.Position, String) => Unit = c.error): Unit = {

--- a/joinrun/src/main/scala/code/chymyst/jc/ReactionMacros.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/ReactionMacros.scala
@@ -46,6 +46,20 @@ class ReactionMacros(override val c: blackbox.Context) extends CommonMacros(c) {
 
   private val seqExtractorHeads = Set("scala.collection.generic.SeqFactory.unapplySeq")
 
+  /** Detect whether a pattern-matcher expression tree represents an irrefutable pattern.
+    * For example, Some(_) is refutable because it does not match None.
+    * The pattern (_, x, y, (z, _)) is irrefutable.
+    *
+    * @param binderTerm Binder pattern tree.
+    * @return `true` or `false`
+    */
+  def isIrrefutablePattern(binderTerm: Tree): Boolean = binderTerm match {
+    case pq"_" => true
+    case pq"$x @ _" => true
+    case pq"(..$exprs)" if exprs.size >= 2 => exprs.forall(t => isIrrefutablePattern(t.asInstanceOf[Tree]))
+    case _ => false
+  }
+
   /** Detect whether an expression tree represents a constant expression.
     * A constant expression is either a literal constant (Int, String, Symbol, etc.), (), None, Nil, or Some(...), Left(...), Right(...), List(...), and tuples of constant expressions.
     *
@@ -107,32 +121,6 @@ class ReactionMacros(override val c: blackbox.Context) extends CommonMacros(c) {
       case Nil => None
     }
   }
-//      if exprTree.children.headOption.exists(_.children.size >= 2) =>
-//      val extrCode = showCode(exprTree.asInstanceOf[Tree])
-//      val cleanedCode = extrCode.substring(0, 1 + extrCode.indexOf("("))
-//      seqExtractorCodes.get(cleanedCode).flatMap { extractor =>
-//        val childrenOpt: Option[List[Trees#Tree]] = exprTree.children.headOption flatMap { firstChild =>
-          // firstChild.children == List(e,x) now.
-
-
-//          case pq"$e(..$x)"
-//            if seqExtractorHeads.contains(e.symbol.fullName) &&
-//              x.headOption.exists(_.symbol.toString === "value <unapply-selector>") &&
-//              exprTree.children.nonEmpty =>
-//            Some(exprTree.children.drop(1))
-//          case _ => None // not sure what that is!
-
-
-//        val resultTree: Option[Tree] = for {
-//          children <- childrenOpt
-//          trees = for {
-//            child <- children
-//            childConst <- getConstantTree(child).map(_.asInstanceOf[Tree])
-//          } yield childConst.asInstanceOf[Tree]
-//          if trees.size === children.size
-//        } yield q"$extractor(..$trees)"
-//        resultTree
-//      }
 
   def identToScalaSymbol(ident: Ident): ScalaSymbol = ident.name.decodedName.toString.toScalaSymbol
 
@@ -373,10 +361,15 @@ class ReactionMacros(override val c: blackbox.Context) extends CommonMacros(c) {
       case Ident(termNames.WILDCARD) => WildcardF
       case Bind(t@TermName(_), Ident(termNames.WILDCARD)) => SimpleVarF(Ident(t), binderTerm, None)
       case _ => getConstantTree(binderTerm)
-        .map(t => SimpleConstF(t.asInstanceOf[Tree]))
+        .map(t => ConstantPatternF(t.asInstanceOf[Tree]))
         .getOrElse {
+          // If we are here, we do not have a constant pattern. It could be either an irrefutable compound pattern such as (_, x, (a,b,_)), or a general other pattern.
           val vars = PatternVars.from(binderTerm)
-          OtherPatternF(binderTerm, EmptyTree, vars)
+          val guardTreeOpt = if (isIrrefutablePattern(binderTerm))
+            None
+          else
+            Some(EmptyTree)
+          OtherInputPatternF(binderTerm, guardTreeOpt, vars)
         }
     }
 
@@ -465,7 +458,6 @@ class ReactionMacros(override val c: blackbox.Context) extends CommonMacros(c) {
     }
   }
 
-
   def guardVarsConstrainOnlyThisMolecule(guardVarList: List[Ident], moleculeFlag: InputPatternFlag): Boolean =
     guardVarList.forall(v => moleculeFlag.varNames.exists(mv => mv.name === v.name))
 
@@ -475,11 +467,11 @@ class ReactionMacros(override val c: blackbox.Context) extends CommonMacros(c) {
   // This boilerplate is necessary for being able to use PatternType values in quasiquotes.
   implicit val liftableInputPatternFlag: Liftable[InputPatternFlag] = Liftable[InputPatternFlag] {
     case WildcardF => q"_root_.code.chymyst.jc.Wildcard"
-    case SimpleConstF(tree) => q"_root_.code.chymyst.jc.SimpleConst($tree)"
+    case ConstantPatternF(tree) => q"_root_.code.chymyst.jc.SimpleConst($tree)"
     case SimpleVarF(v, binder, cond) =>
       val guardFunction = cond.map(c => matcherFunction(binder, c, List(v)))
       q"_root_.code.chymyst.jc.SimpleVar(${identToScalaSymbol(v)}, $guardFunction)"
-    case OtherPatternF(matcherTree, guardTree, vars) => q"_root_.code.chymyst.jc.OtherInputPattern(${matcherFunction(matcherTree, guardTree, vars)}, ${vars.map(identToScalaSymbol)})"
+    case OtherInputPatternF(matcherTree, guardTreeOpt, vars) => q"_root_.code.chymyst.jc.OtherInputPattern(${matcherFunction(matcherTree, guardTreeOpt.getOrElse(EmptyTree), vars)}, ${vars.map(identToScalaSymbol)}, ${guardTreeOpt.isEmpty})"
     case _ => q"_root_.code.chymyst.jc.Wildcard" // this case will not be encountered here; we are conflating InputPatternFlag and ReplyInputPatternFlag
   }
 

--- a/joinrun/src/main/scala/code/chymyst/jc/ReactionMacros.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/ReactionMacros.scala
@@ -54,9 +54,13 @@ class ReactionMacros(override val c: blackbox.Context) extends CommonMacros(c) {
     * @return `true` or `false`
     */
   def isIrrefutablePattern(binderTerm: Tree): Boolean = binderTerm match {
-    case pq"_" => true
-    case pq"$x @ _" => true
-    case pq"(..$exprs)" if exprs.size >= 2 => exprs.forall(t => isIrrefutablePattern(t.asInstanceOf[Tree]))
+    case Ident(termNames.WILDCARD) =>
+      true
+    case pq"$x @ $y" =>
+      isIrrefutablePattern(y.asInstanceOf[Tree])
+    case pq"(..$exprs)"
+      if exprs.size >= 2 =>
+      exprs.forall(t => isIrrefutablePattern(t.asInstanceOf[Tree]))
     case _ => false
   }
 
@@ -420,7 +424,7 @@ class ReactionMacros(override val c: blackbox.Context) extends CommonMacros(c) {
             }
             inputMolecules.append((t.symbol, flag1, Some(flag2)))
           }
-          // We do not need to traverse binder2 since it's an error (WrongReplyVarF) to have anything other than a SimpleVarF there.
+        // We do not need to traverse binder2 since it's an error (WrongReplyVarF) to have anything other than a SimpleVarF there.
 
         // After traversing the subtree, we append this molecule information.
 

--- a/joinrun/src/test/scala/code/chymyst/jc/GuardsSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/GuardsSpec.scala
@@ -77,8 +77,8 @@ class GuardsSpec extends FlatSpec with Matchers {
 
     result.info.inputs should matchPattern {
       case Array(
-      InputMoleculeInfo(`a`, 0, OtherInputPattern(_, List('x)), _),
-      InputMoleculeInfo(`bb`, 1, OtherInputPattern(_, List('list, 'y)), _)
+      InputMoleculeInfo(`a`, 0, OtherInputPattern(_, List('x), false), _),
+      InputMoleculeInfo(`bb`, 1, OtherInputPattern(_, List('list, 'y), false), _)
       ) =>
     }
     result.info.toString shouldEqual "a(?x) + bb(?list,y) => "
@@ -111,8 +111,8 @@ class GuardsSpec extends FlatSpec with Matchers {
 
     result.info.inputs should matchPattern {
       case Array(
-      InputMoleculeInfo(`a`, 0, OtherInputPattern(_, List('x)), _),
-      InputMoleculeInfo(`bb`, 1, OtherInputPattern(_, List('list, 'y)), _)
+      InputMoleculeInfo(`a`, 0, OtherInputPattern(_, List('x), false), _),
+      InputMoleculeInfo(`bb`, 1, OtherInputPattern(_, List('list, 'y), false), _)
       ) =>
     }
     result.info.toString shouldEqual "a(?x) + bb(?list,y) if(x,list,y) => "
@@ -182,8 +182,9 @@ class GuardsSpec extends FlatSpec with Matchers {
 
     reaction.info.guardPresence should matchPattern { case GuardPresent(Array(Array('x, 'y)), None, Array()) => }
 
+    reaction.info.inputs.head.flag should matchPattern { case OtherInputPattern(_, _, true) => }
     (reaction.info.inputs.head.flag match {
-      case OtherInputPattern(cond, vars) =>
+      case OtherInputPattern(cond, vars, true) =>
         cond.isDefinedAt((1, 2, 0, 0)) shouldEqual false
         cond.isDefinedAt((2, 1, 0, 0)) shouldEqual true
         vars shouldEqual List('x, 'y, 'z, 't)

--- a/joinrun/src/test/scala/code/chymyst/jc/GuardsSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/GuardsSpec.scala
@@ -182,15 +182,25 @@ class GuardsSpec extends FlatSpec with Matchers {
 
     reaction.info.guardPresence should matchPattern { case GuardPresent(Array(Array('x, 'y)), None, Array()) => }
 
-    reaction.info.inputs.head.flag should matchPattern { case OtherInputPattern(_, _, true) => }
+    reaction.info.inputs.head.flag should matchPattern { case OtherInputPattern(_, _, false) => }
     (reaction.info.inputs.head.flag match {
-      case OtherInputPattern(cond, vars, true) =>
+      case OtherInputPattern(cond, vars, false) =>
         cond.isDefinedAt((1, 2, 0, 0)) shouldEqual false
         cond.isDefinedAt((2, 1, 0, 0)) shouldEqual true
         vars shouldEqual List('x, 'y, 'z, 't)
         true
       case _ => false
     }) shouldEqual true
+  }
+
+  it should "compute reaction info with compound irrefutable matcher" in {
+    val a = m[(Int, (Int, Int), Int)]
+
+    val reaction = go { case a(x@(_, (y@_, z), t)) => }
+
+    reaction.info.guardPresence should matchPattern { case AllMatchersAreTrivial => }
+
+    reaction.info.inputs.head.flag should matchPattern { case OtherInputPattern(_, List('x, 'y, 'z, 't), true) => }
   }
 
   it should "recognize a guard condition with captured non-molecule variables" in {

--- a/joinrun/src/test/scala/code/chymyst/jc/GuardsSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/GuardsSpec.scala
@@ -269,6 +269,16 @@ class GuardsSpec extends FlatSpec with Matchers {
     result.info.toString shouldEqual "a(?x,y,z) => "
   }
 
+  it should "compile a guard that references a variable via library functions" in {
+    val done = m[Array[Int]]
+    /* The guard `if arr.nonEmpty` is not compiled correctly: it generates the partial function
+      { case (arr @ _) if scala.Predef.intArrayOps(arr).nonEmpty => () }
+      which gives a type error: `arr` is typed as `Any` instead of `Array[Int]` as required.
+    */
+//    val reaction = go { case done(arr) if arr.nonEmpty => }
+//    reaction.info.inputs.head.flag should matchPattern { case InputMoleculeInfo(`done`, 0, SimpleVar('arr, Some(_)), _) => }
+  }
+
   behavior of "cross-molecule guards"
 
   it should "handle a cross-molecule guard condition with missing types" in {

--- a/joinrun/src/test/scala/code/chymyst/jc/MacroErrorSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/MacroErrorSpec.scala
@@ -109,8 +109,8 @@ class MacroErrorSpec extends FlatSpec with Matchers {
     bb.isInstanceOf[M[Int]] shouldEqual true
     bbb.isInstanceOf[M[Int]] shouldEqual true
 
-    "val r = go { case a((x,y)) => a((1,1)) }" should compile // cannot detect unconditional livelock here
-    "val r = go { case a((_,x)) => a((x,x)) }" should compile // cannot detect unconditional livelock here
+    "val r = go { case a((x,y)) => a((1,1)) }" shouldNot compile
+    "val r = go { case a((_,x)) => a((x,x)) }" shouldNot compile
     "val r = go { case a((1,_)) => a((1,1)) }" should compile // cannot detect unconditional livelock here
     "val r = go { case bb(x) if x > 0 => bb(1) }" should compile // no unconditional livelock due to guard
     "val r = go { case bbb(1) => bbb(2) }" should compile // no unconditional livelock

--- a/joinrun/src/test/scala/code/chymyst/jc/MacroErrorSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/MacroErrorSpec.scala
@@ -14,7 +14,7 @@ class MacroErrorSpec extends FlatSpec with Matchers {
   }
 
   it should "fail to compile a guard that replies" in {
-    val f = b[Unit,Unit]
+    val f = b[Unit, Unit]
     val x = 2
     x shouldEqual 2
     f.isInstanceOf[EE] shouldEqual true
@@ -24,7 +24,9 @@ class MacroErrorSpec extends FlatSpec with Matchers {
 
   it should "fail to compile a reaction that is not defined inline" in {
     val a = m[Unit]
-    val body: ReactionBody = { case _ => a() }
+    val body: ReactionBody = {
+      case _ => a()
+    }
     body.isInstanceOf[ReactionBody] shouldEqual true
 
     "val r = go(body)" shouldNot compile
@@ -60,8 +62,8 @@ class MacroErrorSpec extends FlatSpec with Matchers {
     val c = b[Unit, Unit]
     val e = m[Unit]
 
-    a.isInstanceOf[B[Unit,Unit]] shouldEqual true
-    c.isInstanceOf[B[Unit,Unit]] shouldEqual true
+    a.isInstanceOf[B[Unit, Unit]] shouldEqual true
+    c.isInstanceOf[B[Unit, Unit]] shouldEqual true
     e.isInstanceOf[M[Unit]] shouldEqual true
 
     // Note: these tests will produce several warnings "expects 2 patterns to hold but crushing into 2-tuple to fit single pattern".
@@ -105,7 +107,7 @@ class MacroErrorSpec extends FlatSpec with Matchers {
     val bb = m[Int]
     val bbb = m[Int]
 
-    a.isInstanceOf[M[(Int,Int)]] shouldEqual true
+    a.isInstanceOf[M[(Int, Int)]] shouldEqual true
     bb.isInstanceOf[M[Int]] shouldEqual true
     bbb.isInstanceOf[M[Int]] shouldEqual true
 
@@ -122,6 +124,21 @@ class MacroErrorSpec extends FlatSpec with Matchers {
     "val r = go { case bbb(_) => bbb(0) }" shouldNot compile // unconditional livelock
     "val r = go { case bbb(x) => bbb(x) + bb(x) }" shouldNot compile
     "val r = go { case bbb(x) + bb(y) => bbb(x) + bb(x) + bb(y) }" shouldNot compile
+  }
+
+  it should "inspect a pattern with a compound constant" in {
+    val a = m[(Int, Int)]
+    val c = m[Unit]
+    val reaction = go { case a((1, _)) + c(_) => a((1, 1)) }
+    reaction.info.inputs.head.flag should matchPattern { case OtherInputPattern(_, List(), false) => }
+    (reaction.info.inputs.head.flag match {
+      case OtherInputPattern(matcher, List(), false) =>
+        matcher.isDefinedAt((1,1)) shouldEqual true
+        matcher.isDefinedAt((1,2)) shouldEqual true
+        matcher.isDefinedAt((0,1)) shouldEqual false
+        true
+      case _ => false
+    }) shouldEqual true
   }
 
   it should "inspect a pattern with a crushed tuple" in {

--- a/joinrun/src/test/scala/code/chymyst/jc/MacrosSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/MacrosSpec.scala
@@ -734,6 +734,8 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     y2 should fullyMatch regex "x\\$[0-9]+"
   }
 
+  behavior of "errors while emitting singletons"
+
   it should "refuse to emit singleton from non-reaction thread" in {
     val dIncorrectSingleton = m[Unit]
     val e = m[Unit]

--- a/joinrun/src/test/scala/code/chymyst/jc/MacrosSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/MacrosSpec.scala
@@ -317,9 +317,9 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
       InputMoleculeInfo(`c`, 4, Wildcard, _),
       InputMoleculeInfo(`bb`, 5, SimpleConst((0, None)), _),
       InputMoleculeInfo(`bb`, 6, SimpleConst((1, Some(2))), _),
-      InputMoleculeInfo(`bb`, 7, OtherInputPattern(_, List('z)), _),
-      InputMoleculeInfo(`bb`, 8, OtherInputPattern(_, List()), _),
-      InputMoleculeInfo(`bb`, 9, OtherInputPattern(_, List('t, 'q)), _),
+      InputMoleculeInfo(`bb`, 7, OtherInputPattern(_, List('z), false), _),
+      InputMoleculeInfo(`bb`, 8, OtherInputPattern(_, List(), false), _),
+      InputMoleculeInfo(`bb`, 9, OtherInputPattern(_, List('t, 'q), false), _),
       InputMoleculeInfo(`s`, 10, Wildcard, _)
       ) =>
     }
@@ -551,9 +551,9 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     val result = go { case a(1|2) + c(()) + bb(p@(ytt, 1, None, (s, Some(t)))) => }
     result.info.inputs should matchPattern {
       case Array(
-      InputMoleculeInfo(`a`, 0, OtherInputPattern(_, List()), _),
+      InputMoleculeInfo(`a`, 0, OtherInputPattern(_, List(), false), _),
       InputMoleculeInfo(`c`, 1, Wildcard, _),
-      InputMoleculeInfo(`bb`, 2, OtherInputPattern(_, List('p, 'ytt, 's, 't)), _)
+      InputMoleculeInfo(`bb`, 2, OtherInputPattern(_, List('p, 'ytt, 's, 't), false), _)
       ) =>
     }
     result.info.toString shouldEqual "a(?) + bb(?p,ytt,s,t) + c(_) => "
@@ -573,7 +573,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     pat_bb.molecule shouldEqual bb
 
     (pat_aa.flag match {
-      case OtherInputPattern(matcher, vars) =>
+      case OtherInputPattern(matcher, vars, false) =>
         matcher.isDefinedAt(Some(1)) shouldEqual true
         matcher.isDefinedAt(None) shouldEqual false
         vars shouldEqual List('x)

--- a/joinrun/src/test/scala/code/chymyst/jc/ReactionSiteSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/ReactionSiteSpec.scala
@@ -68,4 +68,20 @@ class ReactionSiteSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     r.info.inputs.head.admitsValue(MolValue((0, Some(0)))) shouldEqual false
     r.info.inputs.head.admitsValue(MolValue((1, None))) shouldEqual false
   }
+
+  it should "run reactions with cross-molecule conditionals but without cross-molecule guards" in {
+    val result = withPool(new FixedPool(2)) { tp =>
+      val a = m[Int]
+      val f = b[Unit, Int]
+      site(
+        go { case a(x) + a(y) + f(_, r) if x > 0 => r(x + y) }
+      )
+      a(1)
+      a(2)
+      f() shouldEqual 3 // If this fails, a message will be printed below.
+    }
+    if (result.isFailure) println(s"Test failed with message: ${result.failed.get.getMessage}")
+    result.isSuccess shouldEqual true
+    result.isFailure shouldEqual false
+  }
 }

--- a/joinrun/src/test/scala/code/chymyst/test/BlockingMoleculesSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/test/BlockingMoleculesSpec.scala
@@ -1,7 +1,6 @@
 package code.chymyst.test
 
 import code.chymyst.jc._
-import Core._
 import org.scalatest.{FlatSpec, Matchers, BeforeAndAfterEach, Args, Status}
 import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.time.{Millis, Span}

--- a/joinrun/src/test/scala/code/chymyst/test/FairnessSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/test/FairnessSpec.scala
@@ -35,20 +35,21 @@ class FairnessSpec extends FlatSpec with Matchers with TimeLimitedTests {
     val tp1 = new FixedPool(1)
 
     site(tp, tp1)(
+      // The guard `if arr.nonEmpty` is needed to prevent the livelock error.
       go { case getC(_, r) + done(arr) => r(arr) },
-      go { case a0(_) + c((n, arr)) => if (n > 0) {
+      go { case a0(_) + c((n, arr)) if arr.nonEmpty => if (n > 0) {
         arr(0) += 1; c((n - 1, arr)) + a0()
       } else done(arr)
       },
-      go { case a1(_) + c((n, arr)) => if (n > 0) {
+      go { case a1(_) + c((n, arr)) if arr.nonEmpty => if (n > 0) {
         arr(1) += 1; c((n - 1, arr)) + a1()
       } else done(arr)
       },
-      go { case a2(_) + c((n, arr)) => if (n > 0) {
+      go { case a2(_) + c((n, arr)) if arr.nonEmpty => if (n > 0) {
         arr(2) += 1; c((n - 1, arr)) + a2()
       } else done(arr)
       },
-      go { case a3(_) + c((n, arr)) => if (n > 0) {
+      go { case a3(_) + c((n, arr)) if arr.nonEmpty => if (n > 0) {
         arr(3) += 1; c((n - 1, arr)) + a3()
       } else done(arr)
       }


### PR DESCRIPTION
Molecule pattern matchers such as `a((x,y))` or `a( (_, x, (_,y), _, z) )` are irrefutable, even though they are not simple variables or wildcards.
If the reaction site knows about this (which is determined by macros at compile time), the scheduler can optimize the choice of values for these molecules.