### PR TITLE
hiding reaction sites from reflection

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,2 @@
 ignore:
-  - "benchmark/src/main/scala" # ignore benchmark application for coverage analysis (but include the tests)
-  - "helloworld" # ignore helloworld application entirely for coverage analysis
+  - "benchmark/src" # ignore benchmarks for coverage analysis

--- a/README.md
+++ b/README.md
@@ -418,14 +418,10 @@ User code should depend on that JAR only.
 
 # Use `Chymyst Core` in your programs
 
-At the moment `Chymyst Core` is published to Sonatype.
-So, you will need to add this to your `build.sbt` at the appropriate places:
+`Chymyst Core` is published to Maven Central.
+Add this to your `build.sbt` at the appropriate place:
 
 ```scala
-resolvers ++= Seq(
-  Resolver.sonatypeRepo("releases")
-)
-
 libraryDependencies ++= Seq(
   "io.chymyst" %% "core" % "latest.integration"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,7 @@ val commonSettings = Defaults.coreDefaultSettings ++ Seq(
   ),
   licenses := Seq("Apache License, Version 2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt")),
   homepage := Some(url("https://chymyst.github.io/joinrun-scala/")),
+  description := "Declarative concurrency framework for Scala - the core library implementing the chemical machine / join calculus",
 //  scmInfo := Some(ScmInfo(url("git@github.com:Chymyst/joinrun-scala.git"), "scm:git:git@github.com:Chymyst/joinrun-scala.git", None)),
 //  developers := List(Developer(id = "winitzki", name = "Sergei Winitzki", email = "swinitzk@hotmail.com", url("https://sites.google.com/site/winitzki"))),
 
@@ -82,7 +83,7 @@ lazy val buildAll = (project in file("."))
 lazy val core = (project in file("core"))
   .settings(commonSettings: _*)
   .settings(
-    name := "core",
+    name := "chymyst-core",
     wartremoverWarnings in(Compile, compile) ++= warningsForWartRemover,
     wartremoverErrors in(Compile, compile) ++= errorsForWartRemover,
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ $ sbt
 
 val commonSettings = Defaults.coreDefaultSettings ++ Seq(
   organization := "io.chymyst",
-  version := "0.1.7",
+  version := "0.1.8-SNAPSHOT",
   scalaVersion := "2.11.8",
   crossScalaVersions := Seq("2.11.8", "2.12.1"),
   resolvers ++= Seq(

--- a/core/src/main/scala/io/chymyst/jc/Molecules.scala
+++ b/core/src/main/scala/io/chymyst/jc/Molecules.scala
@@ -95,15 +95,14 @@ sealed trait Molecule extends PersistentHashCode {
     *
     * @param rs A reaction site.
     * @return `None` if the molecule is not bound to any reaction site, or if it is bound to `rs`.
-    *         If the molecule is already bound to a reaction site different from `rs`, return
+    *         Otherwise the molecule is already bound to a reaction site different from `rs`, so return
     *         the string representation of that reaction site as a non-empty option.
     */
-  final private[jc] def isBoundToAnother(rs: ReactionSite): Option[String] = if (isBound) {
-    if (reactionSiteWrapper.sameReactionSite(rs))
-      None
-    else
-      Some(reactionSiteWrapper.toString)
-  } else None
+  final private[jc] def isBoundToAnother(rs: ReactionSite): Option[String] =
+  if (isBound && !reactionSiteWrapper.sameReactionSite(rs))
+    Some(reactionSiteWrapper.toString)
+  else
+    None
 
   protected var reactionSiteWrapper: ReactionSiteWrapper[_, _] = ReactionSiteWrapper.noReactionSite(this)
 

--- a/core/src/main/scala/io/chymyst/jc/Molecules.scala
+++ b/core/src/main/scala/io/chymyst/jc/Molecules.scala
@@ -82,10 +82,7 @@ sealed trait Molecule extends PersistentHashCode {
 
   override def toString: String = (if (name.isEmpty) "<no name>" else name) + (if (isBlocking) "/B" else "")
 
-  final private[jc] def setReactionSite(rs: ReactionSite): Unit = {
-    hasReactionSite = true
-    reactionSiteWrapper = rs.newWrapper(this)
-  }
+  private[jc] def setReactionSite(rs: ReactionSite): Unit
 
   /** Check whether the molecule is already bound to a reaction site.
     * Note that molecules can be emitted only if they are bound.
@@ -94,28 +91,35 @@ sealed trait Molecule extends PersistentHashCode {
     */
   final def isBound: Boolean = hasReactionSite
 
-  // This is @volatile because the reaction site will assign this variable possibly from another thread.
-  private var reactionSiteWrapper: ReactionSite = _
-
-  private var hasReactionSite: Boolean = false
-
-  /** A shorthand method to get the reaction site to which this molecule is bound.
-    * This method should be used only when we are sure that the molecule is already bound.
+  /** Check whether this molecule is already bound to a reaction site that's different from the given reaction site.
     *
-    * @return The reaction site to which the molecule is bound. If not yet bound, throws an exception.
+    * @param rs A reaction site.
+    * @return `None` if the molecule is not bound to any reaction site, or if it is bound to `rs`.
+    *         If the molecule is already bound to a reaction site different from `rs`, return
+    *         the string representation of that reaction site as a non-empty option.
     */
-  final private[jc] def site: ReactionSite =
-    reactionSiteOpt.getOrElse(throw new ExceptionNoReactionSite(s"Molecule $this is not bound to any reaction site"))
+  final private[jc] def isBoundToAnother(rs: ReactionSite): Option[String] = if (isBound) {
+    if (reactionSiteWrapper.sameReactionSite(rs))
+      None
+    else
+      Some(reactionSiteWrapper.toString)
+  } else None
+
+  protected var reactionSiteWrapper: ReactionSiteWrapper[_, _] = ReactionSiteWrapper.noReactionSite(this)
+
+  protected var hasReactionSite: Boolean = false
 
   /** The set of reactions that can consume this molecule.
     *
     * @return `None` if the molecule emitter is not yet bound to any reaction site.
     */
-  final private[jc] def consumingReactions: Option[List[Reaction]] =
-    reactionSiteOpt.map(_ => consumingReactionsSet)
+  final private[jc] def consumingReactions: Option[List[Reaction]] = if (isBound)
+    Some(reactionSiteWrapper.consumingReactions)
+  else None
 
-  final private[jc] lazy val consumingReactionsSet: List[Reaction] =
-    reactionSiteOpt.get.reactionInfos.keys.filter(_.inputMoleculesSet contains this).toList
+  // Not using this now?
+  // TODO remove
+  //    throw new ExceptionNoReactionSite(s"Molecule $this is not bound to any reaction site")
 
   /** The set of all reactions that *potentially* emit this molecule as output.
     * Some of these reactions may evaluate a runtime condition to decide whether to emit the molecule; so emission is not guaranteed.
@@ -135,10 +139,9 @@ sealed trait Molecule extends PersistentHashCode {
     ()
   }
 
-  final def setLogLevel(logLevel: Int): Unit =
-    site.logLevel = logLevel
+  final def setLogLevel(logLevel: Int): Unit = reactionSiteWrapper.setLogLevel(logLevel)
 
-  final def logSoup: String = site.printBag
+  final def logSoup: String = reactionSiteWrapper.logSoup()
 
   val isBlocking: Boolean
 
@@ -163,7 +166,7 @@ final class M[T](val name: String) extends (T => Unit) with Molecule {
     *
     * @param v Value to be put onto the emitted molecule.
     */
-  def apply(v: T): Unit = site.emit[T](this, MolValue(v))
+  def apply(v: T): Unit = reactionSiteWrapper.asInstanceOf[ReactionSiteWrapper[T, Unit]].emit(this, MolValue(v))
 
   def apply()(implicit ev: TypeIsUnit[T]): Unit = apply(ev.getUnit)
 
@@ -172,22 +175,25 @@ final class M[T](val name: String) extends (T => Unit) with Molecule {
     *
     * @return The value carried by the singleton when it was last emitted. Will throw exception if the singleton has not yet been emitted.
     */
-  def volatileValue: T = reactionSiteOpt match {
-    case Some(reactionSite) =>
-      if (isSingleton)
-        volatileValueContainer
-      else throw new Exception(s"In $reactionSite: volatile reader requested for non-singleton ($this)")
-
-    case None => throw new Exception("Molecule c is not bound to any reaction site")
+  def volatileValue: T = if (isBound) {
+    if (isSingleton)
+      volatileValueContainer
+    else throw new Exception(s"In $reactionSiteWrapper: volatile reader requested for non-singleton ($this)")
   }
+  else throw new Exception("Molecule c is not bound to any reaction site")
 
   private[jc] def assignSingletonVolatileValue(molValue: AbsMolValue[_]) =
     volatileValueContainer = molValue.asInstanceOf[MolValue[T]].getValue
 
   @volatile private var volatileValueContainer: T = _
 
-  override lazy val isSingleton: Boolean =
-    reactionSiteOpt.exists(_.singletonsDeclared.contains(this))
+  override lazy val isSingleton: Boolean = isBound &&
+    reactionSiteWrapper.singletonsDeclared.contains(this)
+
+  override private[jc] def setReactionSite(rs: ReactionSite): Unit = {
+    hasReactionSite = true
+    reactionSiteWrapper = rs.makeWrapper[T, Unit](this)
+  }
 
 }
 
@@ -364,8 +370,8 @@ final class B[T, R](val name: String) extends (T => R) with Molecule {
     * @param v        Value to be put onto the emitted molecule.
     * @return Non-empty option if the reply was received; None on timeout.
     */
-  def timeout(v: T)(duration: Duration): Option[R] =
-    site.emitAndAwaitReplyWithTimeout[T, R](duration.toNanos, this, v, new ReplyValue[T, R])
+  def timeout(v: T)(duration: Duration): Option[R] = reactionSiteWrapper.asInstanceOf[ReactionSiteWrapper[T, R]]
+    .emitAndAwaitReplyWithTimeout(duration.toNanos, this, v, new ReplyValue[T, R])
 
   /** Same but for molecules with type `T = Unit`, with shorter syntax. */
   def timeout()(duration: Duration)(implicit ev: TypeIsUnit[T]): Option[R] = timeout(ev.getUnit)(duration)
@@ -376,19 +382,26 @@ final class B[T, R](val name: String) extends (T => R) with Molecule {
     * @return None if there was no match; Some(...) if the reaction inputs matched.
     */
   def unapply(arg: InputMoleculeList): Option[(T, ReplyValue[T, R])] =
-    arg.headOption
-      .map(_._2.asInstanceOf[BlockingMolValue[T, R]])
-      .map { bmv => (bmv.v, bmv.replyValue.asInstanceOf[ReplyValue[T, R]]) }
+  arg.headOption
+    .map(_._2.asInstanceOf[BlockingMolValue[T, R]])
+    .map { bmv => (bmv.v, bmv.replyValue.asInstanceOf[ReplyValue[T, R]]) }
 
   /** Emit a blocking molecule and receive a value when the reply action is performed.
     *
     * @param v Value to be put onto the emitted molecule.
     * @return The "reply" value.
     */
-  def apply(v: T): R = site.emitAndAwaitReply[T, R](this, v, new ReplyValue[T, R])
+  def apply(v: T): R = reactionSiteWrapper.asInstanceOf[ReactionSiteWrapper[T, R]]
+    .emitAndAwaitReply(this, v, new ReplyValue[T, R])
 
   /** This enables the short syntax `b()` and will only work when `T == Unit`. */
   def apply()(implicit ev: TypeIsUnit[T]): R = apply(ev.getUnit)
+
+  override private[jc] def setReactionSite(rs: ReactionSite): Unit = {
+    hasReactionSite = true
+    reactionSiteWrapper = rs.makeWrapper[T, R](this)
+  }
+
 }
 
 /** Mix this trait into your class to make the has code persistent after the first time it's computed.

--- a/core/src/main/scala/io/chymyst/jc/Molecules.scala
+++ b/core/src/main/scala/io/chymyst/jc/Molecules.scala
@@ -87,10 +87,12 @@ sealed trait Molecule extends PersistentHashCode {
     *
     * @return True if already bound, false otherwise.
     */
-  final def isBound: Boolean = reactionSiteOpt.nonEmpty
+  final def isBound: Boolean = isBoundBoolean
 
   // This is @volatile because the reaction site will assign this variable possibly from another thread.
   @volatile private[jc] var reactionSiteOpt: Option[ReactionSite] = None
+
+  @volatile private[jc] var isBoundBoolean: Boolean = false
 
   /** A shorthand method to get the reaction site to which this molecule is bound.
     * This method should be used only when we are sure that the molecule is already bound.

--- a/core/src/main/scala/io/chymyst/jc/ReactionMacros.scala
+++ b/core/src/main/scala/io/chymyst/jc/ReactionMacros.scala
@@ -704,7 +704,7 @@ class ReactionMacros(override val c: blackbox.Context) extends CommonMacros(c) {
     * @param patternWhat What was incorrect about the molecule usage.
     * @param molecules   List of molecules (or other objects) that were incorrectly used.
     * @param connector   Phrase connector. By default: `"not contain a pattern that"`.
-    * @param method      How to report the error; by default, will use {{{c.error}}}.
+    * @param method      How to report the error; by default, will use `c.error`.
     * @tparam T Type of molecule or other object.
     */
   def maybeError[T](what: String, patternWhat: String, molecules: Seq[T], connector: String = "not contain a pattern that", method: (c.Position, String) => Unit = c.error): Unit = {

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,6 +1,7 @@
 // Following instructions from https://github.com/xerial/sbt-sonatype
 // see https://issues.sonatype.org/browse/OSSRH-27720
 pomExtra in Global :=
+    <inceptionYear>2016</inceptionYear>
     <scm>
       <url>git@github.com:Chymyst/joinrun-scala.git</url>
       <connection>scm:git:git@github.com:Chymyst/joinrun-scala.git</connection>


### PR DESCRIPTION
At the moment, molecule emitters have methods such as `reactionSiteOpt`, which are private but still amenable to reflection.

Instead of this and other semi-private methods, use mutable functions to assign closures, so that the reaction site value is closed over and impossible to access via run-time reflection.