### PR TITLE
Implement better syntax support

### DIFF
--- a/benchmark/src/main/scala/code/chymyst/benchmark/Benchmarks7.scala
+++ b/benchmark/src/main/scala/code/chymyst/benchmark/Benchmarks7.scala
@@ -58,7 +58,7 @@ object Benchmarks7 {
     j8.f(initialTime)
   }
 
-  private def make_counters(done: E, counters: Int, init: Int, tp: Pool) = {
+  private def make_counters(done: M, counters: Int, init: Int, tp: Pool) = {
     val c = m[Int]
     val d = m[Unit]
 

--- a/benchmark/src/main/scala/code/chymyst/benchmark/Benchmarks7.scala
+++ b/benchmark/src/main/scala/code/chymyst/benchmark/Benchmarks7.scala
@@ -58,7 +58,7 @@ object Benchmarks7 {
     j8.f(initialTime)
   }
 
-  private def make_counters(done: M, counters: Int, init: Int, tp: Pool) = {
+  private def make_counters(done: M[Unit], counters: Int, init: Int, tp: Pool) = {
     val c = m[Int]
     val d = m[Unit]
 

--- a/benchmark/src/main/scala/code/chymyst/benchmark/Benchmarks9.scala
+++ b/benchmark/src/main/scala/code/chymyst/benchmark/Benchmarks9.scala
@@ -11,7 +11,7 @@ object Benchmarks9 {
 
   val numberOfCounters = 5
 
-  def make_counter_1(done: M[Unit], counters: Int, init: Int, tp: Pool): B = {
+  def make_counter_1(done: M[Unit], counters: Int, init: Int, tp: Pool): B[Unit, Unit] = {
     val c = m[Int]
     val d = b[Unit, Unit]
 
@@ -47,7 +47,7 @@ object Benchmarks9 {
   }
 
 
-  def make_ping_pong_stack(done: M, tp: Pool): B[Int,Int] = {
+  def make_ping_pong_stack(done: M[Unit], tp: Pool): B[Int,Int] = {
     val c = m[Unit]
     val d = b[Int, Int]
     val e = b[Int, Int]

--- a/benchmark/src/main/scala/code/chymyst/benchmark/Benchmarks9.scala
+++ b/benchmark/src/main/scala/code/chymyst/benchmark/Benchmarks9.scala
@@ -11,7 +11,7 @@ object Benchmarks9 {
 
   val numberOfCounters = 5
 
-  def make_counter_1(done: M[Unit], counters: Int, init: Int, tp: Pool): EE = {
+  def make_counter_1(done: M[Unit], counters: Int, init: Int, tp: Pool): B = {
     val c = m[Int]
     val d = b[Unit, Unit]
 
@@ -47,7 +47,7 @@ object Benchmarks9 {
   }
 
 
-  def make_ping_pong_stack(done: E, tp: Pool): B[Int,Int] = {
+  def make_ping_pong_stack(done: M, tp: Pool): B[Int,Int] = {
     val c = m[Unit]
     val d = b[Int, Int]
     val e = b[Int, Int]
@@ -123,7 +123,7 @@ object Benchmarks9 {
     collect(0)
 
     val numberOfFailures = (1 to count*counterMultiplier).map { _ =>
-      if (f.timeout(200.millis)().isEmpty) 1 else 0
+      if (f.timeout()(200.millis).isEmpty) 1 else 0
     }.sum
 
     // In this benchmark, we used to have about 4% numberOfFailures and about 2 numberOfFalseReplies in 100,000

--- a/benchmark/src/test/scala/code/chymyst/benchmark/ReactionDelaySpec.scala
+++ b/benchmark/src/test/scala/code/chymyst/benchmark/ReactionDelaySpec.scala
@@ -129,7 +129,7 @@ class ReactionDelaySpec extends FlatSpec with Matchers {
         val t1 = nextInt(maxTimeout)
         val t2 = nextInt(maxTimeout)
         val timeInit = LocalDateTime.now
-        val res = f.timeout(t1.millis)(t2.toLong).isEmpty
+        val res = f.timeout(t2.toLong)(t1.millis).isEmpty
         val timeElapsed = timeInit.until(LocalDateTime.now, ChronoUnit.MILLIS)
         done((t1, t2, timeElapsed, res))
       },

--- a/chymyst/src/test/scala/code/chymyst/ChymystSpec.scala
+++ b/chymyst/src/test/scala/code/chymyst/ChymystSpec.scala
@@ -26,8 +26,8 @@ class ChymystSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
   it should "emit a molecule from a future computed out of a given future" in {
 
-    val c = new M("c")
-    val f = new B("f")
+    val c = m[Unit]
+    val f = b[Unit, Unit]
 
     val tp = new FixedPool(2)
     site(tp)(
@@ -60,11 +60,11 @@ class ChymystSpec extends FlatSpec with Matchers with TimeLimitedTests {
   it should "not emit a molecule from a future prematurely" in {
     val waiter = new Waiter
 
-    val c = new M("c")
-    val d = new M("d")
-    val e = new M("e")
-    val f = new EB[String]("f")
-    val f2 = new EB[String]("f2")
+    val c = m[Unit]
+    val d = m[Unit]
+    val e = m[Unit]
+    val f = b[Unit, String]
+    val f2 = b[Unit, String]
 
     val tp = new FixedPool(4)
     site(tp)(
@@ -95,7 +95,7 @@ class ChymystSpec extends FlatSpec with Matchers with TimeLimitedTests {
     val waiter = new Waiter
     val tp = new FixedPool(4)
 
-    val b = new M("b")
+    val b = m[Unit]
 
     // "fut" will succeed when "c" is emitted
     val (c, fut) = moleculeFuture[String](tp)

--- a/chymyst/src/test/scala/code/chymyst/ChymystSpec.scala
+++ b/chymyst/src/test/scala/code/chymyst/ChymystSpec.scala
@@ -26,8 +26,8 @@ class ChymystSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
   it should "emit a molecule from a future computed out of a given future" in {
 
-    val c = new E("c")
-    val f = new EE("f")
+    val c = new M("c")
+    val f = new B("f")
 
     val tp = new FixedPool(2)
     site(tp)(
@@ -60,9 +60,9 @@ class ChymystSpec extends FlatSpec with Matchers with TimeLimitedTests {
   it should "not emit a molecule from a future prematurely" in {
     val waiter = new Waiter
 
-    val c = new E("c")
-    val d = new E("d")
-    val e = new E("e")
+    val c = new M("c")
+    val d = new M("d")
+    val e = new M("e")
     val f = new EB[String]("f")
     val f2 = new EB[String]("f2")
 
@@ -95,7 +95,7 @@ class ChymystSpec extends FlatSpec with Matchers with TimeLimitedTests {
     val waiter = new Waiter
     val tp = new FixedPool(4)
 
-    val b = new E("b")
+    val b = new M("b")
 
     // "fut" will succeed when "c" is emitted
     val (c, fut) = moleculeFuture[String](tp)

--- a/docs/chymyst07.md
+++ b/docs/chymyst07.md
@@ -42,7 +42,7 @@ Here is example usage:
 ```scala
 val never = wait_forever() // Declare a new blocking emitter of type B[Unit, Unit].
 
-never.timeout(1 second)() // this will time out in 1 seconds
+never.timeout()(1 second) // this will time out in 1 seconds
 never() // this will never return
 
 ```

--- a/docs/joinrun.md
+++ b/docs/joinrun.md
@@ -98,7 +98,7 @@ import scala.concurrent.duration.DurationInt
 
 val f = b[Int, String]
 
-val result: Option[String] = f.timeout(100 millis)(10)
+val result: Option[String] = f.timeout(10)(100 millis)
 
 ```
 
@@ -124,7 +124,7 @@ val f = b[Int, String]
 
 site ( go { case f(x, r) + a(_) => val status = r.checkTimeout(x); b(status) } )
 
-val result: Option[String] = f.timeout(100 millis)(10)
+val result: Option[String] = f.timeout(10)(100 millis)
 
 ```
 

--- a/joinrun/src/main/scala/code/chymyst/jc/Core.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Core.scala
@@ -13,7 +13,8 @@ import scala.util.{Left, Right}
   */
 sealed trait TypeIsUnit[A] {
   type UnapplyType
-  def get: A
+
+  def getUnit: A
 }
 
 /** Syntax helper for molecules with unit values.
@@ -21,7 +22,8 @@ sealed trait TypeIsUnit[A] {
   */
 object TypeIsUnitValue extends TypeIsUnit[Unit] {
   override type UnapplyType = Boolean
-  override def get: Unit = ()
+
+  override def getUnit: Unit = ()
 }
 
 object Core {
@@ -37,7 +39,7 @@ object Core {
 
   def getSha1(c: Any): String = getSha1String(c.toString)
 
-//  def flatten[T](optionSeq: Option[Seq[T]]): Seq[T] = optionSeq.getOrElse(Seq())
+  //  def flatten[T](optionSeq: Option[Seq[T]]): Seq[T] = optionSeq.getOrElse(Seq())
 
   implicit class SeqWithOption[S](s: Seq[S]) {
     def toOptionSeq: Option[Seq[S]] = if (s.isEmpty) None else Some(s)
@@ -141,7 +143,7 @@ object Core {
 
     /** "flat foldLeft" will perform a `foldLeft` unless the function `op` returns `None` at some point in the sequence.
       *
-      * @param z Initial value of type `R`.
+      * @param z  Initial value of type `R`.
       * @param op Binary operation, returns an `Option[R]`.
       * @tparam R Type of the return value `r` under option.
       * @return Result value `Some(r)`, having folded to the end of the sequence. Will return `None` if `op` returned `None` at any point.

--- a/joinrun/src/main/scala/code/chymyst/jc/Core.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Core.scala
@@ -6,6 +6,24 @@ import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.util.{Left, Right}
 
+
+/** Syntax helper for zero-argument molecule emitters.
+  *
+  * @tparam A Type of the molecule value. If this is `Unit`, we will have an implicit value of type `TypeIsUnit[A]`, which will provide extra functionality.
+  */
+sealed trait TypeIsUnit[A] {
+  type UnapplyType
+  def get: A
+}
+
+/** Syntax helper for molecules with unit values.
+  *
+  */
+object TypeIsUnitValue extends TypeIsUnit[Unit] {
+  override type UnapplyType = Boolean
+  override def get: Unit = ()
+}
+
 object Core {
 
   /** A special value for `ReactionInfo` to signal that we are not running a reaction.

--- a/joinrun/src/main/scala/code/chymyst/jc/Macros.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Macros.scala
@@ -3,7 +3,7 @@ package code.chymyst.jc
 import Core._
 
 import scala.language.experimental.macros
-import scala.reflect.macros.{blackbox, whitebox}
+import scala.reflect.macros.blackbox
 import scala.reflect.NameTransformer.LOCAL_SUFFIX_STRING
 
 class CommonMacros(val c: blackbox.Context) {
@@ -127,40 +127,24 @@ class CommonMacros(val c: blackbox.Context) {
 
 }
 
-final class WhiteboxMacros(override val c: whitebox.Context) extends CommonMacros(c) {
+final class MoleculeMacros(override val c: blackbox.Context) extends CommonMacros(c) {
 
   import c.universe._
 
   def mImpl[T: c.WeakTypeTag]: c.universe.Tree = {
     val moleculeName = getEnclosingName
-
     val moleculeValueType = c.weakTypeOf[T]
-    if (moleculeValueType =:= typeOf[Unit])
-      q"new E($moleculeName)"
-    else
-      q"new M[$moleculeValueType]($moleculeName)"
+    q"new M[$moleculeValueType]($moleculeName)"
   }
 
   // Does providing an explicit return type here as c.Expr[...] helps anything? Looks like it doesn't, so far.
   def bImpl[T: c.WeakTypeTag, R: c.WeakTypeTag]: Tree = {
 
     val moleculeName = getEnclosingName
-
     val moleculeValueType = c.weakTypeOf[T]
     val replyValueType = c.weakTypeOf[R]
 
-    if (replyValueType =:= typeOf[Unit]) {
-      if (moleculeValueType =:= typeOf[Unit])
-        q"new EE($moleculeName)"
-      else
-        q"new BE[$moleculeValueType]($moleculeName)"
-    } else {
-      // reply type is not Unit
-      if (moleculeValueType =:= typeOf[Unit])
-        q"new EB[$replyValueType]($moleculeName)"
-      else
-        q"new B[$moleculeValueType,$replyValueType]($moleculeName)"
-    }
+    q"new B[$moleculeValueType,$replyValueType]($moleculeName)"
   }
 
 }

--- a/joinrun/src/main/scala/code/chymyst/jc/Molecules.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Molecules.scala
@@ -256,6 +256,8 @@ sealed class M[T](val name: String) extends (T => Unit) with NonblockingMolecule
     */
   def apply(v: T): Unit = site.emit[T](this, MolValue(v))
 
+  def apply()(implicit ev: TypeIsUnit[T]): Unit = apply(ev.get)
+
   /** Volatile reader for a molecule.
     * The molecule must be declared as a singleton.
     *
@@ -435,6 +437,8 @@ private[jc] class ReplyValue[T, R] extends (R => Unit) with AbsReplyValue[T, R] 
     */
   def apply(x: R): Unit = performReplyActionWithoutTimeoutCheck(x)
 
+  def apply()(implicit ev: TypeIsUnit[R]): Unit = apply(ev.get)
+
   /** Perform a reply action for a blocking molecule while checking the timeout status.
     * For each blocking molecule consumed by a reaction, exactly one reply action should be performed within the reaction body.
     *
@@ -442,6 +446,8 @@ private[jc] class ReplyValue[T, R] extends (R => Unit) with AbsReplyValue[T, R] 
     * @return True if the reply was successful. False if the blocking molecule timed out, or if a reply action was already performed.
     */
   def checkTimeout(x: R): Boolean = performReplyAction(x)
+
+  def checkTimeout()(implicit ev: TypeIsUnit[R]): Boolean = checkTimeout(ev.get)
 }
 
 /** Blocking molecule class. Instance is mutable until the molecule is bound to a reaction site and until all reactions involving this molecule are declared.
@@ -461,6 +467,8 @@ sealed class B[T, R](val name: String) extends (T => R) with BlockingMolecule[T,
     */
   def apply(v: T): R =
     site.emitAndAwaitReply[T,R](this, v, new ReplyValue[T,R])
+
+  def apply()(implicit ev: TypeIsUnit[T]): R = apply(ev.get)
 
   def unapply(arg: InputMoleculeList): Option[(T, Reply)] = unapplyInternal(arg)
 }

--- a/joinrun/src/main/scala/code/chymyst/jc/Molecules.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Molecules.scala
@@ -317,7 +317,7 @@ private[jc] sealed trait AbsReplyValue[T, R] {
   * @tparam T Type of the value carried by the molecule.
   * @tparam R Type of the value replied to the caller via the "reply" action.
   */
-private[jc] class ReplyValue[T, R] extends (R => Unit) with AbsReplyValue[T, R] {
+private[jc] final class ReplyValue[T, R] extends (R => Unit) with AbsReplyValue[T, R] {
 
   /** Perform a reply action for a blocking molecule without checking the timeout status (this is slightly faster).
     * For each blocking molecule consumed by a reaction, exactly one reply action should be performed within the reaction body.
@@ -346,7 +346,7 @@ private[jc] class ReplyValue[T, R] extends (R => Unit) with AbsReplyValue[T, R] 
   * @tparam T Type of the value carried by the molecule.
   * @tparam R Type of the value replied to the caller via the "reply" action.
   */
-sealed class B[T, R](val name: String) extends (T => R) with Molecule {
+final class B[T, R](val name: String) extends (T => R) with Molecule {
 
   val isBlocking = true
 
@@ -385,7 +385,7 @@ sealed class B[T, R](val name: String) extends (T => R) with Molecule {
 /** Mix this trait into your class to make the has code persistent after the first time it's computed.
   *
   */
-trait PersistentHashCode {
+sealed trait PersistentHashCode {
   private lazy val hashCodeValue: Int = super.hashCode()
 
   override def hashCode(): Int = hashCodeValue

--- a/joinrun/src/main/scala/code/chymyst/jc/ReactionSite.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/ReactionSite.scala
@@ -301,7 +301,7 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
   }
 
   // Remove a blocking molecule if it is present.
-  private def removeBlockingMolecule[T, R](bm: BlockingMolecule[T, R], blockingMolValue: BlockingMolValue[T, R]): Unit = {
+  private def removeBlockingMolecule[T, R](bm: B[T, R], blockingMolValue: BlockingMolValue[T, R]): Unit = {
     moleculesPresent.synchronized {
       moleculesPresent.removeFromBag(bm, blockingMolValue)
       if (logLevel > 0) println(s"Debug: $this removed $bm($blockingMolValue) on thread pool $sitePool, now have molecules [${moleculeBagToString(moleculesPresent)}]")
@@ -318,7 +318,7 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
     * @tparam R Type of the reply value.
     * @return Reply status for the reply action.
     */
-  private def emitAndAwaitReplyInternal[T, R](timeoutOpt: Option[Long], bm: BlockingMolecule[T, R], v: T, replyValueWrapper: AbsReplyValue[T, R]): ReplyStatus = {
+  private def emitAndAwaitReplyInternal[T, R](timeoutOpt: Option[Long], bm: B[T, R], v: T, replyValueWrapper: AbsReplyValue[T, R]): ReplyStatus = {
     val blockingMolValue = BlockingMolValue(v, replyValueWrapper)
     emit(bm, blockingMolValue)
     val timedOut: Boolean = !BlockingIdle {
@@ -335,7 +335,7 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
 
   // Adding a blocking molecule may trigger at most one reaction and must return a value of type R.
   // We must make this a blocking call, so we acquire a semaphore (with or without timeout).
-  private[jc] def emitAndAwaitReply[T, R](bm: BlockingMolecule[T, R], v: T, replyValueWrapper: AbsReplyValue[T, R]): R = {
+  private[jc] def emitAndAwaitReply[T, R](bm: B[T, R], v: T, replyValueWrapper: AbsReplyValue[T, R]): R = {
     // check if we had any errors, and that we have a result value
     emitAndAwaitReplyInternal(timeoutOpt = None, bm, v, replyValueWrapper) match {
       case ErrorNoReply(message) => throw new Exception(message)
@@ -344,7 +344,7 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
   }
 
   // This is a separate method because it has a different return type than [[emitAndAwaitReply]].
-  private[jc] def emitAndAwaitReplyWithTimeout[T, R](timeout: Long, bm: BlockingMolecule[T, R], v: T, replyValueWrapper: AbsReplyValue[T, R]):
+  private[jc] def emitAndAwaitReplyWithTimeout[T, R](timeout: Long, bm: B[T, R], v: T, replyValueWrapper: AbsReplyValue[T, R]):
   Option[R] = {
     // check if we had any errors, and that we have a result value
     emitAndAwaitReplyInternal(timeoutOpt = Some(timeout), bm, v, replyValueWrapper) match {

--- a/joinrun/src/main/scala/code/chymyst/jc/package.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/package.scala
@@ -64,9 +64,9 @@ package object jc {
     * The name of the molecule will be automatically assigned (via macro) to the name of the enclosing variable.
     *
     * @tparam T Type of the value carried by the molecule.
-    * @return A new instance of class [[code.chymyst.jc.M]] if `T` is not `Unit`, or of class [[code.chymyst.jc.E]] if `T` is `Unit`.
+    * @return A new instance of class [[code.chymyst.jc.M]] if `T` is not `Unit`, or of class [[code.chymyst.jc.M]] if `T` is `Unit`.
     */
-  def m[T]: M[T] = macro WhiteboxMacros.mImpl[T]
+  def m[T]: M[T] = macro MoleculeMacros.mImpl[T]
 
   /** Declare a new blocking molecule emitter.
     * The name of the molecule will be automatically assigned (via macro) to the name of the enclosing variable.
@@ -74,9 +74,9 @@ package object jc {
     * @tparam T Type of the value carried by the molecule.
     * @tparam R Type of the reply value.
     * @return A new instance of class [[code.chymyst.jc.B]]`[T,R]` if both `T` and `R` are not `Unit`.
-    *         Otherwise will return a new instance of one of the subclasses: [[code.chymyst.jc.EB]]`[R]`, [[code.chymyst.jc.BE]]`[T]`, or [[code.chymyst.jc.EE]].
+    *         Otherwise will return a new instance of one of the subclasses: [[code.chymyst.jc.EB]]`[R]`, [[code.chymyst.jc.BE]]`[T]`, or [[code.chymyst.jc.B]].
     *                  */
-  def b[T, R]: B[T, R] = macro WhiteboxMacros.bImpl[T, R]
+  def b[T, R]: B[T, R] = macro MoleculeMacros.bImpl[T, R]
 
   val defaultSitePool = new FixedPool(2)
   val defaultReactionPool = new FixedPool(4)

--- a/joinrun/src/main/scala/code/chymyst/jc/package.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/package.scala
@@ -102,4 +102,6 @@ package object jc {
     }
   }
 
+  implicit val typeIsUnit = TypeIsUnitValue
+
 }

--- a/joinrun/src/main/scala/code/chymyst/jc/package.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/package.scala
@@ -102,6 +102,6 @@ package object jc {
     }
   }
 
-  implicit val typeIsUnit = TypeIsUnitValue
+  implicit val typeIsUnit: TypeIsUnit[Unit] = TypeIsUnitValue
 
 }

--- a/joinrun/src/test/scala/code/chymyst/jc/MacroErrorSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/MacroErrorSpec.scala
@@ -17,7 +17,7 @@ class MacroErrorSpec extends FlatSpec with Matchers {
     val f = b[Unit, Unit]
     val x = 2
     x shouldEqual 2
-    f.isInstanceOf[EE] shouldEqual true
+    f.isInstanceOf[B[Unit,Unit]] shouldEqual true
 
     "val r = go { case f(_, r) if r() && x == 2 => }" shouldNot compile
   }
@@ -36,8 +36,8 @@ class MacroErrorSpec extends FlatSpec with Matchers {
     val a = m[Unit]
     val b = m[Unit]
 
-    a.isInstanceOf[E] shouldEqual true
-    b.isInstanceOf[E] shouldEqual true
+    a.isInstanceOf[M[Unit]] shouldEqual true
+    b.isInstanceOf[M[Unit]] shouldEqual true
 
     "val r = go { case a(_) =>; case b(_) => }" shouldNot compile
   }
@@ -47,7 +47,7 @@ class MacroErrorSpec extends FlatSpec with Matchers {
     val qq = m[Unit]
 
     a.isInstanceOf[M[Int]] shouldEqual true
-    qq.isInstanceOf[E] shouldEqual true
+    qq.isInstanceOf[M[Unit]] shouldEqual true
 
     """val result = go {
       case a(x) => qq()

--- a/joinrun/src/test/scala/code/chymyst/jc/MacrosSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/MacrosSpec.scala
@@ -26,9 +26,9 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
   behavior of "reaction site"
 
   it should "track whether molecule emitters are bound" in {
-    val a = new E("a123")
-    val b = new E("b")
-    val c = new E("")
+    val a = new M[Unit]("a123")
+    val b = new M[Unit]("b")
+    val c = new M[Unit]("")
 
     a.toString shouldEqual "a123"
     b.toString shouldEqual "b"
@@ -70,43 +70,39 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     val a = m[Option[(Int, Int, Map[String, Boolean])]] // complicated type
 
     a.isInstanceOf[M[_]] shouldEqual true
-    a.isInstanceOf[E] shouldEqual false
     a.toString shouldEqual "a"
 
     val s = b[Map[(Boolean, Unit), Seq[Int]], Option[List[(Int, Option[Map[Int, String]])]]] // complicated type
 
     s.isInstanceOf[B[_, _]] shouldEqual true
-    s.isInstanceOf[EB[_]] shouldEqual false
-    s.isInstanceOf[BE[_]] shouldEqual false
-    s.isInstanceOf[EE] shouldEqual false
     s.toString shouldEqual "s/B"
   }
 
-  it should "create an emitter of class E for m[Unit]" in {
+  it should "create an emitter of class M[Unit] for m[Unit]" in {
     val a = m[Unit]
-    a.isInstanceOf[E] shouldEqual true
+    a.isInstanceOf[M[Unit]] shouldEqual true
   }
 
-  it should "create an emitter of class BE[Int] for b[Int, Unit]" in {
+  it should "create an emitter of class B[Int, Unit] for b[Int, Unit]" in {
     val a = b[Int, Unit]
-    a.isInstanceOf[BE[Int]] shouldEqual true
+    a.isInstanceOf[B[Int, Unit]] shouldEqual true
   }
 
-  it should "create an emitter of class EB[Int] for b[Unit, Int]" in {
+  it should "create an emitter of class B[Unit, Int] for b[Unit, Int]" in {
     val a = b[Unit, Int]
-    a.isInstanceOf[EB[Int]] shouldEqual true
+    a.isInstanceOf[B[Unit, Int]] shouldEqual true
   }
 
-  it should "create an emitter of class EE for b[Unit, Unit]" in {
+  it should "create an emitter of class B[Unit, Unit] for b[Unit, Unit]" in {
     val a = b[Unit, Unit]
-    a.isInstanceOf[EE] shouldEqual true
+    a.isInstanceOf[B[Unit, Unit]] shouldEqual true
   }
 
   behavior of "macros for inspecting a reaction body"
 
   it should "fail to compile a reaction with regrouped inputs" in {
     val a = m[Unit]
-    a.isInstanceOf[E] shouldEqual true
+    a.isInstanceOf[M[Unit]] shouldEqual true
 
     "val r = go { case a(_) + (a(_) + a(_)) => }" shouldNot compile
     "val r = go { case a(_) + (a(_) + a(_)) + a(_) => }" shouldNot compile
@@ -140,8 +136,8 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
 
     val reaction =
       go { case a(x) =>
-        val q = new M[Int]("q")
-        val s = new E("s")
+        val q = m[Int]
+        val s = m[Unit]
         go { case q(_) + s(_) => }
         q(0)
       }
@@ -162,7 +158,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
       }
     )
     a(1)
-    f.timeout(1000 millis)() shouldEqual Some(2)
+    f.timeout()(1000 millis) shouldEqual Some(2)
   }
 
   it should "inspect reaction body with embedded join and go" in {
@@ -178,7 +174,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
       }
     )
     a(1)
-    f.timeout(1000 millis)() shouldEqual Some(2)
+    f.timeout()(1000 millis) shouldEqual Some(2)
   }
 
   val simpleVarXSha1 = ""
@@ -329,9 +325,9 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
   }
 
   it should "not fail to define a reaction with correct inputs with non-default pattern-matching in the middle of reaction" in {
-    val a = new M[Option[Int]]("a")
-    val b = new E("b")
-    val c = new E("c")
+    val a = m[Option[Int]]
+    val b = m[Unit]
+    val c = m[Unit]
 
     site(tp0)(go { case b(_) + a(Some(x)) + c(_) => })
 
@@ -339,9 +335,9 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
   }
 
   it should "define a reaction with correct inputs with default pattern-matching in the middle of reaction" in {
-    val a = new M[Option[Int]]("a")
-    val b = new E("b")
-    val c = new E("c")
+    val a = m[Option[Int]]
+    val b = m[Unit]
+    val c = m[Unit]
 
     site(tp0)(go { case b(_) + a(None) + c(_) => })
 
@@ -349,9 +345,9 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
   }
 
   it should "define a reaction with correct inputs with non-simple default pattern-matching in the middle of reaction" in {
-    val a = new M[Seq[Int]]("a")
-    val b = new E("b")
-    val c = new E("c")
+    val a = m[Seq[Int]]
+    val b = m[Unit]
+    val c = m[Unit]
 
     site(go { case b(_) + a(List()) + c(_) => })
 
@@ -359,9 +355,9 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
   }
 
   it should "not fail to define a simple reaction with correct inputs with empty option pattern-matching at start of reaction" in {
-    val a = new M[Option[Int]]("a")
-    val b = new E("b")
-    val c = new E("c")
+    val a = m[Option[Int]]
+    val b = m[Unit]
+    val c = m[Unit]
 
     site(tp0)(go { case a(None) + b(_) + c(_) => })
 
@@ -369,9 +365,9 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
   }
 
   it should "define a reaction with correct inputs with empty option pattern-matching at start of reaction" in {
-    val a = new M[Option[Int]]("a")
-    val b = new E("b")
-    val c = new E("c")
+    val a = m[Option[Int]]
+    val b = m[Unit]
+    val c = m[Unit]
 
     site(tp0)(go { case a(None) + b(_) + c(_) => })
 
@@ -379,9 +375,9 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
   }
 
   it should "define a reaction with correct inputs with non-default pattern-matching at start of reaction" in {
-    val a = new M[Option[Int]]("a")
-    val b = new E("b")
-    val c = new E("c")
+    val a = m[Option[Int]]
+    val b = m[Unit]
+    val c = m[Unit]
 
     site(tp0)(go { case a(Some(x)) + b(_) + c(_) => })
 
@@ -398,7 +394,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     waitSome()
     waitSome()
     a.logSoup shouldEqual "Site{a + f/B => ...}\nMolecules: a(Some(1))"
-    f.timeout(2.second)() shouldEqual Some(1)
+    f.timeout()(2.second) shouldEqual Some(1)
     a.logSoup shouldEqual "Site{a + f/B => ...}\nNo molecules"
   }
 
@@ -414,7 +410,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     waitSome()
     waitSome()
     a.logSoup shouldEqual "Site{a + f/B => ...}\nMolecules: a(Some(1))"
-    f.timeout(2.second)() shouldEqual None
+    f.timeout()(2.second) shouldEqual None
     a.logSoup shouldEqual "Site{a + f/B => ...}\nMolecules: a(Some(1))"
   }
 
@@ -430,7 +426,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     waitSome()
     waitSome()
     a.logSoup shouldEqual "Site{a + f/B => ...}\nMolecules: a(Some(10))"
-    f.timeout(2.second)(0) shouldEqual None
+    f.timeout(0)(2.second) shouldEqual None
     a.logSoup shouldEqual "Site{a + f/B => ...}\nMolecules: a(Some(10))"
   }
 
@@ -446,7 +442,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     waitSome()
     waitSome()
     a.logSoup shouldEqual "Site{a + f/B => ...}\nMolecules: a(Some(1))"
-    f.timeout(2.second)(0) shouldEqual Some(1)
+    f.timeout(0)(2.second) shouldEqual Some(1)
     a.logSoup shouldEqual "Site{a + f/B => ...}\nNo molecules"
   }
 
@@ -464,14 +460,14 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     waitSome()
     waitSome()
     a.logSoup shouldEqual "Site{a + c + f/B => ...}\nMolecules: a(Some(1)), c(123)"
-    f.timeout(2.second)(0) shouldEqual Some(124)
+    f.timeout(0)(2.second) shouldEqual Some(124)
     a.logSoup shouldEqual "Site{a + c + f/B => ...}\nNo molecules"
   }
 
   it should "define a reaction with correct inputs with constant non-default pattern-matching at start of reaction" in {
-    val a = new M[Int]("a")
-    val b = new E("b")
-    val c = new E("c")
+    val a = m[Int]
+    val b = m[Unit]
+    val c = m[Unit]
 
     site(tp0)(go { case a(1) + b(_) + c(_) => })
 
@@ -479,9 +475,9 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
   }
 
   it should "define a reaction with correct inputs with constant default option pattern-matching at start of reaction" in {
-    val a = new M[Option[Int]]("a")
-    val b = new E("b")
-    val c = new E("c")
+    val a = m[Option[Int]]
+    val b = m[Unit]
+    val c = m[Unit]
 
     site(tp0)(go { case a(None) + b(_) + c(_) => })
 
@@ -489,10 +485,10 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
   }
 
   it should "determine constant input and output patterns correctly" in {
-    val a = new M[Option[Int]]("a")
-    val b = new M[String]("b")
-    val c = new M[(Int, Int)]("c")
-    val d = new E("d")
+    val a = m[Option[Int]]
+    val b = m[String]
+    val c = m[(Int, Int)]
+    val d = m[Unit]
     val e = m[Either[Option[Int],String]]
 
     val r = go { case a(Some(1)) + b("xyz") + d(()) + c((2, 3)) + e(Left(Some(1))) + e(Right("input")) =>
@@ -753,16 +749,16 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     val thrown = intercept[Exception] {
       r1.body.apply(inputs) shouldEqual 123 // Reaction ran on a non-reaction thread (i.e. on this thread) and attempted to emit the singleton.
     }
-    val expectedMessage = s"In Site{${dIncorrectSingleton.name} + ${e.name} => ...}: Refusing to emit singleton ${dIncorrectSingleton.name}() because this thread does not run a chemical reaction"
+    val expectedMessage = s"In Site{${dIncorrectSingleton.name} + e => ...}: Refusing to emit singleton ${dIncorrectSingleton.name}() because this thread does not run a chemical reaction"
     thrown.getMessage shouldEqual expectedMessage
     waitSome()
-    e.logSoup shouldEqual s"Site{${dIncorrectSingleton.name} + ${e.name} => ...}\nMolecules: ${dIncorrectSingleton.name}()"
+    e.logSoup shouldEqual s"Site{${dIncorrectSingleton.name} + e => ...}\nMolecules: ${dIncorrectSingleton.name}()"
   }
 
   it should "refuse to emit singleton from a reaction that did not consume it when this cannot be determined statically" in {
-    val c = m[Unit]
+    val c = new M[Unit]("c")
     val dIncorrectSingleton = m[Unit]
-    val e = m[E]
+    val e = new M[M[Unit]]("e")
 
     site(tp0)(
       go { case e(s) => s() },
@@ -772,8 +768,8 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
 
     e(dIncorrectSingleton)
     waitSome()
-    e.logSoup shouldEqual s"Site{c + ${dIncorrectSingleton.name} => ...; ${e.name} => ...}\nMolecules: ${dIncorrectSingleton.name}()"
-    globalErrorLog.exists(_.contains(s"In Site{c + ${dIncorrectSingleton.name} => ...; ${e.name} => ...}: Refusing to emit singleton ${dIncorrectSingleton.name}() because this reaction {${e.name}(s) => } does not consume it")) shouldEqual true
+    e.logSoup shouldEqual s"Site{c + ${dIncorrectSingleton.name} => ...; e => ...}\nMolecules: ${dIncorrectSingleton.name}()"
+    globalErrorLog.exists(_.contains(s"In Site{c + ${dIncorrectSingleton.name} => ...; e => ...}: Refusing to emit singleton ${dIncorrectSingleton.name}() because this reaction {e(s) => } does not consume it")) shouldEqual true
   }
 
 }

--- a/joinrun/src/test/scala/code/chymyst/jc/MacrosSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/MacrosSpec.scala
@@ -205,7 +205,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     result.info.sha1 shouldEqual "435CBA662F8A4992849522C11B78BE206E8D29D4"
   }
 
-  val ax_qq_reaction_sha1 = "84BE76228B9549230BCA620A56209B9BD1D0D25F"
+  val ax_qq_reaction_sha1 = "CFE7446374369C443EFB46040D6AC395E56D5A7A"
 
   it should "inspect a two-molecule reaction body" in {
     val a = m[Int]

--- a/joinrun/src/test/scala/code/chymyst/jc/ReactionSiteSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/ReactionSiteSpec.scala
@@ -88,9 +88,11 @@ class ReactionSiteSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
   it should "support concise syntax for Unit-typed molecules" in {
     val a = new M[Unit]("a")
     val f = new B[Unit, Unit]("f")
+    val g = b[Unit, Unit]
     a.name shouldEqual "a"
     f.name shouldEqual "f"
+    g.name shouldEqual "g"
     // This should compile without any argument adaptation warnings or errors:
-    "val r = go { case a(_) + f(_, r) => a() + r() + f(); val status = r.checkTimeout() }" should compile
+    "val r = go { case a(_) + f(_, r) + g(_, s) => a() + s() + f(); val status = r.checkTimeout() }" should compile
   }
 }

--- a/joinrun/src/test/scala/code/chymyst/jc/ReactionSiteSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/ReactionSiteSpec.scala
@@ -1,5 +1,6 @@
 package code.chymyst.jc
 
+import code.chymyst.jc.Core.ReactionBody
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 
 class ReactionSiteSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
@@ -83,5 +84,12 @@ class ReactionSiteSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     if (result.isFailure) println(s"Test failed with message: ${result.failed.get.getMessage}")
     result.isSuccess shouldEqual true
     result.isFailure shouldEqual false
+  }
+
+  it should "support concise syntax for Unit-typed molecules" in {
+    val a = new M[Unit]("a")
+    val f = new B[Unit, Unit]("f")
+    // This should compile without any argument adaptation warnings or errors:
+    val pf: ReactionBody = { case a(_) + f(_, r) => a() + r() + f(); val status = r.checkTimeout() }
   }
 }

--- a/joinrun/src/test/scala/code/chymyst/jc/ReactionSiteSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/ReactionSiteSpec.scala
@@ -1,6 +1,5 @@
 package code.chymyst.jc
 
-import code.chymyst.jc.Core.ReactionBody
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 
 class ReactionSiteSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
@@ -89,7 +88,9 @@ class ReactionSiteSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
   it should "support concise syntax for Unit-typed molecules" in {
     val a = new M[Unit]("a")
     val f = new B[Unit, Unit]("f")
+    a.name shouldEqual "a"
+    f.name shouldEqual "f"
     // This should compile without any argument adaptation warnings or errors:
-    val pf: ReactionBody = { case a(_) + f(_, r) => a() + r() + f(); val status = r.checkTimeout() }
+    "val r = go { case a(_) + f(_, r) => a() + r() + f(); val status = r.checkTimeout() }" should compile
   }
 }

--- a/joinrun/src/test/scala/code/chymyst/test/DiningPhilosophersSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/test/DiningPhilosophersSpec.scala
@@ -44,8 +44,8 @@ class DiningPhilosophersSpec extends FlatSpec with Matchers {
     val fork45 = m[Unit]
     val fork51 = m[Unit]
 
-    val done = new E("done")
-    val check = new EE("check")
+    val done = m[Unit]
+    val check = b[Unit, Unit]
 
     site(tp) (
       go { case thinking1(n) => thinking(1); hungry1(n - 1) },

--- a/joinrun/src/test/scala/code/chymyst/test/FairnessSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/test/FairnessSpec.scala
@@ -154,7 +154,7 @@ class FairnessSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
     val tp = new FixedPool(8)
 
-    def makeRS(d1: E, d2: E): (E, E, E) = {
+    def makeRS(d1: M[Unit], d2: M[Unit]): (M[Unit], M[Unit], M[Unit]) = {
       val a = m[Unit]
       val b = m[Unit]
       val c = m[Unit]

--- a/joinrun/src/test/scala/code/chymyst/test/MoreBlockingSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/test/MoreBlockingSpec.scala
@@ -56,7 +56,7 @@ class MoreBlockingSpec extends FlatSpec with Matchers with TimeLimitedTests {
       go { case f(_, r) + a(true) => Thread.sleep(500); a(r.checkTimeout(123)) }
     )
     a(true)
-    f.timeout(300.millis)() shouldEqual None // should give enough time so that the reaction can start
+    f.timeout()(300.millis) shouldEqual None // should give enough time so that the reaction can start
     g() shouldEqual false  // will be `true` when the `f` reaction did not start before timeout
 
     tp.shutdownNow()
@@ -74,7 +74,7 @@ class MoreBlockingSpec extends FlatSpec with Matchers with TimeLimitedTests {
       go { case f(_, r) + a(true) => Thread.sleep(500); a(r.checkTimeout()) }
     )
     a(true)
-    f.timeout(300.millis)() shouldEqual None // should give enough time so that the reaction can start
+    f.timeout()(300.millis) shouldEqual None // should give enough time so that the reaction can start
     g() shouldEqual false
 
     tp.shutdownNow()
@@ -90,7 +90,7 @@ class MoreBlockingSpec extends FlatSpec with Matchers with TimeLimitedTests {
     site(tp)(
       go { case f(_, r) => val res = r.checkTimeout(123); waiter { res shouldEqual true; ()}; waiter.dismiss() }
     )
-    f.timeout(10.seconds)() shouldEqual Some(123)
+    f.timeout()(10.seconds) shouldEqual Some(123)
 
     waiter.await()
     tp.shutdownNow()
@@ -113,12 +113,12 @@ class MoreBlockingSpec extends FlatSpec with Matchers with TimeLimitedTests {
     collect(0)
 
     val numberOfFailures = (1 to 1000).map { _ =>
-      if (f.timeout(1000 millis)().isEmpty) 1 else 0
+      if (f.timeout()(1000 millis).isEmpty) 1 else 0
     }.sum
 
     // we used to have about 4% numberOfFailures (but we get zero failures if we do not nullify the semaphore!) and about 4 numberOfFalseReplies in 100,000.
     // now it seems to pass even with a million iterations (but that's too long for Travis).
-    val numberOfFalseReplies = get.timeout(2000 millis)()
+    val numberOfFalseReplies = get.timeout()(2000 millis)
 
     (numberOfFailures, numberOfFalseReplies) shouldEqual ((0, Some(0)))
 
@@ -136,7 +136,7 @@ class MoreBlockingSpec extends FlatSpec with Matchers with TimeLimitedTests {
     )
     a.setLogLevel(4)
     a.logSoup shouldEqual "Site{a + f/B => ...}\nNo molecules"
-    f.timeout(100 millis)() shouldEqual None
+    f.timeout()(100 millis) shouldEqual None
     // TODO: this test sometimes fails because f is not withdrawn and reacts with a(123) - even though logSoup prints "No molecules"!
     // there should be no a(0) now, because the reaction has not yet run ("f" timed out and was withdrawn, so no molecules)
     a.logSoup shouldEqual "Site{a + f/B => ...}\nNo molecules"
@@ -165,7 +165,7 @@ class MoreBlockingSpec extends FlatSpec with Matchers with TimeLimitedTests {
     )
 
     a.logSoup shouldEqual "Site{a + g/B => ...; f/B => ...}\nNo molecules"
-    f.timeout(300 millis)() shouldEqual None // this times out because the f => ... reaction is blocked by g(), which is waiting for a()
+    f.timeout()(300 millis) shouldEqual None // this times out because the f => ... reaction is blocked by g(), which is waiting for a()
     a.logSoup shouldEqual "Site{a + g/B => ...; f/B => ...}\nMolecules: g/B()" // f() should have been removed but g() remains
     a(123) // Now g() starts reacting with a() and unblocks the "f" reaction, which should try to reply to "f" after "f" timed out.
     // The attempt to reply to "f" should fail, which is indicated by returning "false" from "r(x)". This is verified by the "waiter".
@@ -208,9 +208,9 @@ class MoreBlockingSpec extends FlatSpec with Matchers with TimeLimitedTests {
     )
     d(100)
     incr() // reaction 3 started and is waiting for e()
-    get_d.timeout(400 millis)() shouldEqual None
+    get_d.timeout()(400 millis) shouldEqual None
     e()
-    get_d.timeout(800 millis)() shouldEqual Some(101)
+    get_d.timeout()(800 millis) shouldEqual Some(101)
 
     tp.shutdownNow()
   }
@@ -259,7 +259,7 @@ class MoreBlockingSpec extends FlatSpec with Matchers with TimeLimitedTests {
     d.setLogLevel(4)
     d(100)
     c() // update started and is waiting for e(), which should come after incr() gets its reply
-    get_f.timeout(400 millis)() shouldEqual None
+    get_f.timeout()(400 millis) shouldEqual None
 
     tp.shutdownNow()
   }

--- a/joinrun/src/test/scala/code/chymyst/test/ParallelOrSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/test/ParallelOrSpec.scala
@@ -21,7 +21,7 @@ class ParallelOrSpec extends FlatSpec with Matchers {
     * @param tp Thread pool on which to run this.
     * @return New blocking molecule emitter that will return the desired result or block.
     */
-  def parallelOr(f: EB[Boolean], g: EB[Boolean], tp: Pool): EB[Boolean] = {
+  def parallelOr(f: B[Unit, Boolean], g: B[Unit, Boolean], tp: Pool): B[Unit, Boolean] = {
     val c = m[Unit]
     val d = m[Unit]
     val done = m[Boolean]
@@ -79,8 +79,8 @@ class ParallelOrSpec extends FlatSpec with Matchers {
     parallelOr(slowFalse, fastFalse, tp)() shouldEqual false
     parallelOr(fastFalse, slowTrue, tp)() shouldEqual true
 
-    parallelOr(never, fastFalse, tp).timeout(200 millis)() shouldEqual None
-    parallelOr(never, slowFalse, tp).timeout(200 millis)() shouldEqual None
+    parallelOr(never, fastFalse, tp).timeout()(200 millis) shouldEqual None
+    parallelOr(never, slowFalse, tp).timeout()(200 millis) shouldEqual None
 
     tp.shutdownNow()
   }
@@ -94,7 +94,7 @@ class ParallelOrSpec extends FlatSpec with Matchers {
     * @tparam T Type of the return value.
     * @return New blocking molecule emitter that will return the desired result.
     */
-  def firstResult[T](b1: EB[T], b2: EB[T], tp: Pool): EB[T] = {
+  def firstResult[T](b1: B[Unit, T], b2: B[Unit, T], tp: Pool): B[Unit, T] = {
     val get = b[Unit, T]
     val res = b[Unit, T]
     val res1 = m[Unit]
@@ -115,7 +115,8 @@ class ParallelOrSpec extends FlatSpec with Matchers {
 
   @tailrec
   final def neverReturn[T]: T = {
-    Thread.sleep(1000000); neverReturn[T]
+    Thread.sleep(1000000)
+    neverReturn[T]
   }
 
   it should "implement the First Result operation correctly" in {

--- a/joinrun/src/test/scala/code/chymyst/test/Patterns01Spec.scala
+++ b/joinrun/src/test/scala/code/chymyst/test/Patterns01Spec.scala
@@ -186,7 +186,7 @@ class Patterns01Spec extends FlatSpec with Matchers with BeforeAndAfterEach {
     (1 to n).foreach(i => begin((f(i),g(i))))
     counterInit()
     endCounter(n)
-    done.timeout(1000 millis)() shouldEqual Some(())
+    done.timeout()(1000 millis) shouldEqual Some(())
 
     val result: Seq[String] = logFile.iterator().asScala.toSeq
     result.size shouldEqual 2*n

--- a/joinrun/src/test/scala/code/chymyst/test/SingletonMoleculeSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/test/SingletonMoleculeSpec.scala
@@ -31,7 +31,7 @@ class SingletonMoleculeSpec extends FlatSpec with Matchers with TimeLimitedTests
         d(s"bad $i") // this "d" should not be emitted, even though "d" is sometimes not in the soup due to reactions!
       }
       thrown.getMessage shouldEqual s"In Site{d + f/B => ...}: Refusing to emit singleton d(bad $i) because this thread does not run a chemical reaction"
-      f.timeout(500 millis)() shouldEqual Some("ok")
+      f.timeout()(500 millis) shouldEqual Some("ok")
     }
 
     tp1.shutdownNow()
@@ -57,7 +57,7 @@ class SingletonMoleculeSpec extends FlatSpec with Matchers with TimeLimitedTests
         // and even if the initial d() emission was done late
         }
         thrown.getMessage shouldEqual s"In Site{d + f/B => ...}: Refusing to emit singleton d(bad $i $j) because this thread does not run a chemical reaction"
-        f.timeout(500 millis)() shouldEqual Some("ok")
+        f.timeout()(500 millis) shouldEqual Some("ok")
       }
 
     }
@@ -325,11 +325,11 @@ class SingletonMoleculeSpec extends FlatSpec with Matchers with TimeLimitedTests
       go { case d(x) + stabilize_d(_, r) => d(x); r() }, // Await stabilizing the presence of d
       go { case _ => d(n) } // singleton
     )
-    stabilize_d.timeout(500 millis)()
+    stabilize_d.timeout()(500 millis)
     d.volatileValue shouldEqual n
 
     (n+1 to n+delta_n).map { i =>
-      incr.timeout(500 millis)() shouldEqual Some(())
+      incr.timeout()(500 millis) shouldEqual Some(())
 
       i - d.volatileValue // this is mostly 0 but sometimes 1
     }.sum should be > 0 // there should be some cases when d.value reads the previous value
@@ -353,12 +353,12 @@ class SingletonMoleculeSpec extends FlatSpec with Matchers with TimeLimitedTests
       go { case d(x) + stabilize_d(_, r) => d(x); r() } onThreads tp1, // Await stabilizing the presence of d
       go { case _ => d(100) } // singleton
     )
-    stabilize_d.timeout(500 millis)() shouldEqual Some(())
+    stabilize_d.timeout()(500 millis) shouldEqual Some(())
     d.volatileValue shouldEqual 100
-    incr.timeout(500 millis)() shouldEqual Some(()) // update started and is waiting for e()
+    incr.timeout()(500 millis) shouldEqual Some(()) // update started and is waiting for e()
     d.volatileValue shouldEqual 100 // We don't have d() present in the soup, but we can read its previous value.
     e()
-    stabilize_d.timeout(500 millis)() shouldEqual Some(())
+    stabilize_d.timeout()(500 millis) shouldEqual Some(())
     d.volatileValue shouldEqual 101
 
     tp1.shutdownNow()


### PR DESCRIPTION
The auxiliary classes `E`, `EB`, `BE`, `EE` are now eliminated using an implicit argument, - big thanks to @cruhland for this suggestion!

Without the auxiliary classes, the molecule types become much simpler - just M[T] and B[T,R] as before. Also, we do not need to use any whitebox macros, and IntelliJ is now happy with the syntax.

The only breaking change, besides the disappearance of the auxiliary classes, is that the timeout syntax had to be changed from `f.timeout(1 second)()` to `f.timeout()(1 second)`.