### PR TITLE
#80 add a test that ensures the absence of the bug

### DIFF
--- a/joinrun/src/test/scala/code/chymyst/jc/MacroErrorSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/MacroErrorSpec.scala
@@ -113,7 +113,7 @@ class MacroErrorSpec extends FlatSpec with Matchers {
 
     "val r = go { case a((x,y)) => a((1,1)) }" shouldNot compile
     "val r = go { case a((_,x)) => a((x,x)) }" shouldNot compile
-    "val r = go { case a((1,_)) => a((1,1)) }" should compile // cannot detect unconditional livelock here
+    "val r = go { case a((1,_)) => a((1,1)) }" should compile // cannot detect unconditional livelock here at compile time, since we can't evaluate the binder yet
     "val r = go { case bb(x) if x > 0 => bb(1) }" should compile // no unconditional livelock due to guard
     "val r = go { case bbb(1) => bbb(2) }" should compile // no unconditional livelock
 

--- a/joinrun/src/test/scala/code/chymyst/test/StaticAnalysisSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/test/StaticAnalysisSpec.scala
@@ -223,6 +223,17 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
     result shouldEqual WarningsAndErrors(List("Possible livelock: reaction {a(?x) => a(?)}"), List(), "Site{a => ...}")
   }
 
+  it should "detect unavoidable livelock in a single reaction due to nontrivial matcher and constant output" in {
+    val thrown = intercept[Exception] {
+      val a = m[(Int, Int)]
+      val result = site(
+        go { case a((_, 1)) => a((1, 1)) }
+      )
+      result shouldEqual WarningsAndErrors(List("Possible livelock: reaction {a(?) => a((1,1))}"), List(), "Site{a => ...}") // If this passes, we confused possible livelock with unavoidable livelock
+    }
+    thrown.getMessage shouldEqual "In Site{a => ...}: Unavoidable livelock: reaction {a(?) => a((1,1))}"
+  }
+
   it should "detect livelock in a single reaction due to constant output values with nontrivial matchers" in {
     val thrown = intercept[Exception] {
       val a = m[Option[Int]]


### PR DESCRIPTION
The bug did not actually exist. This livelock situation is impossible to catch at compile time, and is already properly detected at run time.