### PR TITLE
WIP Feature/granular reactions

### DIFF
--- a/benchmark/src/main/scala/io/chymyst/benchmark/Benchmarks1.scala
+++ b/benchmark/src/main/scala/io/chymyst/benchmark/Benchmarks1.scala
@@ -35,7 +35,7 @@ object Benchmarks1 {
     }.get
   }
 
-  def make_counter2a(init: Int): (AsyName[Unit],AsyName[Unit],SynName[LocalDateTime, Long],SynName[Unit,Int]) = {
+  def make_counterJoinScala(init: Int): (AsyName[Unit],AsyName[Unit],SynName[LocalDateTime, Long],SynName[Unit,Int]) = {
     object j2 extends Join {
       object c extends AsyName[Int]
       object g extends SynName[Unit, Int]
@@ -57,7 +57,7 @@ object Benchmarks1 {
     (j2.d,j2.i,j2.f,j2.g)
   }
 
-  def make_counter(init: Int, tp: Pool) = {
+  def make_counterChymyst(init: Int, tp: Pool) = {
     val c = m[Int]
     val g = b[Unit,Int]
     val i = m[Unit]
@@ -66,9 +66,9 @@ object Benchmarks1 {
 
     site(tp)(
       go { case c(0) + f(tInit, r) => r(elapsed(tInit)) },
-      go { case g(_,reply) + c(n) => c(n); reply(n) },
-      go { case c(n) + i(_) => c(n+1) },
-      go { case c(n) + d(_) if n > 0 => c(n-1) }
+      go { case g(_, reply) + c(n) => c(n); reply(n) },
+      go { case c(n) + i(_) => c(n + 1) },
+      go { case c(n) + d(_) if n > 0 => c(n - 1) }
     )
 
     c(init)
@@ -104,7 +104,7 @@ object Benchmarks1 {
 
     val initialTime = LocalDateTime.now
 
-    val (d,_,f,_) = make_counter2a(count)
+    val (d,_,f,_) = make_counterJoinScala(count)
     (1 to count).foreach{ _ => d(()) }
     f(initialTime)
   }
@@ -113,7 +113,7 @@ object Benchmarks1 {
 
     val initialTime = LocalDateTime.now
 
-    val (d,_,f,_) = make_counter(count, tp)
+    val (d,_,f,_) = make_counterChymyst(count, tp)
     (1 to count).foreach{ _ => d() }
 
     f(initialTime)

--- a/benchmark/src/main/scala/io/chymyst/benchmark/Benchmarks11.scala
+++ b/benchmark/src/main/scala/io/chymyst/benchmark/Benchmarks11.scala
@@ -1,33 +1,48 @@
 package io.chymyst.benchmark
 
-import io.chymyst.benchmark.Common._
 import io.chymyst.jc._
-
+import Common._
+import MergeSort._
 
 object Benchmarks11 {
+  val counterMultiplier = 5
+
   def benchmark11(count: Int, tp: Pool): Long = timeThis {
-    val c = m[(Int, Int)]
-    val done = m[Int]
-    val f = b[Unit, Int]
-
-    val total = count * Benchmarks9.counterMultiplier
-
     val tp1 = new FixedPool(5)
+    (1 to counterMultiplier).foreach { _ ⇒
+      val c = m[(Int, Int)]
+      val done = m[Int]
+      val f = b[Unit, Int]
 
-    site(tp, tp1)(
-      go { case f(_, r) + done(x) => r(x) },
-      go { case c((n, x)) + c((m, y)) if x <= y =>
-        val p = n + m
-        val z = x + y
-        if (p == total)
-          done(z)
-        else
-          c((n + m, x + y))
-      }
-    )
+      val total = count
 
-    (1 to total).foreach(i => c((1, i * i)))
-    f()
+      site(tp, tp1)(
+        go { case f(_, r) + done(x) => r(x) },
+        go { case c((n, x)) + c((m, y)) if x <= y =>
+          val p = n + m
+          val z = x + y
+          if (p == total)
+            done(z)
+          else
+            c((n + m, x + y))
+        }
+      )
+
+      (1 to total).foreach(i => c((1, i * i)))
+      f()
+    }
     tp1.shutdownNow()
   }
+
+  val mergeSortSize = 1000
+  val mergeSortIterations = 20
+
+  def benchmark12(count: Int, tp: Pool): Long = timeThis {
+
+    (1 to mergeSortIterations).foreach { _ ⇒
+      val arr = Array.fill[Int](mergeSortSize)(scala.util.Random.nextInt(mergeSortSize))
+      performMergeSort(arr, 8)
+    }
+  }
+
 }

--- a/benchmark/src/main/scala/io/chymyst/benchmark/Benchmarks11.scala
+++ b/benchmark/src/main/scala/io/chymyst/benchmark/Benchmarks11.scala
@@ -12,7 +12,7 @@ object Benchmarks11 {
 
     val total = count * Benchmarks9.counterMultiplier
 
-    val tp1 = new FixedPool(1)
+    val tp1 = new FixedPool(5)
 
     site(tp, tp1)(
       go { case f(_, r) + done(x) => r(x) },

--- a/benchmark/src/main/scala/io/chymyst/benchmark/Benchmarks9.scala
+++ b/benchmark/src/main/scala/io/chymyst/benchmark/Benchmarks9.scala
@@ -31,8 +31,9 @@ object Benchmarks9 {
     val all_done = m[Int]
     val f = b[LocalDateTime,Long]
 
+    val tp1 = new FixedPool(8)
 
-    site(tp)(
+    site(tp, tp1)(
       go { case all_done(0) + f(tInit, r) => r(elapsed(tInit)) },
       go { case all_done(x) + done(_) if x > 0 => all_done(x-1) }
     )
@@ -43,7 +44,9 @@ object Benchmarks9 {
     val d = make_counter_1(done, numberOfCounters, count, tp)
     (1 to (count*numberOfCounters)).foreach{ _ => d() }
 
-    f(initialTime)
+    val result = f(initialTime)
+    tp1.shutdownNow()
+    result
   }
 
 

--- a/benchmark/src/main/scala/io/chymyst/benchmark/Benchmarks9.scala
+++ b/benchmark/src/main/scala/io/chymyst/benchmark/Benchmarks9.scala
@@ -37,7 +37,6 @@ object Benchmarks9 {
       go { case all_done(0) + f(tInit, r) => r(elapsed(tInit)) },
       go { case all_done(x) + done(_) if x > 0 => all_done(x-1) }
     )
-    //    done.setLogLevel(2)
     val initialTime = LocalDateTime.now
     all_done(numberOfCounters)
 
@@ -95,7 +94,6 @@ object Benchmarks9 {
       go { case all_done(0) + f(tInit, r) => r(elapsed(tInit)) },
       go { case all_done(x) + done(_) if x > 0 => all_done(x-1) }
     )
-    //    done.setLogLevel(2)
     val initialTime = LocalDateTime.now
     all_done(1)
 

--- a/benchmark/src/main/scala/io/chymyst/benchmark/MainApp.scala
+++ b/benchmark/src/main/scala/io/chymyst/benchmark/MainApp.scala
@@ -18,7 +18,7 @@ object MainApp extends App {
 
   import MainAppConfig._
 
-  val version = "0.1.8-SNAPSHOT"
+  val version = "0.1.9-SNAPSHOT"
 
   def run3times(task: => Long): Long = {
     task

--- a/benchmark/src/main/scala/io/chymyst/benchmark/MainApp.scala
+++ b/benchmark/src/main/scala/io/chymyst/benchmark/MainApp.scala
@@ -55,9 +55,11 @@ object MainApp extends App {
 
     s"${Benchmarks9.pingPongCalls} blocked threads with ping-pong calls" -> benchmark9_2 _,
 
-    s"count to ${counterMultiplier * n} using blocking access with checking reply status" -> benchmark10 _,
+    s"count to ${Benchmarks9.counterMultiplier * n} using blocking access with checking reply status" -> benchmark10 _,
 
-    s"sum an array of size ${counterMultiplier * n} using repeated molecules" -> benchmark11 _
+    s"sum an array of size $n using repeated molecules, ${Benchmarks11.counterMultiplier} times" -> benchmark11 _,
+
+    s"perform merge-sort of size ${Benchmarks11.mergeSortSize}, ${Benchmarks11.mergeSortIterations} times" → benchmark12 _
 
   ).zipWithIndex.foreach {
     case ((message, benchmark), i) => println(s"Benchmark ${i + 1} took ${

--- a/benchmark/src/main/scala/io/chymyst/benchmark/MergeSort.scala
+++ b/benchmark/src/main/scala/io/chymyst/benchmark/MergeSort.scala
@@ -1,0 +1,75 @@
+package io.chymyst.benchmark
+
+import io.chymyst.jc.{+, FixedPool, M, m, B, b, go, Reaction, ReactionInfo, InputMoleculeInfo, AllMatchersAreTrivial, OutputMoleculeInfo, site, EmitMultiple}
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+object MergeSort {
+  type Coll[T] = IndexedSeq[T]
+
+  def arrayMerge[T: Ordering](arr1: Coll[T], arr2: Coll[T]): Coll[T] = {
+    val result = new mutable.ArraySeq[T](arr1.length + arr2.length) // just to allocate space
+
+    def isLess(x: T, y: T) = implicitly[Ordering[T]].compare(x, y) < 0
+
+    // will now modify result
+    @tailrec
+    def mergeRec(i1: Int, i2: Int, i: Int): Unit = {
+      if (i1 == arr1.length && i2 == arr2.length) ()
+      else {
+        val (x, newI1, newI2) = if (i1 < arr1.length && (i2 == arr2.length || isLess(arr1(i1), arr2(i2))))
+          (arr1(i1), i1 + 1, i2) else (arr2(i2), i1, i2 + 1)
+        result(i) = x
+        mergeRec(newI1, newI2, i + 1)
+      }
+    }
+
+    mergeRec(0, 0, 0)
+    result.toIndexedSeq
+  }
+
+  def performMergeSort[T: Ordering](array: Coll[T], threads: Int = 8): Coll[T] = {
+
+    val finalResult = m[Coll[T]]
+    val getFinalResult = b[Unit, Coll[T]]
+    val reactionPool = new FixedPool(threads)
+    val sitePool = new FixedPool(threads)
+
+    site(sitePool, sitePool)(
+      go { case finalResult(arr) + getFinalResult(_, r) => r(arr) }
+    )
+
+    // recursive molecule that will define the reactions at one level lower
+
+    val mergesort = m[(Coll[T], M[Coll[T]])]
+
+    site(reactionPool, sitePool)(
+      go { case mergesort((arr, resultToYield)) =>
+        if (arr.length <= 1) resultToYield(arr)
+        else {
+          val (part1, part2) = arr.splitAt(arr.length / 2)
+          // "sorted1" and "sorted2" will be the sorted results from the lower level
+          val sorted1 = m[Coll[T]]
+          val sorted2 = m[Coll[T]]
+          site(reactionPool, sitePool)(
+            go { case sorted1(x) + sorted2(y) =>
+              resultToYield(arrayMerge(x, y))
+            }
+          )
+          // emit `mergesort` with the lower-level `sorted` result molecules
+          mergesort((part1, sorted1)) + mergesort((part2, sorted2))
+        }
+      }
+    )
+    // sort our array: emit `mergesort` at top level
+    mergesort((array, finalResult))
+    mergesort.setLogLevel(0)
+
+    val result = getFinalResult()
+    reactionPool.shutdownNow()
+    sitePool.shutdownNow()
+    result
+  }
+
+}

--- a/benchmark/src/test/scala/io/chymyst/benchmark/MapReduceSpec.scala
+++ b/benchmark/src/test/scala/io/chymyst/benchmark/MapReduceSpec.scala
@@ -321,7 +321,7 @@ class MapReduceSpec extends FlatSpec with Matchers {
     val done = m[Int]
     val f = b[Unit, Int]
 
-    val count = 20
+    val count = 30
     val nThreadsSite = 1
 
     val tp = new FixedPool(cpuCores)

--- a/benchmark/src/test/scala/io/chymyst/benchmark/MapReduceSpec.scala
+++ b/benchmark/src/test/scala/io/chymyst/benchmark/MapReduceSpec.scala
@@ -67,7 +67,6 @@ class MapReduceSpec extends FlatSpec with Matchers {
       },
       go { case accum((n, b)) + fetch(_, reply) if n == arr.size => reply(b) }
     )
-carrier.setLogLevel(2)
     // emit molecules
     accum((0, 0))
     arr.foreach(i => carrier(i))
@@ -98,7 +97,6 @@ carrier.setLogLevel(2)
     site(tp)(
       go { case carrier(x) => val res = f(x); interm((1, res)) }
     )
- carrier.setLogLevel(2)
     // reactions for "reduce" must be together since they share "accum"
     site(tp)(
       go { case interm((n1, x1)) + interm((n2, x2)) ⇒
@@ -106,7 +104,6 @@ carrier.setLogLevel(2)
       },
       go { case interm((n, x)) + fetch(_, reply) if n == arr.size ⇒ reply(x) }
     )
-
     // emit molecules
     arr.foreach(i => carrier(i))
     val result = fetch()

--- a/benchmark/src/test/scala/io/chymyst/benchmark/MapReduceSpec.scala
+++ b/benchmark/src/test/scala/io/chymyst/benchmark/MapReduceSpec.scala
@@ -45,7 +45,7 @@ class MapReduceSpec extends FlatSpec with Matchers {
 
     val initTime = System.currentTimeMillis()
 
-    val arr = 1 to 100000
+    val arr = 1 to 10000
 
     // declare molecule types
     val carrier = m[Int]
@@ -85,7 +85,7 @@ class MapReduceSpec extends FlatSpec with Matchers {
 
     val initTime = System.currentTimeMillis()
 
-    val arr = 1 to 100000
+    val arr = 1 to 10000
 
     // declare molecule types
     val carrier = m[Int]

--- a/benchmark/src/test/scala/io/chymyst/benchmark/MergesortSpec.scala
+++ b/benchmark/src/test/scala/io/chymyst/benchmark/MergesortSpec.scala
@@ -1,99 +1,13 @@
 package io.chymyst.benchmark
 
-import io.chymyst.jc._
 import org.scalatest.{FlatSpec, Matchers}
-
-import scala.annotation.tailrec
-import scala.collection.mutable
+import MergeSort._
 
 import Common._
 
 class MergesortSpec extends FlatSpec with Matchers {
 
   // auxiliary functions for merge-sort tests
-
-  // this object is not used now
-  object amCounter {
-    var c: Int = 0
-
-    def inc(): Unit = {
-      synchronized {
-        c += 1
-      }
-    }
-  }
-
-  type Coll[T] = IndexedSeq[T]
-
-  def arrayMerge[T: Ordering](arr1: Coll[T], arr2: Coll[T]): Coll[T] = {
-    val id = amCounter.c
-    //      amCounter.inc() // avoid this for now - this is a debugging tool
-    val wantToLog = false // (arr1.length > 20000 && arr1.length < 41000)
-    if (wantToLog) println(s"${System.currentTimeMillis} start merging #$id")
-
-    val result = new mutable.ArraySeq[T](arr1.length + arr2.length) // just to allocate space
-
-    def isLess(x: T, y: T) = implicitly[Ordering[T]].compare(x, y) < 0
-
-    // will now modify result
-    @tailrec
-    def mergeRec(i1: Int, i2: Int, i: Int): Unit = {
-      if (i1 == arr1.length && i2 == arr2.length) ()
-      else {
-        val (x, newI1, newI2) = if (i1 < arr1.length && (i2 == arr2.length || isLess(arr1(i1), arr2(i2))))
-          (arr1(i1), i1 + 1, i2) else (arr2(i2), i1, i2 + 1)
-        result(i) = x
-        mergeRec(newI1, newI2, i + 1)
-      }
-    }
-
-    mergeRec(0, 0, 0)
-    if (wantToLog) println(s"${System.currentTimeMillis} finished merging #$id")
-    result.toIndexedSeq
-  }
-
-  def performMergeSort[T: Ordering](array: Coll[T], threads: Int = 8): Coll[T] = {
-
-    val finalResult = m[Coll[T]]
-    val getFinalResult = b[Unit, Coll[T]]
-    val reactionPool = new FixedPool(threads)
-    val sitePool = new FixedPool(threads)
-
-    site(sitePool, sitePool)(
-      go { case finalResult(arr) + getFinalResult(_, r) => r(arr) }
-    )
-
-    // recursive molecule that will define the reactions at one level lower
-
-    val mergesort = m[(Coll[T], M[Coll[T]])]
-
-    site(reactionPool, sitePool)(
-      go { case mergesort((arr, resultToYield)) =>
-        if (arr.length <= 1) resultToYield(arr)
-        else {
-          val (part1, part2) = arr.splitAt(arr.length / 2)
-          // "sorted1" and "sorted2" will be the sorted results from the lower level
-          val sorted1 = m[Coll[T]]
-          val sorted2 = m[Coll[T]]
-          site(reactionPool, sitePool)(
-            go { case sorted1(x) + sorted2(y) =>
-              resultToYield(arrayMerge(x, y))
-            }
-          )
-          // emit `mergesort` with the lower-level `sorted` result molecules
-          mergesort((part1, sorted1)) + mergesort((part2, sorted2))
-        }
-      }
-    )
-    // sort our array: emit `mergesort` at top level
-    mergesort((array, finalResult))
-    mergesort.setLogLevel(0)
-
-    val result = getFinalResult()
-    reactionPool.shutdownNow()
-    sitePool.shutdownNow()
-    result
-  }
 
   behavior of "merge sort"
 

--- a/benchmark/src/test/scala/io/chymyst/benchmark/MergesortSpec.scala
+++ b/benchmark/src/test/scala/io/chymyst/benchmark/MergesortSpec.scala
@@ -87,12 +87,15 @@ class MergesortSpec extends FlatSpec with Matchers {
     )
     // sort our array: emit `mergesort` at top level
     mergesort((array, finalResult))
+    mergesort.setLogLevel(0)
 
     val result = getFinalResult()
     reactionPool.shutdownNow()
     sitePool.shutdownNow()
     result
   }
+
+  behavior of "merge sort"
 
   it should "merge arrays correctly" in {
     arrayMerge(IndexedSeq(1, 2, 5), IndexedSeq(3, 6)) shouldEqual IndexedSeq(1, 2, 3, 5, 6)
@@ -118,6 +121,14 @@ class MergesortSpec extends FlatSpec with Matchers {
     val expectedResult = arr.sorted
 
     performMergeSort(arr, threads) shouldEqual expectedResult
+  }
+
+  it should "perform concurrent merge-sort without deadlock" in { // This has been a race condition in a MessageDigest global object.
+    val count = 5
+    (1 to 2000).foreach { i ⇒
+      val arr = Array.fill[Int](count)(scala.util.Random.nextInt(count))
+      performMergeSort(arr, 8)
+    }
   }
 
   it should "sort an array using concurrent merge-sort more quickly with many threads than with one thread" in {

--- a/core/src/main/scala/io/chymyst/jc/Core.scala
+++ b/core/src/main/scala/io/chymyst/jc/Core.scala
@@ -339,14 +339,13 @@ object Core {
   }
 
   def streamDiff[T](s: Iterator[T], skipBag: MutableMultiset[T]): Iterator[T] = {
-    s.map(Some(_)).scanLeft[Option[T]](None) { (b, tOpt) ⇒
-      val Some(t) = tOpt
+    s.filter{ t ⇒
       if (skipBag contains t) {
         skipBag.remove(t)
-        None
+        false
       }
-      else tOpt
-    }.flatten
+      else true
+    }
   }
 
 }

--- a/core/src/main/scala/io/chymyst/jc/Core.scala
+++ b/core/src/main/scala/io/chymyst/jc/Core.scala
@@ -338,13 +338,14 @@ object Core {
     }
   }
 
-  def streamDiff[T](s: Stream[T], skipBag: MutableMultiset[T]): Stream[T] = {
-    s.scanLeft[Option[T], Stream[Option[T]]](None) { (b, t) ⇒
+  def streamDiff[T](s: Iterator[T], skipBag: MutableMultiset[T]): Iterator[T] = {
+    s.map(Some(_)).scanLeft[Option[T]](None) { (b, tOpt) ⇒
+      val Some(t) = tOpt
       if (skipBag contains t) {
         skipBag.remove(t)
         None
       }
-      else Some(t)
+      else tOpt
     }.flatten
   }
 

--- a/core/src/main/scala/io/chymyst/jc/Core.scala
+++ b/core/src/main/scala/io/chymyst/jc/Core.scala
@@ -1,5 +1,6 @@
 package io.chymyst.jc
 
+import java.security.MessageDigest
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicLong
 
@@ -24,15 +25,13 @@ object TypeMustBeUnitValue extends TypeMustBeUnit[Unit] {
 }
 
 object Core {
-  private lazy val sha1Digest = java.security.MessageDigest.getInstance("SHA-1")
-
   private val longId: AtomicLong = new AtomicLong(0L)
 
   private[jc] def getNextId: Long = longId.incrementAndGet()
 
-  def getSha1String(c: String): String = sha1Digest.digest(c.getBytes("UTF-8")).map("%02X".format(_)).mkString
+  def getMessageDigest: MessageDigest = MessageDigest.getInstance("SHA-1")
 
-  def getSha1(c: Any): String = getSha1String(c.toString)
+  def getSha1(c: String, md: MessageDigest): String = md.digest(c.getBytes("UTF-8")).map("%02X".format(_)).mkString
 
   //  def flatten[T](optionSeq: Option[Seq[T]]): Seq[T] = optionSeq.getOrElse(Seq())
 

--- a/core/src/main/scala/io/chymyst/jc/Core.scala
+++ b/core/src/main/scala/io/chymyst/jc/Core.scala
@@ -348,4 +348,8 @@ object Core {
     }
   }
 
+  private[jc] def unboundOutputMolecules(nonStaticReactions: Seq[Reaction]): Set[Molecule] = nonStaticReactions.flatMap(_.info.outputs.map(_.molecule)).toSet.filterNot(_.isBound)
+
+  private[jc] def unboundOutputMoleculesString(nonStaticReactions: Seq[Reaction]): String = unboundOutputMolecules(nonStaticReactions).map(_.toString).toList.sorted.mkString(", ")
+
 }

--- a/core/src/main/scala/io/chymyst/jc/Core.scala
+++ b/core/src/main/scala/io/chymyst/jc/Core.scala
@@ -324,16 +324,18 @@ object Core {
 
   def arrayShuffleInPlace[T](arr: Array[T]): Unit = {
     val s = arr.length
+    //    java.util.Collections.shuffle(java.util.Arrays.asList(arr: _*))
     // Do nothing when the array has length 1 or less.
     if (s >= 2) {
-      (0 to s - 2).foreach { index ⇒
+      var index = 0
+      while (index < s - 1) {
         val randomIndex = s - 1 - scala.util.Random.nextInt(s - 1 - index)
         // randomIndex is between index + 1 and s - 1 inclusive.
         val tempElement = arr(randomIndex)
         arr(randomIndex) = arr(index)
         arr(index) = tempElement
+        index += 1
       }
-
     }
   }
 

--- a/core/src/main/scala/io/chymyst/jc/Molecules.scala
+++ b/core/src/main/scala/io/chymyst/jc/Molecules.scala
@@ -92,17 +92,17 @@ sealed trait Molecule extends PersistentHashCode {
 
   def typeSymbol: Symbol = valTypeSymbol
 
-  def index: Int = inputIndex
+  def siteIndex: Int = siteIndexValue
 
   /** This is called by a [[ReactionSite]] when a molecule becomes bound to that reaction site.
     *
-    * @param rs    Reaction site to which the molecule is now bound.
-    * @param index Zero-based index of the input molecule at that reaction site.
+    * @param rs        Reaction site to which the molecule is now bound.
+    * @param siteIndex Zero-based index of the input molecule at that reaction site.
     */
-  private[jc] def setReactionSiteInfo(rs: ReactionSite, index: Int, valType: Symbol, pipelined: Boolean): Unit = {
+  private[jc] def setReactionSiteInfo(rs: ReactionSite, siteIndex: Int, typeSymbol: Symbol, pipelined: Boolean): Unit = {
     hasReactionSite = true
-    inputIndex = index
-    valTypeSymbol = valType
+    siteIndexValue = siteIndex
+    valTypeSymbol = typeSymbol
     valIsPipelined = pipelined
   }
 
@@ -133,7 +133,7 @@ sealed trait Molecule extends PersistentHashCode {
 
   protected var valTypeSymbol: Symbol = _
 
-  protected var inputIndex: Int = -1
+  protected var siteIndexValue: Int = -1
 
   protected var hasReactionSite: Boolean = false
 

--- a/core/src/main/scala/io/chymyst/jc/Molecules.scala
+++ b/core/src/main/scala/io/chymyst/jc/Molecules.scala
@@ -213,14 +213,14 @@ final class M[T](val name: String) extends (T => Unit) with Molecule {
       volatileValueContainer
     else throw new Exception(s"In $reactionSiteWrapper: volatile reader requested for non-static molecule ($this)")
   }
-  else throw new Exception("Molecule c is not bound to any reaction site")
+  else throw new Exception(s"Molecule $name is not bound to any reaction site")
 
   private[jc] def assignStaticMolVolatileValue(molValue: AbsMolValue[_]) =
     volatileValueContainer = molValue.asInstanceOf[MolValue[T]].moleculeValue
 
   @volatile private var volatileValueContainer: T = _
 
-  override lazy val isStatic: Boolean = reactionSiteWrapper.staticMolsDeclared.contains(this)
+  override lazy val isStatic: Boolean = reactionSiteWrapper.isStatic()
 
   override private[jc] def setReactionSiteInfo(rs: ReactionSite, index: Int, valType: Symbol, pipelined: Boolean) = {
     super.setReactionSiteInfo(rs, index, valType, pipelined)

--- a/core/src/main/scala/io/chymyst/jc/MutableBag.scala
+++ b/core/src/main/scala/io/chymyst/jc/MutableBag.scala
@@ -118,9 +118,17 @@ final class MutableQueueBag[T] extends MutableBag[T] {
     ()
   }
 
+  /** Remove value from the bag. This is expected to succeed.
+    * If the value was not present in the bag, the removal fails.
+    *
+    * @param v Value to remove.
+    * @return `true` if removal was successful, `false` otherwise.
+    */
   override def remove(v: T): Boolean = {
     sizeValue.decrementAndGet()
-    bag.remove(v)
+    val status = bag.remove(v)
+    if (!status) sizeValue.incrementAndGet()
+    status
   }
 
   override def find(predicate: (T) => Boolean): Option[T] = bag.iterator.asScala.find(predicate)

--- a/core/src/main/scala/io/chymyst/jc/MutableBag.scala
+++ b/core/src/main/scala/io/chymyst/jc/MutableBag.scala
@@ -36,17 +36,17 @@ sealed trait MutableBag[T] {
   /** List all values, perhaps with repetitions.
     * It is not guaranteed that the values will be repeated the correct number of times.
     *
-    * @return A stream of values.
+    * @return An iterator of values.
     */
-  def allValues: Stream[T]
+  def allValues: Iterator[T]
 
   /** List all values, with repetitions, excluding values from a given sequence (which can also contain repeated values).
     * It is guaranteed that the values will be repeated the correct number of times.
     *
     * @param skipping A sequence of values that should be skipped while running the iterator.
-    * @return A stream of values.
+    * @return An iterator of values.
     */
-  def allValuesSkipping(skipping: MutableMultiset[T]): Stream[T]
+  def allValuesSkipping(skipping: MutableMultiset[T]): Iterator[T]
 }
 
 /** Implementation using guava's `com.google.common.collect.ConcurrentHashMultiset`.
@@ -81,14 +81,14 @@ final class MutableMapBag[T] extends MutableBag[T] {
     .map(entry => (entry.getElement, entry.getCount))
     .toMap
 
-  override def allValues: Stream[T] = bag
+  override def allValues: Iterator[T] = bag
     .createEntrySet()
     .asScala
-    .toStream
+    .toIterator
     .map(_.getElement)
 
-  override def allValuesSkipping(skipping: MutableMultiset[T]): Stream[T] =
-    Core.streamDiff(iterator.toStream, skipping)
+  override def allValuesSkipping(skipping: MutableMultiset[T]): Iterator[T] =
+    Core.streamDiff(iterator, skipping)
 }
 
 /** Implementation using `java.util.concurrent.ConcurrentLinkedQueue`.
@@ -135,9 +135,9 @@ final class MutableQueueBag[T] extends MutableBag[T] {
       .groupBy(identity)
       .mapValues(_.size)
 
-  override def allValues: Stream[T] = iterator.toStream
+  override def allValues: Iterator[T] = iterator
 
-  override def allValuesSkipping(skipping: MutableMultiset[T]): Stream[T] =
+  override def allValuesSkipping(skipping: MutableMultiset[T]): Iterator[T] =
     Core.streamDiff(allValues, skipping)
 }
 

--- a/core/src/main/scala/io/chymyst/jc/MutableBag.scala
+++ b/core/src/main/scala/io/chymyst/jc/MutableBag.scala
@@ -2,6 +2,7 @@ package io.chymyst.jc
 
 
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.JavaConverters.{asScalaIteratorConverter, asScalaSetConverter}
 import com.google.common.collect.ConcurrentHashMultiset
@@ -105,16 +106,22 @@ final class MutableMapBag[T] extends MutableBag[T] {
 final class MutableQueueBag[T] extends MutableBag[T] {
   private val bag = new ConcurrentLinkedQueue[T]()
 
+  private val sizeValue = new AtomicInteger(0)
+
   override def isEmpty: Boolean = bag.isEmpty
 
-  override def size: Int = bag.size
+  override def size: Int = sizeValue.get
 
   override def add(v: T): Unit = {
     bag.add(v)
+    sizeValue.incrementAndGet()
     ()
   }
 
-  override def remove(v: T): Boolean = bag.remove(v)
+  override def remove(v: T): Boolean = {
+    sizeValue.decrementAndGet()
+    bag.remove(v)
+  }
 
   override def find(predicate: (T) => Boolean): Option[T] = bag.iterator.asScala.find(predicate)
 

--- a/core/src/main/scala/io/chymyst/jc/Pool.scala
+++ b/core/src/main/scala/io/chymyst/jc/Pool.scala
@@ -15,7 +15,7 @@ class FixedPool(threads: Int) extends PoolExecutor(threads, { t =>
   * Tasks submitted for execution can have an optional name (useful for debugging).
   * The pool can be shut down, in which case all further tasks will be refused.
   */
-trait Pool {
+trait Pool extends AutoCloseable {
   def shutdownNow(): Unit
 
   def runClosure(closure: => Unit, info: ChymystThreadInfo): Unit
@@ -23,6 +23,8 @@ trait Pool {
   def runRunnable(runnable: Runnable): Unit
 
   def isInactive: Boolean
+
+  override def close(): Unit = shutdownNow()
 }
 
 /** Basic implementation of a thread pool.

--- a/core/src/main/scala/io/chymyst/jc/Reaction.scala
+++ b/core/src/main/scala/io/chymyst/jc/Reaction.scala
@@ -400,6 +400,8 @@ final case class InputMoleculeInfo(molecule: Molecule, index: Int, flag: InputPa
   private[jc] def matcherIsSimilarToOutput(info: OutputMoleculeInfo): Option[Boolean] = {
     if (molecule =!= info.molecule)
       Some(false)
+    else if (!info.atLeastOnce)
+      None
     else flag match {
       case WildcardInput |
            SimpleVarInput(_, None) |
@@ -650,8 +652,11 @@ final class ReactionInfo(
     }
   */
 
+  val isStatic: Boolean = inputsSortedByConstraintStrength.isEmpty
+
   override val toString: String = {
     val inputsInfo = inputsSortedByConstraintStrength.map(_.toString).mkString(" + ")
+    val staticPrefix = if (isStatic) "_" else ""
     val guardInfo = guardPresence match {
       case _
         if guardPresence.noCrossGuards =>
@@ -662,8 +667,8 @@ final class ReactionInfo(
         val crossGuardsInfo = guards.flatMap(_.symbols).map(_.name).distinct.mkString(",")
         s" if($crossGuardsInfo)"
     }
-    val outputsInfo = outputs.map(_.toString).mkString(" + ")
-    s"$inputsInfo$guardInfo → $outputsInfo"
+    val outputsInfo = shrunkOutputs.map(_.toString).mkString(" + ")
+    s"$inputsInfo$staticPrefix$guardInfo → $outputsInfo"
   }
 }
 

--- a/core/src/main/scala/io/chymyst/jc/Reaction.scala
+++ b/core/src/main/scala/io/chymyst/jc/Reaction.scala
@@ -726,7 +726,7 @@ final case class Reaction(
   }
 
   /** Find a set of input molecule values for this reaction. */
-  private[jc] def findInputMolecules(moleculesPresent: MoleculeBagArray): Option[(Reaction, InputMoleculeList)] = {
+  private[jc] def findInputMolecules(moleculesPresent: MoleculeBagArray): Option[InputMoleculeList] = {
     // A simpler, non-flatMap algorithm for the case when there are no cross-dependencies of molecule values.
     // For each single (non-repeated) input molecule, select a molecule value that satisfies the conditional.
     // For each group of repeated input molecules of the same sort, check whether the bag contains enough molecule values.
@@ -763,7 +763,7 @@ final case class Reaction(
           }
         // If we have no cross-conditionals, we do not need to use the SearchDSL sequence and we are finished.
         if (info.crossGuards.isEmpty && info.crossConditionalsForRepeatedMols.isEmpty)
-          true
+          true // The expression `if () true else ()` was not simplified only to preserve code readability.
         else {
           // Map from site-wide molecule index to the multiset of values that have been selected for repeated copies of this molecule.
           // This is used only for selecting repeated input molecules.
@@ -828,7 +828,7 @@ final case class Reaction(
         }
       }
     if (foundResult)
-      Some((this, foundValues))
+      Some(foundValues)
     else
       None
   }

--- a/core/src/main/scala/io/chymyst/jc/Reaction.scala
+++ b/core/src/main/scala/io/chymyst/jc/Reaction.scala
@@ -706,7 +706,8 @@ final case class Reaction(
   // java.security.MessageDigest is not thread safe, so we use a new MessageDigest for each reaction.
   private lazy val md: MessageDigest = getMessageDigest
 
-  private[jc] lazy val inputMoleculesSha1: String = getSha1(inputMoleculesSortedAlphabetically.map(_.hashCode()).mkString(","), md)
+  private[jc] lazy val inputInfoSha1: String =
+    getSha1(inputMoleculesSortedAlphabetically.map(_.hashCode()).mkString(","), md) + info.sha1
 
   // Optimization: this is used often.
   private[jc] val inputMoleculesSet: Set[Molecule] = inputMoleculesSortedAlphabetically.toSet

--- a/core/src/main/scala/io/chymyst/jc/Reaction.scala
+++ b/core/src/main/scala/io/chymyst/jc/Reaction.scala
@@ -701,6 +701,8 @@ final case class Reaction(
       .map(_.molecule)
       .sortBy(_.toString)
 
+  private[jc] lazy val inputMoleculesSha1: String = getSha1String(inputMoleculesSortedAlphabetically.map(_.hashCode()).mkString(","))
+
   // Optimization: this is used often.
   private[jc] val inputMoleculesSet: Set[Molecule] = inputMoleculesSortedAlphabetically.toSet
 

--- a/core/src/main/scala/io/chymyst/jc/Reaction.scala
+++ b/core/src/main/scala/io/chymyst/jc/Reaction.scala
@@ -1,5 +1,7 @@
 package io.chymyst.jc
 
+import java.security.MessageDigest
+
 import Core._
 
 import scala.{Symbol => ScalaSymbol}
@@ -701,7 +703,10 @@ final case class Reaction(
       .map(_.molecule)
       .sortBy(_.toString)
 
-  private[jc] lazy val inputMoleculesSha1: String = getSha1String(inputMoleculesSortedAlphabetically.map(_.hashCode()).mkString(","))
+  // java.security.MessageDigest is not thread safe, so we use a new MessageDigest for each reaction.
+  private lazy val md: MessageDigest = getMessageDigest
+
+  private[jc] lazy val inputMoleculesSha1: String = getSha1(inputMoleculesSortedAlphabetically.map(_.hashCode()).mkString(","), md)
 
   // Optimization: this is used often.
   private[jc] val inputMoleculesSet: Set[Molecule] = inputMoleculesSortedAlphabetically.toSet

--- a/core/src/main/scala/io/chymyst/jc/ReactionSite.scala
+++ b/core/src/main/scala/io/chymyst/jc/ReactionSite.scala
@@ -228,7 +228,7 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
 
       case e: Exception =>
         // Running the reaction body produced an exception. Note that the exception has killed a thread.
-        // We will now re-insert the input molecules (except the blocking ones). Hopefully, no side-effects or output molecules were produced so far.
+        // We will now schedule this reaction again if retry was requested. Hopefully, no side-effects or output molecules were produced so far.
         val (status, retryMessage) =
           if (thisReaction.retry) {
             scheduleReaction(thisReaction, usedInputs, poolForReaction)
@@ -236,7 +236,7 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
           }
           else (ReactionExitFailure(e.getMessage), " Retry run was not scheduled.")
 
-        val generalExceptionMessage = s"In $this: Reaction {${thisReaction.info}} with inputs [$reactionInputs] produced an exception.$retryMessage Message: ${e.getMessage}"
+        val generalExceptionMessage = s"In $this: Reaction {${thisReaction.info}} with inputs [$reactionInputs] produced ${e.getClass.getSimpleName}.$retryMessage Message: ${e.getMessage}"
 
         reportError(generalExceptionMessage)
         status
@@ -652,7 +652,7 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
 
     val staticDiagnostics = WarningsAndErrors(foundWarnings, foundErrors, s"$this")
 
-    staticDiagnostics.checkWarningsAndErrors()
+//    staticDiagnostics.checkWarningsAndErrors()
 
     // Emit static molecules now.
     // This must be done without starting any reactions that might consume these molecules.

--- a/core/src/main/scala/io/chymyst/jc/ReactionSite.scala
+++ b/core/src/main/scala/io/chymyst/jc/ReactionSite.scala
@@ -29,7 +29,7 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
     toString,
     logSoup = () => printBag,
     setLogLevel = { level => logLevel = level },
-    staticMolDeclared.keys.toList,
+    isStatic = () ⇒ staticMolDeclared.contains(molecule),
     emit = (mol, molValue) => emit[T](mol, molValue),
     emitAndAwaitReply = (mol, molValue, replyValue) => emitAndAwaitReply[T, R](mol, molValue, replyValue),
     emitAndAwaitReplyWithTimeout = (timeout, mol, molValue, replyValue) => emitAndAwaitReplyWithTimeout[T, R](timeout, mol, molValue, replyValue),
@@ -823,7 +823,7 @@ private[jc] final class ReactionSiteWrapper[T, R](
   override val toString: String,
   val logSoup: () => String,
   val setLogLevel: Int => Unit,
-  val staticMolsDeclared: List[Molecule],
+  val isStatic: () => Boolean,
   val emit: (Molecule, AbsMolValue[T]) => Unit,
   val emitAndAwaitReply: (B[T, R], T, AbsReplyEmitter[T, R]) => R,
   val emitAndAwaitReplyWithTimeout: (Long, B[T, R], T, AbsReplyEmitter[T, R]) => Option[R],
@@ -833,13 +833,13 @@ private[jc] final class ReactionSiteWrapper[T, R](
 
 private[jc] object ReactionSiteWrapper {
   def noReactionSite[T, R](m: Molecule): ReactionSiteWrapper[T, R] = {
-    def exception: Nothing = throw new ExceptionNoReactionSite(s"Molecule $m is not bound to any reaction site")
+    def exception: Nothing = throw new ExceptionNoReactionSite(s"Molecule $m is not bound to any reaction site!")
 
     new ReactionSiteWrapper(
       toString = "",
       logSoup = () => exception,
       setLogLevel = _ => exception,
-      staticMolsDeclared = List[Molecule](),
+      isStatic = () ⇒ exception,
       emit = (_: Molecule, _: AbsMolValue[T]) => exception,
       emitAndAwaitReply = (_: B[T, R], _: T, _: AbsReplyEmitter[T, R]) => exception,
       emitAndAwaitReplyWithTimeout = (_: Long, _: B[T, R], _: T, _: AbsReplyEmitter[T, R]) => exception,

--- a/core/src/main/scala/io/chymyst/jc/ReactionSite.scala
+++ b/core/src/main/scala/io/chymyst/jc/ReactionSite.scala
@@ -260,7 +260,7 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
       // For any blocking input molecules that have no reply, put an error message into them and reply with empty value to unblock the threads.
 
       // Compute error messages here in case we will need them later.
-      val blockingMoleculesWithNoReply = usedInputs.zipWithIndex
+      val blockingMoleculesWithNoReply = usedInputs.view.zipWithIndex
         .filter(_._1.reactionSentNoReply)
         .map { case (_, i) ⇒ thisReaction.info.inputs(i).molecule }
         .toSeq.toOptionSeq
@@ -699,7 +699,7 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
       .sortBy(_.name)
       .zipWithIndex
       .map { case (mol, index) ⇒
-        val valType = nonStaticReactions
+        val valType = nonStaticReactions.view
           .map(_.info.inputs)
           .flatMap(_.find(_.molecule === mol))
           .headOption

--- a/core/src/main/scala/io/chymyst/jc/ReactionSite.scala
+++ b/core/src/main/scala/io/chymyst/jc/ReactionSite.scala
@@ -46,7 +46,7 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
     */
   private val id: Long = getNextId
 
-  private val (nonStaticReactions, staticReactions) = reactions.toArray.partition(_.inputMoleculesSortedAlphabetically.nonEmpty)
+  private val (staticReactions, nonStaticReactions) = reactions.toArray.partition(_.info.isStatic)
 
   private var unboundOutputMolecules: Set[Molecule] = _
 

--- a/core/src/main/scala/io/chymyst/jc/ReactionSite.scala
+++ b/core/src/main/scala/io/chymyst/jc/ReactionSite.scala
@@ -386,9 +386,11 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
         Some((moleculeAtIndex(i), moleculesPresent(i).size))
       )(breakOut)
 
-  private def addToBag(mol: Molecule, molValue: AbsMolValue[_]): Unit = moleculesPresent(mol.index).add(molValue)
+  private def addToBag(mol: Molecule, molValue: AbsMolValue[_]): Unit =
+    moleculesPresent(mol.index).add(molValue)
 
-  private def removeFromBag(mol: Molecule, molValue: AbsMolValue[_]): Boolean = moleculesPresent(mol.index).remove(molValue)
+  private def removeFromBag(mol: Molecule, molValue: AbsMolValue[_]): Boolean =
+    moleculesPresent(mol.index).remove(molValue)
 
   private[jc] def moleculeBagToString(bags: Array[MutableBag[AbsMolValue[_]]]): String =
     Core.moleculeBagToString(bags.indices

--- a/core/src/main/scala/io/chymyst/jc/ReactionSite.scala
+++ b/core/src/main/scala/io/chymyst/jc/ReactionSite.scala
@@ -302,7 +302,9 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
       .filter(_.info.guardPresence.staticGuardHolds())
       .findAfterMap { r ⇒
         acquireLock(r.initialMoleculeValueLock)
-        findInputMolecules(r, moleculesPresent)
+        val result = findInputMolecules(r, moleculesPresent)
+        relaxLock(r.initialMoleculeValueLock, MoleculeValueLock())
+        result
       }
 
   /** Find a set of input molecule values for a reaction. */
@@ -840,4 +842,4 @@ private[jc] object ReactionSiteWrapper {
   }
 }
 
-private[jc] final case class MoleculeValueLock(counts: Map[Int, Int], molecules: Set[Int])
+private[jc] final case class MoleculeValueLock(counts: Map[Int, Int] = Map(), molecules: Set[Int] = Set())

--- a/core/src/main/scala/io/chymyst/jc/ReactionSite.scala
+++ b/core/src/main/scala/io/chymyst/jc/ReactionSite.scala
@@ -66,7 +66,14 @@ private[jc] final class ReactionSite(reactions: Seq[Reaction], reactionPool: Poo
   private val reactionInfos: Map[Reaction, Array[InputMoleculeInfo]] = nonStaticReactions
     .map { r => (r, r.info.inputs) }(breakOut)
 
-  override val toString: String = s"Site{${nonStaticReactions.map(_.toString).sorted.mkString("; ")}}"
+  private val toStringLimit = 1024
+
+  override val toString: String = {
+    val raw = s"Site{${nonStaticReactions.map(_.toString).sorted.mkString("; ")}}".take(toStringLimit + 1)
+    if (raw.length > toStringLimit)
+      raw.substring(0, toStringLimit) + "..."
+    else raw
+  }
 
   /** The sha1 hash sum of the entire reaction site, computed from sha1 of each reaction.
     * The sha1 hash of each reaction is computed from the Scala syntax tree of the reaction's source code.

--- a/core/src/main/scala/io/chymyst/jc/SmartPool.scala
+++ b/core/src/main/scala/io/chymyst/jc/SmartPool.scala
@@ -16,7 +16,7 @@ object BlockingIdle {
 /** A cached pool that increases its thread count whenever a blocking molecule is emitted, and decreases afterwards.
   * The `BlockingIdle` function, similar to `scala.concurrent.blocking`, is used to annotate expressions that should lead to an increase of thread count, and to a decrease of thread count once the idle blocking call returns.
   */
-class SmartPool(parallelism: Int) extends Pool {
+class SmartPool(parallelism: Int = cpuCores) extends Pool {
 
   private def newThreadFactory: ThreadFactory = new ThreadFactory {
     override def newThread(r: Runnable): Thread = new SmartThread(r, SmartPool.this)

--- a/core/src/main/scala/io/chymyst/jc/StaticAnalysis.scala
+++ b/core/src/main/scala/io/chymyst/jc/StaticAnalysis.scala
@@ -93,7 +93,14 @@ private[jc] object StaticAnalysis {
     None
   }
 
-  private def checkSingleReactionLivelockWarning(reactions: Seq[Reaction]): Option[String] = {
+  private def unboundMoleculeWarning(reactions: Seq[Reaction]): Option[String] = {
+    val warningList = unboundOutputMoleculesString(reactions)
+    if (warningList.nonEmpty)
+      Some(s"Output molecules ($warningList) are still not bound when this reaction site is created")
+    else None
+  }
+
+  private def singleReactionLivelockWarning(reactions: Seq[Reaction]): Option[String] = {
     val warningList = reactions
       .filter { r => inputMatchersAreSimilarToOutput(r.info.inputsSortedByConstraintStrength, r.info.shrunkOutputs) }
       .map(r => s"{${r.info.toString}}")
@@ -180,11 +187,12 @@ private[jc] object StaticAnalysis {
     ).flatMap(_ (reactions))
   }
 
-  private[jc] def findStaticWarnings(reactions: Seq[Reaction]) = {
+  private[jc] def findGeneralWarnings(reactions: Seq[Reaction]) = {
     Seq(
       checkOutputsForDeadlockWarning _,
       checkInputsForDeadlockWarning _,
-      checkSingleReactionLivelockWarning _
+      unboundMoleculeWarning _,
+      singleReactionLivelockWarning _
     ).flatMap(_ (reactions))
   }
 

--- a/core/src/main/scala/io/chymyst/jc/StaticAnalysis.scala
+++ b/core/src/main/scala/io/chymyst/jc/StaticAnalysis.scala
@@ -95,7 +95,7 @@ private[jc] object StaticAnalysis {
 
   private def checkSingleReactionLivelockWarning(reactions: Seq[Reaction]): Option[String] = {
     val warningList = reactions
-      .filter { r => inputMatchersAreSimilarToOutput(r.info.inputsSortedByConstraintStrength, r.info.outputs) }
+      .filter { r => inputMatchersAreSimilarToOutput(r.info.inputsSortedByConstraintStrength, r.info.shrunkOutputs) }
       .map(r => s"{${r.info.toString}}")
     if (warningList.nonEmpty)
       Some(s"Possible livelock: reaction${if (warningList.size == 1) "" else "s"} ${warningList.mkString(", ")}")
@@ -210,14 +210,14 @@ private[jc] object StaticAnalysis {
         case (mol, Some((_, 1))) ⇒
           None
         case (mol, Some((reaction, countConsumed))) =>
-          Some(s"static molecule ($mol) consumed $countConsumed times by reaction ${reaction.info}")
+          Some(s"static molecule ($mol) consumed $countConsumed times by reaction {${reaction.info}}")
       }
 
     val wrongOutput = staticMols.map {
       case (m, _) => m -> reactions.find(r => r.inputMoleculesSortedAlphabetically.count(_ === m) == 1 && !r.info.outputs.exists(_.molecule === m))
     }.flatMap {
       case (mol, Some(r)) =>
-        Some(s"static molecule ($mol) consumed but not emitted by reaction ${r.info}")
+        Some(s"static molecule ($mol) consumed but not emitted by reaction {${r.info}}")
       case _ => None
     }
 
@@ -236,9 +236,9 @@ private[jc] object StaticAnalysis {
         reactions.flatMap { r =>
           val outputTimes = r.info.outputs.count(_.molecule === m)
           if (outputTimes > 1)
-            Some(s"static molecule ($m) emitted more than once by reaction ${r.info}")
+            Some(s"static molecule ($m) emitted more than once by reaction {${r.info}}")
           else if (outputTimes == 1 && !r.inputMoleculesSet.contains(m))
-            Some(s"static molecule ($m) emitted but not consumed by reaction ${r.info}")
+            Some(s"static molecule ($m) emitted but not consumed by reaction {${r.info}}")
           else None
         }
     }

--- a/core/src/main/scala/io/chymyst/jc/StaticAnalysis.scala
+++ b/core/src/main/scala/io/chymyst/jc/StaticAnalysis.scala
@@ -69,9 +69,9 @@ private[jc] object StaticAnalysis {
 
   // There should not be any two reactions whose source code is identical to each other.
   private def findIdenticalReactions(reactions: Seq[Reaction]): Option[String] = {
-    val reactionsSha1 = reactions.map(_.info.sha1)
+    val reactionsSha1 = reactions.map(_.inputMoleculesSha1)
     val repeatedReactionSha1 = (reactionsSha1 difff reactionsSha1.distinct).distinct
-    val repeatedReactions = repeatedReactionSha1.flatMap(sha1 => reactions.find(_.info.sha1 == sha1))
+    val repeatedReactions = repeatedReactionSha1.flatMap(sha1 ⇒ reactions.filter(_.inputMoleculesSha1 === sha1))
 
     if (repeatedReactions.nonEmpty) {
       val errorList = repeatedReactions.map { r => s"{${r.info}}" }.mkString(", ")

--- a/core/src/main/scala/io/chymyst/jc/StaticAnalysis.scala
+++ b/core/src/main/scala/io/chymyst/jc/StaticAnalysis.scala
@@ -69,9 +69,9 @@ private[jc] object StaticAnalysis {
 
   // There should not be any two reactions whose source code is identical to each other.
   private def findIdenticalReactions(reactions: Seq[Reaction]): Option[String] = {
-    val reactionsSha1 = reactions.map(_.inputMoleculesSha1)
+    val reactionsSha1 = reactions.map(_.inputInfoSha1)
     val repeatedReactionSha1 = (reactionsSha1 difff reactionsSha1.distinct).distinct
-    val repeatedReactions = repeatedReactionSha1.flatMap(sha1 ⇒ reactions.filter(_.inputMoleculesSha1 === sha1))
+    val repeatedReactions = repeatedReactionSha1.flatMap(sha1 ⇒ reactions.filter(_.inputInfoSha1 === sha1))
 
     if (repeatedReactions.nonEmpty) {
       val errorList = repeatedReactions.map { r => s"{${r.info}}" }.mkString(", ")

--- a/core/src/main/scala/io/chymyst/jc/StaticAnalysis.scala
+++ b/core/src/main/scala/io/chymyst/jc/StaticAnalysis.scala
@@ -173,6 +173,7 @@ private[jc] object StaticAnalysis {
 
   private[jc] def findGeneralErrors(reactions: Seq[Reaction]) = {
     Seq(
+      findIdenticalReactions _,
       checkReactionShadowing _,
       checkSingleReactionLivelock _,
       checkMultiReactionLivelock _
@@ -181,7 +182,6 @@ private[jc] object StaticAnalysis {
 
   private[jc] def findStaticWarnings(reactions: Seq[Reaction]) = {
     Seq(
-      findIdenticalReactions _,
       checkOutputsForDeadlockWarning _,
       checkInputsForDeadlockWarning _,
       checkSingleReactionLivelockWarning _

--- a/core/src/test/scala/io/chymyst/jc/CoreSpec.scala
+++ b/core/src/test/scala/io/chymyst/jc/CoreSpec.scala
@@ -192,7 +192,7 @@ class CoreSpec extends FlatSpec with Matchers with TimeLimitedTests {
   it should "not exclude elements when skip is empty" in {
     val data = (1 to 10) ++ (1 to 10)
     val skip = new MutableMultiset[Int]()
-    val result = streamDiff(data.toStream, skip)
+    val result = streamDiff(data.toIterator, skip)
     result.toList shouldEqual data.toList
   }
 
@@ -200,7 +200,7 @@ class CoreSpec extends FlatSpec with Matchers with TimeLimitedTests {
     val data = (1 to 10) ++ (1 to 10)
     val skip = new MutableMultiset[Int]().add(Seq(1, 1, 2, 2, 3, 4))
     val expected = (5 to 10) ++ (3 to 10)
-    val result = streamDiff(data.toStream, skip)
+    val result = streamDiff(data.toIterator, skip)
     result.toList shouldEqual expected.toList
   }
 

--- a/core/src/test/scala/io/chymyst/jc/CoreSpec.scala
+++ b/core/src/test/scala/io/chymyst/jc/CoreSpec.scala
@@ -7,6 +7,9 @@ import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.time.{Millis, Span}
 
 class CoreSpec extends FlatSpec with Matchers with TimeLimitedTests {
+  private lazy val sha1Digest = getMessageDigest
+
+  def getSha1Any(c: Any): String = getSha1(c.toString, sha1Digest)
 
   val timeLimit = Span(500, Millis)
 
@@ -17,28 +20,28 @@ class CoreSpec extends FlatSpec with Matchers with TimeLimitedTests {
   behavior of "getSha1"
 
   it should "compute sha1 of integer value" in {
-    getSha1(123) shouldEqual "40BD001563085FC35165329EA1FF5C5ECBDBBEEF"
+    getSha1Any(123) shouldEqual "40BD001563085FC35165329EA1FF5C5ECBDBBEEF"
   }
 
   it should "compute sha1 of string value" in {
-    getSha1("123") shouldEqual "40BD001563085FC35165329EA1FF5C5ECBDBBEEF"
+    getSha1Any("123") shouldEqual "40BD001563085FC35165329EA1FF5C5ECBDBBEEF"
   }
 
   it should "compute sha1 of tuple value" in {
-    getSha1((123, "123")) shouldEqual "C4C7ADA9B819DFAEFE10F765BAD87ABF91A79584"
+    getSha1Any((123, "123")) shouldEqual "C4C7ADA9B819DFAEFE10F765BAD87ABF91A79584"
   }
 
   it should "compute sha1 of List value" in {
-    getSha1(List(123, 456)) shouldEqual "537DC011B1ED7084849573D8921BDB6EE1F87154"
+    getSha1Any(List(123, 456)) shouldEqual "537DC011B1ED7084849573D8921BDB6EE1F87154"
   }
 
   it should "compute sha1 of integer tuple value" in {
-    getSha1((123, 456)) shouldEqual "CE528A746B9311801806D4C802FB08D1FE66DC7F"
+    getSha1Any((123, 456)) shouldEqual "CE528A746B9311801806D4C802FB08D1FE66DC7F"
   }
 
   it should "compute sha1 of case class value" in {
     case class A(b: Int, c: Int)
-    getSha1(A(123, 456)) shouldEqual "7E4D82CC624252B788D54BCE49D0A1380436E846"
+    getSha1Any(A(123, 456)) shouldEqual "7E4D82CC624252B788D54BCE49D0A1380436E846"
   }
 
   behavior of "monadic Either"

--- a/core/src/test/scala/io/chymyst/jc/CoreSpec.scala
+++ b/core/src/test/scala/io/chymyst/jc/CoreSpec.scala
@@ -198,7 +198,7 @@ class CoreSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
   it should "exclude elements with repetitions" in {
     val data = (1 to 10) ++ (1 to 10)
-    val skip = new MutableMultiset[Int]().add(Seq(1, 1, 2, 2, 3, 4))
+    val skip = new MutableMultiset[Int](List(1, 1, 2, 2, 3, 4))
     val expected = (5 to 10) ++ (3 to 10)
     val result = streamDiff(data.toIterator, skip)
     result.toList shouldEqual expected.toList

--- a/core/src/test/scala/io/chymyst/jc/MutableBagSpec.scala
+++ b/core/src/test/scala/io/chymyst/jc/MutableBagSpec.scala
@@ -48,7 +48,7 @@ class MutableBagSpec extends FlatSpec with Matchers with TimeLimitedTests {
   it should "retrieve all elements with repetitions and with skipping" in {
     val bag = new MutableMapBag[Int]()
     val data = (1 to 10) ++ (1 to 10)
-    val skip = new MutableMultiset[Int]().add(List(1, 1, 2, 2, 3, 4))
+    val skip = new MutableMultiset[Int](List(1, 1, 2, 2, 3, 4))
     data.foreach(bag.add)
     val expectedValues = List(3, 4) ++ (5 to 10).flatMap(x ⇒ List(x, x)).toList
     bag.allValuesSkipping(skip).toList shouldEqual expectedValues
@@ -77,8 +77,8 @@ class MutableBagSpec extends FlatSpec with Matchers with TimeLimitedTests {
       b.add(i)
       b.add(i)
     }
-    val skip = new MutableMultiset[Int]().add(1 to n)
-    val skipped = b.allValuesSkipping(skip)
+    val skip = new MutableMultiset[Int]((1 to n).toList)
+    val skipped = b.allValuesSkipping(skip).toList
     skipped.size shouldEqual n
     skipped.sum shouldEqual (1 to n).sum
     ()
@@ -129,7 +129,7 @@ class MutableBagSpec extends FlatSpec with Matchers with TimeLimitedTests {
   it should "retrieve all elements with repetitions and with skipping" in {
     val bag = new MutableQueueBag[Int]()
     val data = (1 to 10) ++ (1 to 10)
-    val skip = new MutableMultiset[Int]().add(List(1, 1, 2, 2, 3, 4))
+    val skip = new MutableMultiset[Int](List(1, 1, 2, 2, 3, 4))
     data.foreach(bag.add)
     val expectedValues = ((5 to 10) ++ (3 to 10)).toList
     bag.allValuesSkipping(skip).toList shouldEqual expectedValues

--- a/core/src/test/scala/io/chymyst/jc/PoolSpec.scala
+++ b/core/src/test/scala/io/chymyst/jc/PoolSpec.scala
@@ -86,7 +86,7 @@ class PoolSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
   }
 
-  it should "run tasks on smart threads and store info" in {
+  it should "run tasks on chymyst threads and store info" in {
     val waiter = new Waiter
 
     var x = 0
@@ -104,6 +104,16 @@ class PoolSpec extends FlatSpec with Matchers with TimeLimitedTests {
 
     x shouldEqual 1
     smartThread.chymystInfo shouldEqual Some(emptyReactionInfo)
+  }
+
+  behavior of "smart pool"
+
+  it should "initialize with default CPU core parallelism" in {
+    val tp = new SmartPool()
+
+    tp.currentPoolSize shouldEqual cpuCores
+
+    tp.close()
   }
 
 }

--- a/core/src/test/scala/io/chymyst/jc/Sha1Props.scala
+++ b/core/src/test/scala/io/chymyst/jc/Sha1Props.scala
@@ -7,11 +7,10 @@ import org.scalacheck.Properties
 import org.scalacheck.Prop.forAll
 
 object Sha1Props extends Properties("Sha1") {
-  property("invariantForLongOrString") = forAll { (a: Long) =>
-    getSha1(a) == getSha1(a.toString)
-  }
+
+  private val md = getMessageDigest
 
   property("noHashCollisionLongs") = forAll { (a: Long, b: Long) =>
-    a == b || getSha1(a) != getSha1(b)
+    a == b || getSha1(a.toString, md) != getSha1(b.toString, md)
   }
 }

--- a/core/src/test/scala/io/chymyst/test/DiningPhilosophersSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/DiningPhilosophersSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.{FlatSpec, Matchers}
 class DiningPhilosophersSpec extends FlatSpec with Matchers {
 
   def randomWait(message: String): Unit = {
-    println(message)
+//    println(message)
     Thread.sleep(math.floor(scala.util.Random.nextDouble*20.0 + 2.0).toLong)
   }
 

--- a/core/src/test/scala/io/chymyst/test/MoleculesSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/MoleculesSpec.scala
@@ -291,7 +291,7 @@ class MoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests with Be
       r
     }
     println(s"results for test 1: ${results.groupBy(identity).mapValues(_.size)}")
-    globalErrorLog.toList should contain("In Site{p → ...}: Reaction {p(s) → } with inputs [p/P(c)] produced an exception that is internal to Chymyst Core. Retry run was not scheduled. Message: Molecule c is not bound to any reaction site")
+    globalErrorLog.toList should contain("In Site{p → ...}: Reaction {p(s) → } with inputs [p/P(c)] produced an exception internal to Chymyst Core. Retry run was not scheduled. Message: Molecule c is not bound to any reaction site")
     results should contain(123)
     results should contain(0)
   }
@@ -332,7 +332,7 @@ class MoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests with Be
     }
     println(s"results for test 2: ${results.groupBy(identity).mapValues(_.size)}")
     results should contain(246)
-    globalErrorLog.toList should contain("In Site{a → ...}: Reaction {a(s) → } with inputs [a/P(e)] produced an exception that is internal to Chymyst Core. Retry run was not scheduled. Message: Molecule e is not bound to any reaction site")
+    globalErrorLog.toList should contain("In Site{a → ...}: Reaction {a(s) → } with inputs [a/P(e)] produced an exception internal to Chymyst Core. Retry run was not scheduled. Message: Molecule e is not bound to any reaction site")
     results should contain(0)
   }
 
@@ -360,7 +360,7 @@ class MoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests with Be
       f()
     }
     println(s"results for test 3: ${results.groupBy(identity).mapValues(_.size)}")
-    globalErrorLog.toList should not contain "In Site{q → ...}: Reaction {q(s) → } with inputs [q/P(e)] produced an exception that is internal to Chymyst Core. Retry run was not scheduled. Message: Molecule e is not bound to any reaction site"
+    globalErrorLog.toList should not contain "In Site{q → ...}: Reaction {q(s) → } with inputs [q/P(e)] produced an exception internal to Chymyst Core. Retry run was not scheduled. Message: Molecule e is not bound to any reaction site"
     results should contain(246)
     results should not contain 0
   }
@@ -377,7 +377,7 @@ class MoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests with Be
     val thrown = intercept[Exception] {
       f() shouldEqual 123 // This should not pass.
     }
-    thrown.getMessage shouldEqual "Error: In Site{a + f/B → ...}: Reaction {a(s) + f/B(_) → } with inputs [a/P(c) + f/B/P()] finished without replying to f/B. Reported error: In Site{a + f/B → ...}: Reaction {a(s) + f/B(_) → } with inputs [a/P(c) + f/B/P()] produced an exception that is internal to Chymyst Core. Retry run was not scheduled. Message: Molecule c is not bound to any reaction site"
+    thrown.getMessage shouldEqual "Error: In Site{a + f/B → ...}: Reaction {a(s) + f/B(_) → } with inputs [a/P(c) + f/B/P()] finished without replying to f/B. Reported error: In Site{a + f/B → ...}: Reaction {a(s) + f/B(_) → } with inputs [a/P(c) + f/B/P()] produced an exception internal to Chymyst Core. Retry run was not scheduled. Message: Molecule c is not bound to any reaction site"
   }
 
   behavior of "basic functionality"
@@ -503,7 +503,7 @@ class MoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests with Be
     val result = g.timeout()(1500 millis)
     tp.shutdownNow()
     result shouldEqual Some(())
-    globalErrorLog.toList should contain("In Site{counter + decrement → .../R; counter + getValue/B → ...}: Reaction {counter(x) + decrement(_) → counter(?)} with inputs [counter(5) + decrement/P()] produced an exception. Retry run was scheduled. Message: crash! (it's OK, ignore this)")
+    globalErrorLog.toList should contain("In Site{counter + decrement → .../R; counter + getValue/B → ...}: Reaction {counter(x) + decrement(_) → counter(?)} with inputs [counter(5) + decrement/P()] produced Exception. Retry run was scheduled. Message: crash! (it's OK, ignore this)")
   }
 
   it should "finish job by retrying reactions with static molecules even if 1 out of 2 processes crash" in {
@@ -529,7 +529,7 @@ class MoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests with Be
     val result = g.timeout()(1500 millis)
     tp.shutdownNow()
     result shouldEqual Some(())
-    globalErrorLog.toList should contain("In Site{counter + decrement → .../R; counter + getValue/B → ...}: Reaction {counter(x) + decrement(_) → counter(?)} with inputs [counter(5) + decrement/P()] produced an exception. Retry run was scheduled. Message: crash! (it's OK, ignore this)")
+    globalErrorLog.toList should contain("In Site{counter + decrement → .../R; counter + getValue/B → ...}: Reaction {counter(x) + decrement(_) → counter(?)} with inputs [counter(5) + decrement/P()] produced Exception. Retry run was scheduled. Message: crash! (it's OK, ignore this)")
   }
 
   it should "retry reactions that contain blocking molecules" in {
@@ -559,7 +559,7 @@ class MoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests with Be
     val result = g.timeout()(1500 millis)
     tp.shutdownNow()
     result shouldEqual Some(())
-    globalErrorLog.toList should contain("In Site{counter + decrement/B → .../R; counter + getValue/B → ...}: Reaction {counter(x) + decrement/B(_) → counter(?)} with inputs [counter(5) + decrement/B/P()] produced an exception. Retry run was scheduled. Message: crash! (it's OK, ignore this)")
+    globalErrorLog.toList should contain("In Site{counter + decrement/B → .../R; counter + getValue/B → ...}: Reaction {counter(x) + decrement/B(_) → counter(?)} with inputs [counter(5) + decrement/B/P()] produced Exception. Retry run was scheduled. Message: crash! (it's OK, ignore this)")
   }
 
 }

--- a/core/src/test/scala/io/chymyst/test/MoleculesSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/MoleculesSpec.scala
@@ -51,13 +51,13 @@ class MoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests with Be
     val g = b[Unit, Unit]
 
     f.typeSymbol shouldEqual null
-    f.index shouldEqual -1
+    f.siteIndex shouldEqual -1
     site(tp0)(
       go { case g(_, r) + d(_) => r() },
       go { case a(_) + bb(_) + c(_) + f(_, r) => r() }
     )
     val molecules = Seq(a, bb, c, d, f, g)
-    molecules.map(_.index) shouldEqual (0 until molecules.size)
+    molecules.map(_.siteIndex) shouldEqual (0 until molecules.size)
     molecules.map(_.typeSymbol) shouldEqual Seq.fill(molecules.size)('Unit)
 
     a.logSoup shouldEqual "Site{a + bb + c + f/B → ...; d + g/B → ...}\nNo molecules"

--- a/core/src/test/scala/io/chymyst/test/StaticAnalysisSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/StaticAnalysisSpec.scala
@@ -509,6 +509,21 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
     }.get
   }
 
+  behavior of "unbound molecule detection"
+
+  it should "correctly identify molecules that are still unbound" in {
+    val a = m[Unit]
+    val c = m[Unit]
+    val d = m[Unit]
+    val e = m[Unit]
+    val f = m[Unit]
+
+    val warnings1 = site(go { case a(_) + e(_) ⇒ c() })
+    warnings1 shouldEqual WarningsAndErrors(List("Output molecules (c) are still not bound when this reaction site is created"), List(), "Site{a + e → ...}")
+    val warnings2 = site(go { case c(_) ⇒ a() + d() + e(); f() })
+    warnings2 shouldEqual WarningsAndErrors(List("Output molecules (d, f) are still not bound when this reaction site is created"), List(), "Site{c → ...}")
+  }
+
   behavior of "deadlock detection"
 
   it should "not warn about likely deadlock for a reaction that emits molecules for itself in the right order" in {

--- a/core/src/test/scala/io/chymyst/test/StaticAnalysisSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/StaticAnalysisSpec.scala
@@ -265,15 +265,15 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
         go { case a(x) if x > 0 => if (x > 0) a(1) else a(1) }
       )
     }
-    thrown.getMessage shouldEqual "In Site{a → ...}: Unavoidable livelock: reaction {a(x if ?) → a(1) + a(1)}"
+    thrown.getMessage shouldEqual "In Site{a → ...}: Unavoidable livelock: reaction {a(x if ?) → a(1)}"
   }
 
-  it should "detect livelock warning in a simple reaction due to if-then-else" in {
+  it should "not detect livelock warning in a simple reaction due to if-then-else" in {
     val a = m[Int]
     val result = site(
       go { case a(1) => if (true) a(1) }
     )
-    result shouldEqual WarningsAndErrors(List("Possible livelock: reaction {a(1) → a(1)}"), List(), "Site{a → ...}")
+    result shouldEqual WarningsAndErrors(List(), List(), "Site{a → ...}")
   }
 
   it should "detect livelock error in a simple reaction due to constant output values and perfect if-then-else shrinkage" in {
@@ -284,7 +284,7 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
       ) // If this test fails because of no exception, it means this `shouldEqual` passes, so a warning was generated instead of an error.
       result shouldEqual WarningsAndErrors(List("Possible livelock: reaction {a(?x) → a((1,2)) + a((1,2))}"), List(), "Site{a → ...}")
     }
-    thrown.getMessage shouldEqual "In Site{a → ...}: Unavoidable livelock: reaction {a(?x) → a((1,2)) + a((1,2))}"
+    thrown.getMessage shouldEqual "In Site{a → ...}: Unavoidable livelock: reaction {a(?x) → a((1,2))}"
   }
 
   it should "detect livelock warning in a simple reaction due to constant output values despite if-then-else shrinkage" in {
@@ -292,7 +292,7 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
     val result = site(
       go { case a((1, x)) => if (x > 0) a((1, 2)) else a((1, 3)) }
     )
-    result shouldEqual WarningsAndErrors(List("Possible livelock: reaction {a(?x) → a((1,2)) + a((1,3))}"), List(), "Site{a → ...}")
+    result shouldEqual WarningsAndErrors(List("Possible livelock: reaction {a(?x) → a(?)}"), List(), "Site{a → ...}")
   }
 
   it should "detect livelock in a single reaction due to constant output values without value assigning" in {
@@ -304,6 +304,24 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
       )
     }
     thrown.getMessage shouldEqual "In Site{a + b → ...}: Unavoidable livelock: reaction {a(1) + b(_) → b(1) + b(2) + a(1)}"
+  }
+
+  // TODO: possibly, implement checking the cross-condition for constant output values
+  it should "detect livelock warning in a single reaction due to constant output values with cross-condition that does not hold" in {
+    val a = m[Int]
+    val b = m[Int]
+    val warnings = site(
+      go { case a(x) + b(y) if x > y => b(1) + b(1) + a(1) }
+    )
+    warnings shouldEqual WarningsAndErrors(List("Possible livelock: reaction {a(x) + b(y) if(x,y) → b(1) + b(1) + a(1)}"), List(), "Site{a + b → ...}")
+  }
+
+  it should "detect no livelock warning when output is conditionally emitted" in {
+    val a = m[Int]
+    val warnings = site(
+      go { case a(x) => if (x > 0) a(1) }
+    )
+    warnings shouldEqual WarningsAndErrors(List(), List(), "Site{a → ...}")
   }
 
   it should "detect livelock in a single reaction due to one constant output value with simple guard" in {
@@ -381,12 +399,22 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
   behavior of "livelock with repeated inputs" // see issue https://github.com/Chymyst/chymyst-core/issues/102
 
   it should "be detected in a reaction with repeated output" in {
-    val a = m[Unit]
+    val a = m[Int]
 
+    the[Exception] thrownBy {
+      val warnings = site(
+        go { case a(x) + a(_) if x > 0 ⇒ if (true) a(1) + a(2) else a(1) + a(2) }
+      )
+      warnings shouldEqual WarningsAndErrors(List(), List(), "Site{a + a → ...}")
+    } should have message "In Site{a + a → ...}: Unavoidable livelock: reaction {a(x if ?) + a(_) → a(1) + a(2)}"
+  }
+
+  it should "not be detected in a reaction with conditionally repeated output" in {
+    val a = m[Int]
     val warnings = site(
-      go { case a(_) + a(_) ⇒ if (true) a() + a() }
+      go { case a(x) + a(_) if x > 0 ⇒ if (true) a(1) + a(2) else a(1) }
     )
-    warnings shouldEqual WarningsAndErrors(List("Possible livelock: reaction {a(_) + a(_) → a() + a()}"), List(), "Site{a + a → ...}")
+    warnings shouldEqual WarningsAndErrors(List(), List(), "Site{a + a → ...}")
   }
 
   it should "be detected as compile-time error in a reaction with repeated output and static guard" in {
@@ -456,14 +484,14 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
   }
 
   // TODO: rewrite this test when static molecules are property analyzed for emitting code environment
-  it should "in a reaction with static molecule emitted conditionally" in {
+  it should "give no warning in a reaction with static molecule emitted conditionally" in {
     withPool(new FixedPool(2)) { tp ⇒
       val a = m[Int]
       val warnings = site(tp)(
         go { case _ ⇒ a(1) },
         go { case a(1) ⇒ val x = 1; if (x > 0) a(x) }
       )
-      warnings shouldEqual WarningsAndErrors(List("Possible livelock: reaction {a(1) → a(?)}"), List(), "Site{a → ...}")
+      warnings shouldEqual WarningsAndErrors(List(), List(), "Site{a → ...}")
     }.get
   }
 
@@ -477,7 +505,7 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
           go { case a(1) ⇒ val x = 1; if (x > 0) a(x) else a(-x) }
         )
         warnings shouldEqual WarningsAndErrors(List("Possible livelock: reaction {a(1) → a(?)}"), List(), "Site{a → ...}")
-      } should have message "In Site{a → ...}: Incorrect static molecule declaration: static molecule (a) emitted more than once by reaction a(1) → a(?) + a(?)"
+      } should have message "In Site{a → ...}: Incorrect static molecule declaration: static molecule (a) emitted more than once by reaction {a(1) → a(?)}"
     }.get
   }
 
@@ -537,7 +565,7 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
       )
       warnings shouldEqual WarningsAndErrors(List(), List(), "Site{a + c → ...; a + c → ...; a + f/B → ...; a + f/B → ...}") // this is unreachable if test passes; later we could rewrite this test when error logging is handled better
     } should have message
-    "In Site{a + c → ...; a + c → ...; a + f/B → ...; a + f/B → ...}: Identical repeated reactions: {a(x) + c(_) → a(?)}, {a(x) + c(_) → a(?)}, {a(x) + f/B(_) → }, {a(x) + f/B(_) → }; Unavoidable nondeterminism: reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {a(x) + f/B(_) → } is shadowed by {a(x) + f/B(_) → }, reaction {a(x) + f/B(_) → } is shadowed by {a(x) + f/B(_) → }"
+      "In Site{a + c → ...; a + c → ...; a + f/B → ...; a + f/B → ...}: Identical repeated reactions: {a(x) + c(_) → a(?)}, {a(x) + c(_) → a(?)}, {a(x) + f/B(_) → }, {a(x) + f/B(_) → }; Unavoidable nondeterminism: reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {a(x) + f/B(_) → } is shadowed by {a(x) + f/B(_) → }, reaction {a(x) + f/B(_) → } is shadowed by {a(x) + f/B(_) → }"
   }
 
   it should "detect a repeated reaction with identical conditions" in {

--- a/core/src/test/scala/io/chymyst/test/StaticAnalysisSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/StaticAnalysisSpec.scala
@@ -528,27 +528,29 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
     val c = m[Unit]
     val f = b[Unit, Int]
 
-    val thrown = intercept[Exception] {
+    the[Exception] thrownBy {
       val warnings = site(
         go { case c(_) + a(x) => a(x) },
         go { case c(_) + a(x) => a(x) },
         go { case a(x) + f(_, r) => r(x) },
         go { case a(x) + f(_, r) => r(x) }
       )
-      warnings shouldEqual WarningsAndErrors(List("Identical repeated reactions: {a(x) + c(_) → a(?)}, {a(x) + f/B(_) → }"), List(), "Site{a + c → ...; a + c → ...; a + f/B → ...; a + f/B → ...}") // this is probably unreachable; later we could rewrite this test when logging is better handled
-    }
-    thrown.getMessage shouldEqual "In Site{a + c → ...; a + c → ...; a + f/B → ...; a + f/B → ...}: Unavoidable nondeterminism: reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {a(x) + f/B(_) → } is shadowed by {a(x) + f/B(_) → }, reaction {a(x) + f/B(_) → } is shadowed by {a(x) + f/B(_) → }"
+      warnings shouldEqual WarningsAndErrors(List(), List(), "Site{a + c → ...; a + c → ...; a + f/B → ...; a + f/B → ...}") // this is unreachable if test passes; later we could rewrite this test when error logging is handled better
+    } should have message
+    "In Site{a + c → ...; a + c → ...; a + f/B → ...; a + f/B → ...}: Identical repeated reactions: {a(x) + c(_) → a(?)}, {a(x) + c(_) → a(?)}, {a(x) + f/B(_) → }, {a(x) + f/B(_) → }; Unavoidable nondeterminism: reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {a(x) + f/B(_) → } is shadowed by {a(x) + f/B(_) → }, reaction {a(x) + f/B(_) → } is shadowed by {a(x) + f/B(_) → }"
   }
 
   it should "detect a repeated reaction with identical conditions" in {
     val a = m[Int]
 
-    val warnings = site(
-      go { case a(x) if x > 0 => },
-      go { case a(x) if x > 0 => },
-      go { case a(x) + a(_) => }
-    )
-    warnings shouldEqual WarningsAndErrors(List("Identical repeated reactions: {a(x if ?) → }, {a(x if ?) → }"), List(), "Site{a + a → ...; a → ...; a → ...}")
+    the[Exception] thrownBy {
+      val warnings = site(
+        go { case a(x) if x > 0 => },
+        go { case a(x) if x > 0 => },
+        go { case a(x) + a(_) => }
+      )
+      warnings shouldEqual WarningsAndErrors(List(), List(), "Site{a + a → ...; a → ...; a → ...}")
+    } should have message "In Site{a + a → ...; a → ...; a → ...}: Identical repeated reactions: {a(x if ?) → }, {a(x if ?) → }"
   }
 
   it should "detect a repeated reaction with different conditions" in {
@@ -644,8 +646,9 @@ class StaticAnalysisSpec extends FlatSpec with Matchers with TimeLimitedTests {
     the[Exception] thrownBy {
       val warnings = site(reaction1, reaction2, reaction3, reaction4, reaction5)
 
-      warnings shouldEqual WarningsAndErrors(List("Identical repeated reactions: {a1(x) + c1(_) → a1(?)}, {c1(_) + f/B(_) → }"), List(), "Site{a1 + c1 → ...; a2 + c2 → ...; a3 + c3 → ...; c1 + f/B → ...; c2 + f/B → ...}")
-    } should have message "In Site{a + c → ...; a + c → ...; a + c → ...; c + f/B → ...; c + f/B → ...}: Unavoidable nondeterminism: reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {c(_) + f/B(_) → } is shadowed by {c(_) + f/B(_) → }, reaction {c(_) + f/B(_) → } is shadowed by {c(_) + f/B(_) → }"
+      warnings shouldEqual WarningsAndErrors(List(), List(), "Site{a1 + c1 → ...; a2 + c2 → ...; a3 + c3 → ...; c1 + f/B → ...; c2 + f/B → ...}")
+    } should have message
+      "In Site{a + c → ...; a + c → ...; a + c → ...; c + f/B → ...; c + f/B → ...}: Identical repeated reactions: {a(x) + c(_) → a(?)}, {a(x) + c(_) → a(?)}, {a(x) + c(_) → a(?)}, {c(_) + f/B(_) → }, {c(_) + f/B(_) → }; Unavoidable nondeterminism: reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {a(x) + c(_) → a(?)} is shadowed by {a(x) + c(_) → a(?)}, reaction {c(_) + f/B(_) → } is shadowed by {c(_) + f/B(_) → }, reaction {c(_) + f/B(_) → } is shadowed by {c(_) + f/B(_) → }"
   }
 
 }

--- a/core/src/test/scala/io/chymyst/test/StaticMoleculesSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/StaticMoleculesSpec.scala
@@ -195,7 +195,7 @@ class StaticMoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests w
       )
     }
 
-    thrown.getMessage shouldEqual "In Site{c + d → ...; f/B → ...}: Refusing to emit molecule f/B() as static (must be a non-blocking molecule)"
+    thrown.getMessage shouldEqual "In Site{c + d → ...; f/B → ...}: Refusing to emit molecule f/B() initially as static (must be a non-blocking molecule)"
   }
 
   behavior of "volatile reader"

--- a/core/src/test/scala/io/chymyst/test/StaticMoleculesSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/StaticMoleculesSpec.scala
@@ -201,13 +201,13 @@ class StaticMoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests w
   behavior of "volatile reader"
 
   it should "refuse to read the value of a molecule not bound to a reaction site" in {
-    val c = m[Int]
+    val cc = m[Int]
 
     val thrown = intercept[Exception] {
-      c.volatileValue shouldEqual null.asInstanceOf[Int] // If this passes, we are not detecting the fact that c is not bound.
+      cc.volatileValue shouldEqual null.asInstanceOf[Int] // If this passes, we are not detecting the fact that cc is not bound.
     }
 
-    thrown.getMessage shouldEqual "Molecule c is not bound to any reaction site"
+    thrown.getMessage shouldEqual "Molecule cc is not bound to any reaction site"
   }
 
   it should "refuse to read the value of a non-static molecule" in {

--- a/core/src/test/scala/io/chymyst/test/StaticMoleculesSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/StaticMoleculesSpec.scala
@@ -123,7 +123,7 @@ class StaticMoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests w
       )
       c()
     }
-    thrown.getMessage shouldEqual "Error: In Site{c/B + d → ...}: Reaction {c/B(_) + d(_) → d()} with inputs [c/B/P() + d/P()] finished without replying to c/B. Reported error: In Site{c/B + d → ...}: Reaction {c/B(_) + d(_) → d()} with inputs [c/B/P() + d/P()] produced an exception that is internal to Chymyst Core. Retry run was not scheduled. Message: In Site{c/B + d → ...}: Refusing to emit static molecule d() because this reaction {c/B(_) + d(_) → d()} already emitted it"
+    thrown.getMessage shouldEqual "Error: In Site{c/B + d → ...}: Reaction {c/B(_) + d(_) → d()} with inputs [c/B/P() + d/P()] finished without replying to c/B. Reported error: In Site{c/B + d → ...}: Reaction {c/B(_) + d(_) → d()} with inputs [c/B/P() + d/P()] produced an exception internal to Chymyst Core. Retry run was not scheduled. Message: In Site{c/B + d → ...}: Refusing to emit static molecule d() because this reaction {c/B(_) + d(_) → d()} already emitted it"
   }
 
   it should "signal error when a static molecule is consumed multiple times by reaction" in {
@@ -139,7 +139,7 @@ class StaticMoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests w
     thrown.getMessage shouldEqual "In Site{d + d + e → ...}: Incorrect static molecule declaration: static molecule (d) consumed 2 times by reaction d(_) + d(_) + e(_) → d()"
   }
 
-  it should "signal error when a static molecule is emitted but not bound to any reaction site" in {
+  it should "signal error when a static molecule is emitted but has no reactions" in {
     val thrown = intercept[Exception] {
       val d = m[Unit]
 
@@ -147,7 +147,38 @@ class StaticMoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests w
         go { case _ => d() } // static reaction
       )
     }
-    thrown.getMessage shouldEqual "Molecule d is not bound to any reaction site"
+    thrown.getMessage shouldEqual "In Site{}: Incorrect static molecule declaration: static molecule (d) not consumed by any reactions"
+  }
+
+  it should "signal error when a static molecule is emitted but bound to another reaction site" in {
+    val thrown = intercept[Exception] {
+      val d = m[Unit]
+
+      site(tp)(
+        go { case d(_) => }
+      )
+
+      site(tp)(
+        go { case _ => d() } // static reaction
+      )
+    }
+    thrown.getMessage shouldEqual "In Site{}: Incorrect static molecule declaration: static molecule (d) not consumed by any reactions"
+  }
+
+  it should "signal error when a static molecule is emitted but incorrectly bound to another reaction site" in {
+    val thrown = intercept[Exception] {
+      val d = m[Unit]
+
+      site(tp)(
+        go { case d(_) => }
+      )
+
+      site(tp)(
+        go { case d(_) => },
+        go { case _ => d() } // static reaction
+      )
+    }
+    thrown.getMessage shouldEqual "Molecule d cannot be used as input in Site{d → ...} since it is already bound to Site{d → ...}"
   }
 
   it should "signal error when a static molecule is emitted but not bound to this reaction site" in {
@@ -207,7 +238,7 @@ class StaticMoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests w
       cc.volatileValue shouldEqual null.asInstanceOf[Int] // If this passes, we are not detecting the fact that cc is not bound.
     }
 
-    thrown.getMessage shouldEqual "Molecule cc is not bound to any reaction site"
+    thrown.getMessage shouldEqual "Molecule cc is not bound to any reaction site, cannot read volatile value"
   }
 
   it should "refuse to read the value of a non-static molecule" in {

--- a/core/src/test/scala/io/chymyst/test/StaticMoleculesSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/StaticMoleculesSpec.scala
@@ -81,7 +81,7 @@ class StaticMoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests w
         go { case _ => d() } // static reaction
       )
     }
-    thrown.getMessage shouldEqual "In Site{c/B + d → ...}: Incorrect static molecule declaration: static molecule (d) consumed but not emitted by reaction c/B(_) + d(_) → "
+    thrown.getMessage shouldEqual "In Site{c/B + d → ...}: Incorrect static molecule declaration: static molecule (d) consumed but not emitted by reaction {c/B(_) + d(_) → }"
   }
 
   it should "signal error when a static molecule is consumed by reaction and emitted twice" in {
@@ -94,7 +94,7 @@ class StaticMoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests w
         go { case _ => d() } // static reaction
       )
     }
-    thrown.getMessage shouldEqual "In Site{c/B + d → ...}: Incorrect static molecule declaration: static molecule (d) emitted more than once by reaction c/B(_) + d(_) → d() + d()"
+    thrown.getMessage shouldEqual "In Site{c/B + d → ...}: Incorrect static molecule declaration: static molecule (d) emitted more than once by reaction {c/B(_) + d(_) → d() + d()}"
   }
 
   it should "signal error when a static molecule is emitted but not consumed by reaction" in {
@@ -109,7 +109,7 @@ class StaticMoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests w
         go { case _ => d() } // static reaction
       )
     }
-    thrown.getMessage shouldEqual "In Site{c/B → ...; e → ...}: Incorrect static molecule declaration: static molecule (d) emitted but not consumed by reaction c/B(_) → d(); static molecule (d) emitted but not consumed by reaction e(_) → d(); Incorrect static molecule declaration: static molecule (d) not consumed by any reactions"
+    thrown.getMessage shouldEqual "In Site{c/B → ...; e → ...}: Incorrect static molecule declaration: static molecule (d) emitted but not consumed by reaction {c/B(_) → d()}; static molecule (d) emitted but not consumed by reaction {e(_) → d()}; Incorrect static molecule declaration: static molecule (d) not consumed by any reactions"
   }
 
   it should "signal error when a static molecule is emitted by reaction inside a loop to trick static analysis" in {
@@ -136,7 +136,7 @@ class StaticMoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests w
         go { case _ => d() } // static reaction
       )
     }
-    thrown.getMessage shouldEqual "In Site{d + d + e → ...}: Incorrect static molecule declaration: static molecule (d) consumed 2 times by reaction d(_) + d(_) + e(_) → d()"
+    thrown.getMessage shouldEqual "In Site{d + d + e → ...}: Incorrect static molecule declaration: static molecule (d) consumed 2 times by reaction {d(_) + d(_) + e(_) → d()}"
   }
 
   it should "signal error when a static molecule is emitted but has no reactions" in {
@@ -195,7 +195,7 @@ class StaticMoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests w
         go { case _ => d() } // static reaction
       )
     }
-    thrown.getMessage shouldEqual "In Site{c/B → ...}: Incorrect static molecule declaration: static molecule (d) emitted but not consumed by reaction c/B(_) → d(); Incorrect static molecule declaration: static molecule (d) not consumed by any reactions"
+    thrown.getMessage shouldEqual "In Site{c/B → ...}: Incorrect static molecule declaration: static molecule (d) emitted but not consumed by reaction {c/B(_) → d()}; Incorrect static molecule declaration: static molecule (d) not consumed by any reactions"
   }
 
   it should "signal error when a static molecule is defined by a static reaction with guard" in {
@@ -210,7 +210,7 @@ class StaticMoleculesSpec extends FlatSpec with Matchers with TimeLimitedTests w
         go { case _ if n > 0 => d() } // static reaction
       )
     }
-    thrown.getMessage shouldEqual "In Site{c/B + d → ...}: Static reaction { if(?) → d()} should not have a guard condition"
+    thrown.getMessage shouldEqual "In Site{c/B + d → ...}: Static reaction {_ if(?) → d()} should not have a guard condition"
   }
 
   it should "refuse to define a blocking molecule as a static molecule" in {

--- a/docs/chymyst02.md
+++ b/docs/chymyst02.md
@@ -648,8 +648,11 @@ The chemical machine has two ways of preventing reactions from starting:
 
 If we wanted to use the first method, we would need to model all the allowed reactions with special auxiliary input molecules.
 We would have to define a new input molecule for each possible intermediate result: first, for each element of the initial array; then for each possible reduction between two consecutive elements; then for each possible reduction result between those, and so on.
-While this is certainly possible to implement, there will be a very large number of possible molecules and reactions for the scheduler to choose from,
-and the performance of this program will suffer.
+While this is certainly possible to implement, it would require is to define _O_(_n_<sub>2</sub>) different molecules and _O_(_n_<sub>3</sub>) different reactions,
+where _n_ is the number of the initial `interm()` molecules before first `reduceB()` is called.  
+This means a very large number of possible molecules and reactions for the scheduler to choose from:
+we will need _O_(_n_<sub>3</sub>) operations just to define the chemistry for this code, which will then run only _O_(_n_) reduce steps.
+For this reason, the code will run unacceptably slowly if implemented in this way.
 
 The solution with the second method is to put a condition on the reaction `interm + interm → interm` so that it will only run between consecutive intermediate results.
 To identify such intermediate results, we need to put an ordering label on the `interm()` molecule values, which will allow us to write a reaction like this:
@@ -703,7 +706,7 @@ go { case interm((l1, n1, x1)) + interm((l2, n2, x2))
 ```
 
 This optimization is completely mechanical: it consists of permuting the order of repeated molecules before applying the guard condition.
-The chemical machine could perform this optimization automatically for all such reactions.
+The chemical machine could perform this code transformation automatically for all such reactions.
 As of version 0.1.8, `Chymyst Core` does not implement this optimization.
 
 ## Example: Concurrent merge-sort

--- a/docs/chymyst03.md
+++ b/docs/chymyst03.md
@@ -270,7 +270,7 @@ A side benefit is that emitting `read()` and `write()` will get unblocked only _
 The price for this convenience is that the Reader thread will remain blocked until access is granted.
 The non-blocking version of the code never blocks any threads, which improves parallelism.
 
-## Nonblocking transformation
+## The "Nonblocking Transformation"
 
 By comparing two versions of the Readers/Writers code, we notice that there is a certain correspondence between blocking and non-blocking code.
 A reaction that emits a blocking molecule is equivalent to two reactions with a new auxiliary reply molecule defined in the scope of the first reaction.

--- a/docs/chymyst_features.md
+++ b/docs/chymyst_features.md
@@ -97,7 +97,7 @@ def f(x1) + f(x2) + g() =>
 
 ```
 
-However, this code does not specify that the reply value `x2` should be sent to the process that emitted `f(x1)` rather than to the process that emitted `f(x2)`.
+However, this code cannot specify that the reply value `x2` should be sent to the process that emitted `f(x1)` rather than to the process that emitted `f(x2)`.
 
 ## Reactions are values
 

--- a/docs/other_work.md
+++ b/docs/other_work.md
@@ -11,8 +11,9 @@ Here are some previous implementations of Join Calculus that I was able to find.
 - Joins library for .NET: [P. Crusso 2006](http://research.microsoft.com/en-us/um/people/crusso/joins/). The project is available as a .NET binary download from Microsoft Research.
 - `ScalaJoins`, a prototype implementation in Scala: [P. Haller 2008](http://lampwww.epfl.ch/~phaller/joins/index.html). The project is not maintained.
 - `ScalaJoin`: an improvement over `ScalaJoins`, [J. He 2011](https://github.com/Jiansen/ScalaJoin). The project is not maintained.
-- Joinads, a not-quite-Join-Calculus implementation in F# and Haskell: [Petricek and Syme 2011](https://www.microsoft.com/en-us/research/publication/joinads-a-retargetable-control-flow-construct-for-reactive-parallel-and-concurrent-programming/). The project is not maintained.
-- Proof-of-concept implementations of Join Calculus for iOS: [CocoaJoin](https://github.com/winitzki/AndroJoin) and Android: [AndroJoin](https://github.com/winitzki/AndroJoin). These projects are not maintained.
+- "Joinads", a Join-Calculus implementation as a compiler patch for F# and Haskell: [Petricek and Syme 2011](https://www.microsoft.com/en-us/research/publication/joinads-a-retargetable-control-flow-construct-for-reactive-parallel-and-concurrent-programming/). The project is not maintained.
+- Implementations of Join Calculus for iOS: [CocoaJoin](https://github.com/winitzki/AndroJoin) and for Android: [AndroJoin](https://github.com/winitzki/AndroJoin). These projects are not maintained.
+- [Join-Language](https://github.com/syallop/Join-Language): implementation of Join Calculus as an embedded Haskell DSL (2014)
 
 The implementation of JC in `Chymyst` is based on ideas from Jiansen He's `ScalaJoin` as well as on CocoaJoin / AndroJoin.
 


### PR DESCRIPTION
Implement finer granularity in the reaction scheduler, as an automatic optimization.

Reactions involving independent molecules should be scheduled concurrently whenever enough molecules are present. The reaction scheduler should not lock the entire set of all molecules while looking for molecule values. Instead, it should implement granular subset locking, so that several instances of reaction scheduler could look for their molecule values concurrently, when this does not modify the result of the computation.