### PR TITLE
better reaction detection

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,7 @@ tutSettings
 
 lazy val errorsForWartRemover = Seq(Wart.EitherProjectionPartial, Wart.Enumeration, Wart.Equals, Wart.ExplicitImplicitTypes, Wart.FinalCaseClass, Wart.FinalVal, Wart.LeakingSealed, Wart.Return, Wart.StringPlusAny, Wart.TraversableOps, Wart.TryPartial)
 
-lazy val warningsForWartRemover = Seq() //Seq(Wart.Any, Wart.AsInstanceOf, Wart.ImplicitConversion, Wart.IsInstanceOf, Wart.JavaConversions, Wart.Option2Iterable, Wart.OptionPartial, Wart.NoNeedForMonad, Wart.Nothing, Wart.Product, Wart.Serializable, Wart.ToString, Wart.While)
+lazy val warningsForWartRemover = Seq(Wart.JavaConversions, Wart.Nothing) //Seq(Wart.Any, Wart.AsInstanceOf, Wart.ImplicitConversion, Wart.IsInstanceOf, Wart.JavaConversions, Wart.Option2Iterable, Wart.OptionPartial, Wart.NoNeedForMonad, Wart.Nothing, Wart.Product, Wart.Serializable, Wart.ToString, Wart.While)
 
 val rootProject = Some(buildAll)
 

--- a/docs/chymyst07.md
+++ b/docs/chymyst07.md
@@ -1056,7 +1056,7 @@ One receiver is available to process one of these calls at a time.
 
 TODO
 
-## Concurrent recursive traversal
+## Concurrent recursive traversal ("fork/join")
 
 TODO
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,6 +2,8 @@
 
 # Version history
 
+- 0.1.6 A different mechanism now implements the syntax `a()` for emitting molecules with `Unit` values; no more auxiliary classes `E`, `BE`, `EB`, `EE`, which simplifies code and eliminates the need for whitebox macros. Breaking change: `timeout(value)(duraction)` instead of `timeout(duraction)(value)` as before. An optimization for the reaction scheduler now makes simple reactions start faster. The project build has been revamped: now there is a single JAR artifact and a single SBT project for `JoinRun`, rather than 3 as before. A skeleton "hello-world" project is available in a separate repository. `Chymyst` has been moved to a separate repository as well. Various improvements in the compile-time analysis of reactions.
+
 - 0.1.5 Bug fix for a rare race condition with time-out on blocking molecules. New `checkTimeout` API to make a clean distinction between replies that need to check the timeout status and replies that don't. Documentation was improved. Code cleanups resulted in 100% test coverage. Revamped reaction site code now supports nonlinear input patterns.
 
 - 0.1.4 Simplify API: now users need only one package import. Many more tutorial examples of chemical machine concurrency. Test code coverage is 97%. More compiler warnings enabled (including deprecation warnings). There are now more intelligent "whitebox" macros that generate different subclasses of `M[T]` and `B[T,R]` when `T` or `R` are the `Unit` type, to avoid deprecation warnings with the syntax `f()`.

--- a/joinrun/src/main/scala/code/chymyst/jc/FractionInt.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/FractionInt.scala
@@ -1,5 +1,5 @@
 package code.chymyst.jc
-
+/*
 import scala.annotation.tailrec
 
 final case class FractionInt(numerator: Int, denominator: Int) {
@@ -53,3 +53,4 @@ object FractionInt extends Fractional[FractionInt] {
 
   override def compare(x: FractionInt, y: FractionInt): Int = (x.numerator * y.denominator) compare (y.numerator * x.denominator)
 }
+*/

--- a/joinrun/src/main/scala/code/chymyst/jc/FractionInt.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/FractionInt.scala
@@ -1,0 +1,55 @@
+package code.chymyst.jc
+
+import scala.annotation.tailrec
+
+final case class FractionInt(numerator: Int, denominator: Int) {
+  def +(y: FractionInt): FractionInt = {
+    val gcd = FractionInt.gcd(denominator, y.denominator)
+    FractionInt((numerator * y.denominator + denominator * y.numerator) / gcd, FractionInt.lcm(denominator, y.denominator))
+  }
+
+  def *(y: FractionInt): FractionInt = {
+    val gcd = FractionInt.gcd(denominator, y.denominator)
+    FractionInt(numerator * y.numerator / gcd, denominator * y.denominator / gcd)
+  }
+
+  def unary_- : FractionInt = FractionInt(-numerator, denominator)
+
+  def -(y: FractionInt): FractionInt = this.+(-y)
+
+  def inverse: FractionInt = FractionInt(denominator, numerator)
+}
+
+object FractionInt extends Fractional[FractionInt] {
+
+  @tailrec
+  def gcd(a: Int, b: Int): Int =
+    if (b == 0) a else gcd(b, a % b)
+
+  def lcm(a: Int, b: Int): Int = {
+    val product = a * b
+    if (product == 0) 0 else product / gcd(a, b)
+  }
+
+  override def div(x: FractionInt, y: FractionInt): FractionInt = x * y.inverse
+
+  override def plus(x: FractionInt, y: FractionInt): FractionInt = x + y
+
+  override def minus(x: FractionInt, y: FractionInt): FractionInt = x - y
+
+  override def times(x: FractionInt, y: FractionInt): FractionInt = x * y
+
+  override def negate(x: FractionInt): FractionInt = -x
+
+  override def fromInt(x: Int): FractionInt = FractionInt(x, 1)
+
+  override def toInt(x: FractionInt): Int = x.numerator / x.denominator
+
+  override def toLong(x: FractionInt): Long = (x.numerator / x.denominator).toLong
+
+  override def toFloat(x: FractionInt): Float = x.numerator.toFloat / x.denominator.toFloat
+
+  override def toDouble(x: FractionInt): Double = x.numerator.toDouble / x.denominator.toDouble
+
+  override def compare(x: FractionInt, y: FractionInt): Int = (x.numerator * y.denominator) compare (y.numerator * x.denominator)
+}

--- a/joinrun/src/main/scala/code/chymyst/jc/Macros.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Macros.scala
@@ -110,18 +110,15 @@ class CommonMacros(val c: blackbox.Context) {
   /** Describes the pattern matcher for output molecules.
     * Possible values:
     * ConstOutputPatternF(x): a(123) or a(Some(4)), etc.
-    * EmptyOutputPatternF: a() - this only happens with `Unit` values.
     * OtherOutputPatternF: a(x), a(x+y), or any other kind of expression.
     */
   sealed trait OutputPatternFlag {
-    def needTraversal: Boolean = false
+    val needTraversal: Boolean = false
   }
 
   case object OtherOutputPatternF extends OutputPatternFlag {
-    override def needTraversal: Boolean = true
+    override val needTraversal: Boolean = true
   }
-
-  case object EmptyOutputPatternF extends OutputPatternFlag
 
   final case class ConstOutputPatternF(v: Tree) extends OutputPatternFlag
 

--- a/joinrun/src/main/scala/code/chymyst/jc/Macros.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Macros.scala
@@ -349,7 +349,7 @@ final class BlackboxMacros(override val c: blackbox.Context) extends ReactionMac
     // However, the order of output molecules corresponds to the order in which they might be emitted.
     val allOutputInfo = bodyOut
     // Neither the pattern nor the guard can emit output molecules.
-    val outputMolecules = allOutputInfo.map { case (m, p, envs) => q"OutputMoleculeInfo(${m.asTerm}, $p, $envs)" }.toArray
+    val outputMolecules = allOutputInfo.map { case (m, p, envs) => q"OutputMoleculeInfo(${m.asTerm}, $p, ${envs.reverse})" }.toArray
 
     // Detect whether this reaction has a simple livelock:
     // All input molecules have trivial matchers and are a subset of output molecules.

--- a/joinrun/src/main/scala/code/chymyst/jc/Macros.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Macros.scala
@@ -37,21 +37,6 @@ class CommonMacros(val c: blackbox.Context) {
   // Instead, we just put them inside the `CommonMacros` class. The price for this is a warning "The outer reference in this type test cannot be checked at run time."
   // This warning is discussed here, http://stackoverflow.com/questions/16450008/typesafe-swing-events-the-outer-reference-in-this-type-test-cannot-be-checked-a
 
-  /** Describe the environment within which an output molecule was emitted.
-    * Possible environments are [[ChooserBlock]] describing an `if` or `match` expression with clauses,
-    * and a function call [[FuncBlock]].
-    *
-    * For example, `if (x>0) a(x) else b(x)` is a chooser block environment with 2 clauses,
-    * while `(1 to 10).foreach(a)` is a function call environment.
-    */
-  sealed trait OutputEnvironment
-
-  final case class ChooserBlock(id: Int, clause: Int) extends OutputEnvironment
-
-  final case class FuncBlock(id: Int, name: String) extends OutputEnvironment
-
-  final case class FuncLambda(id: Int) extends OutputEnvironment
-
   /** Describes the pattern matcher for input molecules.
     * Possible values:
     * Wildcard: a(_)
@@ -364,7 +349,7 @@ final class BlackboxMacros(override val c: blackbox.Context) extends ReactionMac
     // However, the order of output molecules corresponds to the order in which they might be emitted.
     val allOutputInfo = bodyOut
     // Neither the pattern nor the guard can emit output molecules.
-    val outputMolecules = allOutputInfo.map { case (m, p, envs) => q"OutputMoleculeInfo(${m.asTerm}, $p)" }.toArray
+    val outputMolecules = allOutputInfo.map { case (m, p, envs) => q"OutputMoleculeInfo(${m.asTerm}, $p, $envs)" }.toArray
 
     // Detect whether this reaction has a simple livelock:
     // All input molecules have trivial matchers and are a subset of output molecules.

--- a/joinrun/src/main/scala/code/chymyst/jc/Macros.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Macros.scala
@@ -333,14 +333,14 @@ final class BlackboxMacros(override val c: blackbox.Context) extends ReactionMac
     val blockingMoleculesWithoutReply = blockingReplies difff repliedMolecules
     val blockingMoleculesWithMultipleReply = repliedMolecules difff blockingReplies
 
-    maybeError("blocking input molecules", "but no reply found for", blockingMoleculesWithoutReply, "receive a reply")
+    maybeError("blocking input molecules", "but no reply found for", blockingMoleculesWithoutReply, "receive a reply unconditionally")
     maybeError("blocking input molecules", "but multiple replies found for", blockingMoleculesWithMultipleReply, "receive only one reply")
 
     if (patternIn.isEmpty && !isSingletonReaction(pattern, guard, body)) // go { case x => ... }
-      reportError("Reaction's input must be `_` or have some input molecules")
+      reportError("Reaction input must be `_` or must contain some input molecules")
 
     if (isSingletonReaction(pattern, guard, body) && bodyOut.isEmpty)
-      reportError("Reaction must not have an empty list of input molecules and no output molecules")
+      reportError("Singleton reaction must emit some output molecules")
 
     val inputMolecules = patternInWithMergedGuardsAndIndex.map { case (s, i, p, _) => q"InputMoleculeInfo(${s.asTerm}, $i, $p, ${p.patternSha1(t => showCode(t))})" }.toArray
 

--- a/joinrun/src/main/scala/code/chymyst/jc/Macros.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Macros.scala
@@ -37,6 +37,21 @@ class CommonMacros(val c: blackbox.Context) {
   // Instead, we just put them inside the `CommonMacros` class. The price for this is a warning "The outer reference in this type test cannot be checked at run time."
   // This warning is discussed here, http://stackoverflow.com/questions/16450008/typesafe-swing-events-the-outer-reference-in-this-type-test-cannot-be-checked-a
 
+  /** Describe the environment within which an output molecule was emitted.
+    * Possible environments are [[ChooserBlock]] describing an `if` or `match` expression with clauses,
+    * and a function call [[FuncBlock]].
+    *
+    * For example, `if (x>0) a(x) else b(x)` is a chooser block environment with 2 clauses,
+    * while `(1 to 10).foreach(a)` is a function call environment.
+    */
+  sealed trait OutputEnvironment
+
+  final case class ChooserBlock(id: Int, clause: Int) extends OutputEnvironment
+
+  final case class FuncBlock(id: Int, name: String) extends OutputEnvironment
+
+  final case class FuncLambda(id: Int) extends OutputEnvironment
+
   /** Describes the pattern matcher for input molecules.
     * Possible values:
     * Wildcard: a(_)
@@ -177,15 +192,17 @@ final class BlackboxMacros(override val c: blackbox.Context) extends ReactionMac
     val (patternIn, patternOut, patternReply, wrongMoleculesInInput) = moleculeInfoMaker.from(pattern) // patternOut and patternReply should be empty
     maybeError("input molecule patterns", "emits output molecules", patternOut)
     maybeError("input molecule patterns", "perform any reply actions", patternReply, "not")
-    maybeError("input molecules", "uses other molecules inside molecule values", wrongMoleculesInInput)
+    maybeError("input molecules", "uses other molecules inside molecule value patterns", wrongMoleculesInInput)
 
-    val (guardIn, guardOut, guardReply, _) = moleculeInfoMaker.from(guard) // guard in/out/reply lists should be all empty
+    val (guardIn, guardOut, guardReply, wrongMoleculesInGuard) = moleculeInfoMaker.from(guard) // guard in/out/reply lists should be all empty
     maybeError("input guard", "matches on additional input molecules", guardIn.map(_._1))
     maybeError("input guard", "emit any output molecules", guardOut.map(_._1), "not")
     maybeError("input guard", "perform any reply actions", guardReply.map(_._1), "not")
+    maybeError("input guard", "uses other molecules inside molecule value patterns", wrongMoleculesInGuard)
 
-    val (bodyIn, bodyOut, bodyReply, _) = moleculeInfoMaker.from(body) // bodyIn should be empty
+    val (bodyIn, bodyOut, bodyReply, wrongMoleculesInBody) = moleculeInfoMaker.from(body) // bodyIn should be empty
     maybeError("reaction body", "matches on additional input molecules", bodyIn.map(_._1))
+    maybeError("reaction body", "uses other molecules inside molecule value patterns", wrongMoleculesInBody)
 
     val guardCNF: List[List[Tree]] = convertToCNF(guard) // Conjunctive normal form of the guard condition. In this CNF, `true` is List() and `false` is List(List()).
 
@@ -347,7 +364,7 @@ final class BlackboxMacros(override val c: blackbox.Context) extends ReactionMac
     // However, the order of output molecules corresponds to the order in which they might be emitted.
     val allOutputInfo = bodyOut
     // Neither the pattern nor the guard can emit output molecules.
-    val outputMolecules = allOutputInfo.map { case (m, p) => q"OutputMoleculeInfo(${m.asTerm}, $p)" }.toArray
+    val outputMolecules = allOutputInfo.map { case (m, p, envs) => q"OutputMoleculeInfo(${m.asTerm}, $p)" }.toArray
 
     // Detect whether this reaction has a simple livelock:
     // All input molecules have trivial matchers and are a subset of output molecules.

--- a/joinrun/src/main/scala/code/chymyst/jc/Macros.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Macros.scala
@@ -170,7 +170,7 @@ final class BlackboxMacros(override val c: blackbox.Context) extends ReactionMac
   def buildReactionValueImpl(reactionBody: c.Expr[ReactionBody], pattern: Tree, guard: Tree, body: Tree): c.Expr[Reaction] = {
 
     if (DetectInvalidInputGrouping.in(pattern))
-      reportError("Reaction's input molecules must be grouped to the left in chemical notation")
+      reportError("Reaction's input molecules must be grouped to the left in chemical notation, and have no @-pattern variables")
 
     val moleculeInfoMaker = new MoleculeInfo(getCurrentSymbolOwner)
 

--- a/joinrun/src/main/scala/code/chymyst/jc/Reaction.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Reaction.scala
@@ -84,8 +84,6 @@ final case class FuncLambda(id: Int) extends OutputEnvironment
 
 final case class AtLeastOneEmitted(id: Int, name: String) extends OutputEnvironment
 
-final case class ZeroOrMoreEmitted(id: Int, name: String) extends OutputEnvironment
-
 /** Indicates whether a reaction has a guard condition.
   *
   */

--- a/joinrun/src/main/scala/code/chymyst/jc/Reaction.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Reaction.scala
@@ -80,6 +80,8 @@ final case class FuncBlock(id: Int, name: String) extends OutputEnvironment
 
 final case class FuncLambda(id: Int) extends OutputEnvironment
 
+final case class EmitOneOrMore(id: Int, name: String) extends OutputEnvironment
+
 /** Indicates whether a reaction has a guard condition.
   *
   */

--- a/joinrun/src/main/scala/code/chymyst/jc/Reaction.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Reaction.scala
@@ -83,6 +83,13 @@ sealed trait OutputEnvironment {
     * @return The Id number of the output environment.
     */
   def id: Int
+
+  /** Describes the minimum guaranteed fraction of cases in which the molecule will be emitted.
+    * Exact rational fractions are used.
+    * For example, `if(x>0) a(x)` will yield the value 1/2 represented as `FractionInt(1, 2)`.
+    * A `match-case` construct with 3 case clauses will yield values 1/3 for each molecule emitted in one of the clauses.
+    */
+  val fraction: FractionInt = FractionInt.fromInt(0)
 }
 
 /** Describes a molecule emitted in a chooser clause, that is, in an `if-then-else` or `match-case` construct.
@@ -91,7 +98,9 @@ sealed trait OutputEnvironment {
   * @param clause Zero-based index of the clause.
   * @param total  Total number of clauses in the chooser constructs (2 for `if-then-else`, 2 or greater for `match-case`).
   */
-final case class ChooserBlock(id: Int, clause: Int, total: Int) extends OutputEnvironment
+final case class ChooserBlock(id: Int, clause: Int, total: Int) extends OutputEnvironment {
+  override val fraction: FractionInt = FractionInt(1, total)
+}
 
 /** Describes a molecule emitted under a function call.
   *
@@ -113,6 +122,7 @@ final case class FuncLambda(id: Int) extends OutputEnvironment
   */
 final case class AtLeastOneEmitted(id: Int, name: String) extends OutputEnvironment {
   override val atLeastOne: Boolean = true
+  override val fraction: FractionInt = FractionInt.fromInt(1)
 }
 
 /** Indicates whether a reaction has a guard condition.

--- a/joinrun/src/main/scala/code/chymyst/jc/Reaction.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Reaction.scala
@@ -72,7 +72,9 @@ case object OtherOutputPattern extends OutputPatternType
   * while `(1 to 10).foreach(a)` is a function block environment
   * and `(x) => a(x)` is a [[FuncLambda]] environment.
   */
-sealed trait OutputEnvironment
+sealed trait OutputEnvironment {
+  def id: Int
+}
 
 final case class ChooserBlock(id: Int, clause: Int) extends OutputEnvironment
 
@@ -80,7 +82,9 @@ final case class FuncBlock(id: Int, name: String) extends OutputEnvironment
 
 final case class FuncLambda(id: Int) extends OutputEnvironment
 
-final case class EmitOneOrMore(id: Int, name: String) extends OutputEnvironment
+final case class AtLeastOneEmitted(id: Int, name: String) extends OutputEnvironment
+
+final case class ZeroOrMoreEmitted(id: Int, name: String) extends OutputEnvironment
 
 /** Indicates whether a reaction has a guard condition.
   *

--- a/joinrun/src/main/scala/code/chymyst/jc/Reaction.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/Reaction.scala
@@ -83,13 +83,6 @@ sealed trait OutputEnvironment {
     * @return The Id number of the output environment.
     */
   def id: Int
-
-  /** Describes the minimum guaranteed fraction of cases in which the molecule will be emitted.
-    * Exact rational fractions are used.
-    * For example, `if(x>0) a(x)` will yield the value 1/2 represented as `FractionInt(1, 2)`.
-    * A `match-case` construct with 3 case clauses will yield values 1/3 for each molecule emitted in one of the clauses.
-    */
-  val fraction: FractionInt = FractionInt.fromInt(0)
 }
 
 /** Describes a molecule emitted in a chooser clause, that is, in an `if-then-else` or `match-case` construct.
@@ -98,9 +91,7 @@ sealed trait OutputEnvironment {
   * @param clause Zero-based index of the clause.
   * @param total  Total number of clauses in the chooser constructs (2 for `if-then-else`, 2 or greater for `match-case`).
   */
-final case class ChooserBlock(id: Int, clause: Int, total: Int) extends OutputEnvironment {
-  override val fraction: FractionInt = FractionInt(1, total)
-}
+final case class ChooserBlock(id: Int, clause: Int, total: Int) extends OutputEnvironment
 
 /** Describes a molecule emitted under a function call.
   *
@@ -122,7 +113,6 @@ final case class FuncLambda(id: Int) extends OutputEnvironment
   */
 final case class AtLeastOneEmitted(id: Int, name: String) extends OutputEnvironment {
   override val atLeastOne: Boolean = true
-  override val fraction: FractionInt = FractionInt.fromInt(1)
 }
 
 /** Indicates whether a reaction has a guard condition.

--- a/joinrun/src/main/scala/code/chymyst/jc/ReactionMacros.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/ReactionMacros.scala
@@ -657,6 +657,13 @@ class ReactionMacros(override val c: blackbox.Context) extends CommonMacros(c) {
       q"_root_.code.chymyst.jc.OtherOutputPattern"
   }
 
+  implicit val liftableOutputPatternType: Liftable[OutputPatternType] = Liftable[OutputPatternType] {
+    case SimpleConstOutput(v) =>
+      q"_root_.code.chymyst.jc.SimpleConstOutput(${v.asInstanceOf[Tree]})" // When we lift it here, it always has type `Tree`.
+    case OtherOutputPattern =>
+      q"_root_.code.chymyst.jc.OtherOutputPattern"
+  }
+
   implicit val liftableOutputEnvironment: Liftable[OutputEnvironment] = Liftable[OutputEnvironment] {
     case ChooserBlock(id, clause, total) =>
       q"_root_.code.chymyst.jc.ChooserBlock($id, $clause, $total)"

--- a/joinrun/src/main/scala/code/chymyst/jc/ReactionMacros.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/ReactionMacros.scala
@@ -320,9 +320,6 @@ class ReactionMacros(override val c: blackbox.Context) extends CommonMacros(c) {
       case pq"$extr1($_, $extr2($_, $_))"
         if extr1.symbol.fullName === "code.chymyst.jc.$plus" && extr2.symbol.fullName === "code.chymyst.jc.$plus" =>
         found = true
-      case pq"$extr1($_, $_ @ $extr2($_, $_))"
-        if extr1.symbol.fullName === "code.chymyst.jc.$plus" && extr2.symbol.fullName === "code.chymyst.jc.$plus" =>
-        found = true
       case _ =>
         super.traverse(tree)
     }

--- a/joinrun/src/main/scala/code/chymyst/jc/ReactionMacros.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/ReactionMacros.scala
@@ -569,7 +569,7 @@ class ReactionMacros(override val c: blackbox.Context) extends CommonMacros(c) {
               argumentList.foreach(traverse)
             } else {
               renewOutputEnvId()
-              outputEnv.push(FuncBlock(currentOutputEnvId, name = s"$name###$f"))
+              outputEnv.push(FuncBlock(currentOutputEnvId, name = s"${t.symbol.fullName}.$f"))
               argumentList.foreach(traverse)
               finishTraverseWithOutputEnv()
             }

--- a/joinrun/src/main/scala/code/chymyst/jc/ReactionMacros.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/ReactionMacros.scala
@@ -419,11 +419,12 @@ class ReactionMacros(override val c: blackbox.Context) extends CommonMacros(c) {
           }
     }
 
-    private def getOutputFlag(binderTerms: List[Tree]): OutputPatternFlag = binderTerms match {
+    /** We only support one-argument molecules, so here we only inspect the first element in the list of terms. */
+    private def getOutputFlag(outputTerms: List[Tree]): OutputPatternFlag = outputTerms match {
       case List(t) =>
         getConstantTree(t).map(tree => ConstOutputPatternF(tree.asInstanceOf[Tree])).getOrElse(OtherOutputPatternF)
       case Nil =>
-        EmptyOutputPatternF
+        ConstOutputPatternF(q"()")
       case _ =>
         OtherOutputPatternF
     }
@@ -652,9 +653,7 @@ class ReactionMacros(override val c: blackbox.Context) extends CommonMacros(c) {
   implicit val liftableOutputPatternFlag: Liftable[OutputPatternFlag] = Liftable[OutputPatternFlag] {
     case ConstOutputPatternF(tree) =>
       q"_root_.code.chymyst.jc.SimpleConstOutput($tree)"
-    case EmptyOutputPatternF =>
-      q"_root_.code.chymyst.jc.SimpleConstOutput(())"
-    case _ =>
+    case OtherOutputPatternF =>
       q"_root_.code.chymyst.jc.OtherOutputPattern"
   }
 

--- a/joinrun/src/main/scala/code/chymyst/jc/ReactionMacros.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/ReactionMacros.scala
@@ -442,6 +442,7 @@ class ReactionMacros(override val c: blackbox.Context) extends CommonMacros(c) {
 
     private def isReplyValue(t: Trees#Tree): Boolean = t.asInstanceOf[Tree].tpe <:< weakTypeOf[AbsReplyValue[_, _]]
 
+    @SuppressWarnings(Array("org.wartremover.warts.Equals"))
     override def traverse(tree: Tree): Unit = {
       tree match {
         // avoid traversing nested reactions: check whether this subtree is a Reaction() value

--- a/joinrun/src/main/scala/code/chymyst/jc/ReactionSite.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/ReactionSite.scala
@@ -262,8 +262,10 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
     isAllowedToEmit = reactionInfoOpt.exists(_.inputMoleculesSet.contains(m))
     _ <- if (!isAllowedToEmit) {
       val refusalReason = reactionInfoOpt match {
-        case Some(`emptyReactionInfo`) | None => "because this thread does not run a chemical reaction"
-        case Some(info) => s"because this reaction {$info} does not consume it"
+        case Some(`emptyReactionInfo`) | None =>
+          "because this thread does not run a chemical reaction"
+        case Some(info) =>
+          s"because this reaction {$info} does not consume it"
       }
       Left(refusalReason)
     } else Right(())
@@ -338,8 +340,10 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
   private[jc] def emitAndAwaitReply[T, R](bm: B[T, R], v: T, replyValueWrapper: AbsReplyValue[T, R]): R = {
     // check if we had any errors, and that we have a result value
     emitAndAwaitReplyInternal(timeoutOpt = None, bm, v, replyValueWrapper) match {
-      case ErrorNoReply(message) => throw new Exception(message)
-      case HaveReply(res) => res.asInstanceOf[R] // Cannot guarantee type safety due to type erasure of `R`.
+      case ErrorNoReply(message) =>
+        throw new Exception(message)
+      case HaveReply(res) =>
+        res.asInstanceOf[R] // Cannot guarantee type safety due to type erasure of `R`.
     }
   }
 
@@ -348,7 +352,8 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
   Option[R] = {
     // check if we had any errors, and that we have a result value
     emitAndAwaitReplyInternal(timeoutOpt = Some(timeout), bm, v, replyValueWrapper) match {
-      case ErrorNoReply(message) => throw new Exception(message)
+      case ErrorNoReply(message) =>
+        throw new Exception(message)
       case HaveReply(res) =>
         if (replyValueWrapper.isTimedOut)
           None

--- a/joinrun/src/main/scala/code/chymyst/jc/StaticAnalysis.scala
+++ b/joinrun/src/main/scala/code/chymyst/jc/StaticAnalysis.scala
@@ -43,8 +43,8 @@ private[jc] object StaticAnalysis {
     }.nonEmpty
   }
 
-  private def inputMatchersAreWeakerThanOutput(input: List[InputMoleculeInfo], output: Array[OutputMoleculeInfo]): Boolean =
-    inputMatchersWeakerThanOutput((inputInfo, outputInfo) => inputInfo.matcherIsWeakerThanOutput(outputInfo))(input, output)
+  private def inputMatchersSurelyWeakerThanOutput(input: List[InputMoleculeInfo], output: Array[OutputMoleculeInfo]): Boolean =
+    inputMatchersWeakerThanOutput((inputInfo, outputInfo) => inputInfo.matcherIsWeakerThanOutput(outputInfo))(input, output.filter(_.atLeastOnce))
 
   private def inputMatchersAreSimilarToOutput(input: List[InputMoleculeInfo], output: Array[OutputMoleculeInfo]): Boolean =
     inputMatchersWeakerThanOutput((inputInfo, outputInfo) => inputInfo.matcherIsSimilarToOutput(outputInfo))(input, output)
@@ -81,7 +81,7 @@ private[jc] object StaticAnalysis {
 
   private def checkSingleReactionLivelock(reactions: Seq[Reaction]): Option[String] = {
     val errorList = reactions
-      .filter { r => r.info.guardPresence.effectivelyAbsent && inputMatchersAreWeakerThanOutput(r.info.inputsSorted, r.info.outputs) }
+      .filter { r => r.info.guardPresence.effectivelyAbsent && inputMatchersSurelyWeakerThanOutput(r.info.inputsSorted, r.info.shrunkOutputs) }
       .map(r => s"{${r.info.toString}}")
     if (errorList.nonEmpty)
       Some(s"Unavoidable livelock: reaction${if (errorList.size == 1) "" else "s"} ${errorList.mkString(", ")}")

--- a/joinrun/src/test/scala/code/chymyst/jc/CoreSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/CoreSpec.scala
@@ -74,15 +74,21 @@ class CoreSpec extends FlatSpec with Matchers with TimeLimitedTests {
     notLazy shouldEqual false
   }
 
+  it should "support findAfterMap for Seq" in {
+    Seq(1, 2, 3).findAfterMap(x => if (x % 2 == 0) Some(x) else None) shouldEqual Some(2)
+    Seq(1, 2, 3).findAfterMap(x => if (x % 2 != 0) Some(x) else None) shouldEqual Some(1)
+    Seq(1, 2, 3).findAfterMap(x => if (x == 0) Some(x) else None) shouldEqual None
+  }
+
   it should "support flatFoldLeft for Seq" in {
     Seq(1, 2, 3).flatFoldLeft(0)((x, n) => if (n != 0) Some(x + n) else None) shouldEqual Some(6)
     Seq(1, 2, 3).flatFoldLeft(0)((x, n) => if (n % 2 != 0) Some(x + n) else None) shouldEqual None
   }
 
-  it should "support findAfterMap for Seq" in {
-    Seq(1, 2, 3).findAfterMap(x => if (x % 2 == 0) Some(x) else None) shouldEqual Some(2)
-    Seq(1, 2, 3).findAfterMap(x => if (x % 2 != 0) Some(x) else None) shouldEqual Some(1)
-    Seq(1, 2, 3).findAfterMap(x => if (x == 0) Some(x) else None) shouldEqual None
+  it should "support earlyFoldLeft for Seq" in {
+    Seq(1, 2, 3).earlyFoldLeft(0)((x, n) => if (n != 0) Some(x + n) else None) shouldEqual 6
+    Seq(1, 2, 3).earlyFoldLeft(0)((x, n) => if (n == 0) Some(x + n) else None) shouldEqual 0
+    Seq(1, 2, 3).earlyFoldLeft(0)((x, n) => if (n % 2 != 0) Some(x + n) else None) shouldEqual 1
   }
 
   behavior of "cleanup utility"

--- a/joinrun/src/test/scala/code/chymyst/jc/GuardsSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/GuardsSpec.scala
@@ -6,6 +6,15 @@ class GuardsSpec extends FlatSpec with Matchers {
 
   behavior of "miscellaneous"
 
+  it should "detect molecules emitted in foreach blocks with short apply syntax" in {
+    val a = m[Int]
+    val c = m[Int]
+
+    val r = go { case a(x) => if (x > 0) (1 to 10).foreach(c) }
+
+    r.info.outputs(0).environments should matchPattern { case List(ChooserBlock(_, 0), FuncBlock(_, "foreach")) => }
+  }
+
   it should "correctly recognize constants of various kinds" in {
     val a = m[Either[Int, String]]
     val bb = m[scala.Symbol]

--- a/joinrun/src/test/scala/code/chymyst/jc/GuardsSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/GuardsSpec.scala
@@ -6,15 +6,6 @@ class GuardsSpec extends FlatSpec with Matchers {
 
   behavior of "miscellaneous"
 
-  it should "detect molecules emitted in foreach blocks with short apply syntax" in {
-    val a = m[Int]
-    val c = m[Int]
-
-    val r = go { case a(x) => if (x > 0) (1 to 10).foreach(c) }
-
-    r.info.outputs(0).environments should matchPattern { case List(ChooserBlock(_, 0), FuncBlock(_, "foreach")) => }
-  }
-
   it should "correctly recognize constants of various kinds" in {
     val a = m[Either[Int, String]]
     val bb = m[scala.Symbol]

--- a/joinrun/src/test/scala/code/chymyst/jc/GuardsSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/GuardsSpec.scala
@@ -4,7 +4,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class GuardsSpec extends FlatSpec with Matchers {
 
-  behavior of "guard conditions"
+  behavior of "miscellaneous"
 
   it should "correctly recognize constants of various kinds" in {
     val a = m[Either[Int, String]]
@@ -27,8 +27,9 @@ class GuardsSpec extends FlatSpec with Matchers {
       InputMoleculeInfo(`a`, 5, SimpleConst(Right("input")), _)
       ) =>
     }
-
   }
+
+  behavior of "guard conditions"
 
   it should "correctly recognize a trivial true guard condition" in {
     val a = m[Either[Int, String]]

--- a/joinrun/src/test/scala/code/chymyst/jc/MacroErrorSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/MacroErrorSpec.scala
@@ -13,13 +13,19 @@ class MacroErrorSpec extends FlatSpec with Matchers {
     "val r = go { case _ => }" shouldNot compile
   }
 
-  it should "fail to compile a guard that replies" in {
+  it should "fail to compile a guard that replies to molecules" in {
     val f = b[Unit, Unit]
     val x = 2
     x shouldEqual 2
     f.isInstanceOf[B[Unit, Unit]] shouldEqual true
 
     "val r = go { case f(_, r) if r() && x == 2 => }" shouldNot compile
+  }
+
+  it should "fail to compile a guard that emits molecules" in {
+    val f = b[Unit, Boolean]
+    f.isInstanceOf[B[Unit, Boolean]] shouldEqual true
+    "val r = go { case f(_, r) if f() => r(true) }" shouldNot compile
   }
 
   it should "fail to compile a reaction that is not defined inline" in {

--- a/joinrun/src/test/scala/code/chymyst/jc/MacrosSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/MacrosSpec.scala
@@ -698,6 +698,17 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     r.info.outputs(2).environments shouldEqual List()
   }
 
+  it should "detect molecules emitted in custom apply()" in {
+    val a = m[Int]
+    val c = b[Int, Int]
+
+    val r = go { case a(x) => FuncLambda(c(x)) }
+
+    r.info.outputs(0).environments should matchPattern {
+      case List(FuncBlock(1, "code.chymyst.jc.FuncLambda.apply")) =>
+    }
+  }
+
   it should "detect molecules emitted in user-defined methods" in {
     val a = m[Int]
     val c = b[Int, Int]

--- a/joinrun/src/test/scala/code/chymyst/jc/MacrosSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/MacrosSpec.scala
@@ -635,7 +635,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     val a = m[Int]
     val c = m[Unit]
     val d = m[Unit]
-    val r = go { case a(x) => if (x > 0) c() else d(); if (x<0) c() else d() }
+    val r = go { case a(x) => if (x > 0) c() else d(); if (x < 0) c() else d() }
 
     r.info.outputs(0).environments should matchPattern { case List(ChooserBlock(2, 0)) => }
     r.info.outputs(1).environments should matchPattern { case List(ChooserBlock(2, 1)) => }
@@ -660,7 +660,9 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
 
     val r = go { case a(x) => if (x > 0) (1 to 10).foreach(c) }
 
-    r.info.outputs(0).environments should matchPattern { case List(ChooserBlock(_, 0), FuncBlock(_, "foreach")) => }
+    r.info.outputs(0).environments should matchPattern {
+      case List(ChooserBlock(2, 0), FuncBlock(5, "scala.collection.immutable.Range.foreach")) =>
+    }
   }
 
   it should "detect molecules emitted in map blocks" in {
@@ -724,7 +726,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
       }
     }
 
-    r.info.outputs(0).environments should matchPattern { case List(ChooserBlock(2, 0), ChooserBlock(4, 0)) => }
+    r.info.outputs(0).environments should matchPattern { case List(ChooserBlock(2, 0), AtLeastOneEmitted(3, "condition of while")) => }
   }
 
   it should "detect molecules emitted in do-while loops" in {

--- a/joinrun/src/test/scala/code/chymyst/jc/MacrosSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/MacrosSpec.scala
@@ -676,6 +676,17 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     }
   }
 
+  it should "detect molecules emitted in map blocks with short syntax" in {
+    val a = m[Int]
+    val c = b[Int, Int]
+
+    val r = go { case a(x) => (1 to 10).map(c).sum }
+
+    r.info.outputs(0).environments should matchPattern {
+      case List(FuncBlock(3, "scala.collection.TraversableLike.map")) =>
+    }
+  }
+
   it should "detect molecules emitted in arguments of other molecules" in {
     val a = m[Int]
     val c = b[Int, Int]

--- a/joinrun/src/test/scala/code/chymyst/jc/MacrosSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/MacrosSpec.scala
@@ -268,7 +268,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     }) shouldEqual true
     result.info.outputs should matchPattern { case Array(
     OutputMoleculeInfo(`a`, OtherOutputPattern, List()),
-    OutputMoleculeInfo(`a`, OtherOutputPattern, List(ChooserBlock(_, 0))),
+    OutputMoleculeInfo(`a`, OtherOutputPattern, List(ChooserBlock(_, 0, 2))),
     OutputMoleculeInfo(`qqq`, SimpleConstOutput(""), List())
     ) =>
     }
@@ -627,8 +627,8 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     val d = m[Unit]
     val r = go { case a(x) => if (x > 0) c() else d() }
 
-    r.info.outputs(0).environments should matchPattern { case List(ChooserBlock(_, 0)) => }
-    r.info.outputs(1).environments should matchPattern { case List(ChooserBlock(_, 1)) => }
+    r.info.outputs(0).environments should matchPattern { case List(ChooserBlock(_, 0, 2)) => }
+    r.info.outputs(1).environments should matchPattern { case List(ChooserBlock(_, 1, 2)) => }
   }
 
   it should "detect molecules emitted in several if-then-else blocks" in {
@@ -637,10 +637,10 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     val d = m[Unit]
     val r = go { case a(x) => if (x > 0) c() else d(); if (x < 0) c() else d() }
 
-    r.info.outputs(0).environments should matchPattern { case List(ChooserBlock(2, 0)) => }
-    r.info.outputs(1).environments should matchPattern { case List(ChooserBlock(2, 1)) => }
-    r.info.outputs(2).environments should matchPattern { case List(ChooserBlock(4, 0)) => }
-    r.info.outputs(3).environments should matchPattern { case List(ChooserBlock(4, 1)) => }
+    r.info.outputs(0).environments should matchPattern { case List(ChooserBlock(2, 0, 2)) => }
+    r.info.outputs(1).environments should matchPattern { case List(ChooserBlock(2, 1, 2)) => }
+    r.info.outputs(2).environments should matchPattern { case List(ChooserBlock(4, 0, 2)) => }
+    r.info.outputs(3).environments should matchPattern { case List(ChooserBlock(4, 1, 2)) => }
   }
 
   it should "detect molecules emitted in foreach blocks" in {
@@ -650,7 +650,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     val r = go { case a(x) => if (x > 0) (1 to 10).foreach(i => c(i)) }
 
     r.info.outputs(0).environments should matchPattern {
-      case List(ChooserBlock(2, 0), FuncBlock(5, "scala.collection.immutable.Range.foreach"), FuncLambda(6)) =>
+      case List(ChooserBlock(2, 0, 2), FuncBlock(5, "scala.collection.immutable.Range.foreach"), FuncLambda(6)) =>
     }
   }
 
@@ -661,7 +661,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     val r = go { case a(x) => if (x > 0) (1 to 10).foreach(c) }
 
     r.info.outputs(0).environments should matchPattern {
-      case List(ChooserBlock(2, 0), FuncBlock(5, "scala.collection.immutable.Range.foreach")) =>
+      case List(ChooserBlock(2, 0, 2), FuncBlock(5, "scala.collection.immutable.Range.foreach")) =>
     }
   }
 
@@ -672,7 +672,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     val r = go { case a(x) => if (x > 0) (1 to 10).map(i => c(i)) }
 
     r.info.outputs(0).environments should matchPattern {
-      case List(ChooserBlock(2, 0), FuncBlock(5, "scala.collection.TraversableLike.map"), FuncLambda(6)) =>
+      case List(ChooserBlock(2, 0, 2), FuncBlock(5, "scala.collection.TraversableLike.map"), FuncLambda(6)) =>
     }
   }
 
@@ -693,8 +693,8 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
 
     val r = go { case a(x) => c(if (x > 0) c(x) else c(x + 1)) }
 
-    r.info.outputs(0).environments shouldEqual List(ChooserBlock(2, 0))
-    r.info.outputs(1).environments shouldEqual List(ChooserBlock(2, 1))
+    r.info.outputs(0).environments shouldEqual List(ChooserBlock(2, 0, 2))
+    r.info.outputs(1).environments shouldEqual List(ChooserBlock(2, 1, 2))
     r.info.outputs(2).environments shouldEqual List()
   }
 
@@ -718,7 +718,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     val r = go { case a(x) => c(if (x > 0) f(c(x)) else c(x)) }
 
     r.info.outputs(0).environments should matchPattern {
-      case List(ChooserBlock(2, 0), FuncBlock(3, "code.chymyst.jc.MacrosSpec.f")) =>
+      case List(ChooserBlock(2, 0, 2), FuncBlock(3, "code.chymyst.jc.MacrosSpec.f")) =>
     }
   }
 
@@ -734,7 +734,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     }
 
     r.info.outputs(0).environments should matchPattern {
-      case List(ChooserBlock(3, 0), FuncBlock(4, "code.chymyst.jc.MacrosSpec.$anonfun.f")) =>
+      case List(ChooserBlock(3, 0, 2), FuncBlock(4, "code.chymyst.jc.MacrosSpec.$anonfun.f")) =>
     }
   }
 
@@ -748,7 +748,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
       }
     }
 
-    r.info.outputs(0).environments should matchPattern { case List(ChooserBlock(2, 0), AtLeastOneEmitted(3, "condition of while")) => }
+    r.info.outputs(0).environments should matchPattern { case List(ChooserBlock(2, 0, 2), AtLeastOneEmitted(3, "condition of while")) => }
   }
 
   it should "detect molecules emitted in do-while loops" in {
@@ -761,7 +761,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
       } while (x > 0)
     }
 
-    r.info.outputs(0).environments should matchPattern { case List(ChooserBlock(2, 0), AtLeastOneEmitted(_, "do while")) => }
+    r.info.outputs(0).environments should matchPattern { case List(ChooserBlock(2, 0, 2), AtLeastOneEmitted(_, "do while")) => }
   }
 
   it should "detect molecules emitted in match-case blocks with nested if-then-else" in {
@@ -777,13 +777,13 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
       }
     }
 
-    r.info.outputs(0).environments should matchPattern { case List(ChooserBlock(1, 0)) => }
-    r.info.outputs(1).environments should matchPattern { case List(ChooserBlock(1, 0), ChooserBlock(3, 0)) => }
-    r.info.outputs(2).environments should matchPattern { case List(ChooserBlock(1, 1)) => }
-    r.info.outputs(3).environments should matchPattern { case List(ChooserBlock(1, 2)) => }
-    r.info.outputs(4).environments should matchPattern { case List(ChooserBlock(1, 2), ChooserBlock(5, 0)) => }
+    r.info.outputs(0).environments should matchPattern { case List(ChooserBlock(1, 0, 3)) => }
+    r.info.outputs(1).environments should matchPattern { case List(ChooserBlock(1, 0, 3), ChooserBlock(3, 0, 2)) => }
+    r.info.outputs(2).environments should matchPattern { case List(ChooserBlock(1, 1, 3)) => }
+    r.info.outputs(3).environments should matchPattern { case List(ChooserBlock(1, 2, 3)) => }
+    r.info.outputs(4).environments should matchPattern { case List(ChooserBlock(1, 2, 3), ChooserBlock(5, 0, 2)) => }
     r.info.outputs(5).molecule shouldEqual c
-    r.info.outputs(5).environments should matchPattern { case List(ChooserBlock(1, 2), ChooserBlock(5, 1)) => }
+    r.info.outputs(5).environments should matchPattern { case List(ChooserBlock(1, 2, 3), ChooserBlock(5, 1, 2)) => }
   }
 
   it should "detect molecules emitted in anonymous functions" in {
@@ -805,7 +805,7 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
       }
       pf(0)
     }
-    r.info.outputs(0).environments should matchPattern { case List(FuncLambda(1), ChooserBlock(2, 0)) => }
+    r.info.outputs(0).environments should matchPattern { case List(FuncLambda(1), ChooserBlock(2, 0, 1)) => }
   }
 
   behavior of "output value computation"

--- a/joinrun/src/test/scala/code/chymyst/jc/MacrosSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/jc/MacrosSpec.scala
@@ -100,15 +100,6 @@ class MacrosSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
 
   behavior of "macros for inspecting a reaction body"
 
-  it should "fail to compile a reaction with regrouped inputs" in {
-    val a = m[Unit]
-    a.isInstanceOf[M[Unit]] shouldEqual true
-
-    "val r = go { case a(_) + (a(_) + a(_)) => }" shouldNot compile
-    "val r = go { case a(_) + (a(_) + a(_)) + a(_) => }" shouldNot compile
-    "val r = go { case (a(_) + a(_)) + a(_) + a(_) => }" should compile
-  }
-
   it should "correctly sort input molecules with compound values and Option" in {
     val bb = m[(Int, Option[Int])]
     val reaction = go { case bb((1, Some(2))) + bb((0, None)) => }

--- a/joinrun/src/test/scala/code/chymyst/test/FairnessSpec.scala
+++ b/joinrun/src/test/scala/code/chymyst/test/FairnessSpec.scala
@@ -35,21 +35,20 @@ class FairnessSpec extends FlatSpec with Matchers with TimeLimitedTests {
     val tp1 = new FixedPool(1)
 
     site(tp, tp1)(
-      // The guard `if arr.nonEmpty` is needed to prevent the livelock error.
       go { case getC(_, r) + done(arr) => r(arr) },
-      go { case a0(_) + c((n, arr)) if arr.nonEmpty => if (n > 0) {
+      go { case a0(_) + c((n, arr)) => if (n > 0) {
         arr(0) += 1; c((n - 1, arr)) + a0()
       } else done(arr)
       },
-      go { case a1(_) + c((n, arr)) if arr.nonEmpty => if (n > 0) {
+      go { case a1(_) + c((n, arr)) => if (n > 0) {
         arr(1) += 1; c((n - 1, arr)) + a1()
       } else done(arr)
       },
-      go { case a2(_) + c((n, arr)) if arr.nonEmpty => if (n > 0) {
+      go { case a2(_) + c((n, arr)) => if (n > 0) {
         arr(2) += 1; c((n - 1, arr)) + a2()
       } else done(arr)
       },
-      go { case a3(_) + c((n, arr)) if arr.nonEmpty => if (n > 0) {
+      go { case a3(_) + c((n, arr)) => if (n > 0) {
         arr(3) += 1; c((n - 1, arr)) + a3()
       } else done(arr)
       }


### PR DESCRIPTION
Various improvements in macro support.

- Prevent users from writing `go { case x@a(y) => ...}`.
- Detect whether molecules are emitted under an `if` expression.
- Return to the old code for `FairnessSpec` and `MergesortSpec` where now we have more intelligent livelock checks.
- Improve test code coverage.
- Start on the "shrinkage" algorithm for analyzing the conditional structure of reactions. Implemented only 1-level `ChooserBlock` for now, which is enough for  `FairnessSpec` and `MergesortSpec` .