### PR TITLE
Second attempt to implement granular reactions

### DIFF
--- a/benchmark/src/test/scala/io/chymyst/benchmark/MapReduceSpec.scala
+++ b/benchmark/src/test/scala/io/chymyst/benchmark/MapReduceSpec.scala
@@ -265,7 +265,8 @@ class MapReduceSpec extends FlatSpec with Matchers {
     (if (failures > 0) s"Detected $failures failures out of $n tries" else "OK") shouldEqual "OK"
   }
 
-  /** A binary operation on integers that is associative but not commutative.
+  /** A simple binary operation on integers that is associative but not commutative.
+    * op(x,y) = x + y if x is even, and x - y if x is odd.
     * See: F. J. Budden. A Non-Commutative, Associative Operation on the Reals. The Mathematical Gazette, Vol. 54, No. 390 (Dec., 1970), pp. 368-372
     * http://www.jstor.org/stable/3613855
     *
@@ -273,7 +274,7 @@ class MapReduceSpec extends FlatSpec with Matchers {
     * @param y Second integer.
     * @return Integer result.
     */
-  def assocNonCommut(x: Int, y: Int): Int = {
+  def assocNonCommutOperation(x: Int, y: Int): Int = {
     val s = 1 - math.abs(x % 2) * 2 // s = 1 if x is even, s = -1 if x is odd; math.abs is needed to fix the bug where (-1) % 2 == -1
     x + s * y
   }
@@ -297,7 +298,7 @@ class MapReduceSpec extends FlatSpec with Matchers {
       go { case c((l1, r1, x)) + c((l2, r2, y)) if r2 == l1 || l2 == r1 =>
         val l3 = math.min(l1, l2)
         val r3 = math.max(r1, r2)
-        val z = if (l2 == r1) assocNonCommut(x, y) else assocNonCommut(y, x)
+        val z = if (l2 == r1) assocNonCommutOperation(x, y) else assocNonCommutOperation(y, x)
         if (r3 - l3 == count)
           done(z)
         else
@@ -306,7 +307,7 @@ class MapReduceSpec extends FlatSpec with Matchers {
     )
 
     (1 to count).foreach(i => c((i, i + 1, i * i)))
-    f() shouldEqual (1 to count).map(i => i * i).reduce(assocNonCommut)
+    f() shouldEqual (1 to count).map(i => i * i).reduce(assocNonCommutOperation)
     println(s"associative but non-commutative reduceB() on $count numbers with nonlinear input patterns and $nThreadsSite-thread site pool took ${elapsed(initTime)} ms")
 
   }
@@ -345,7 +346,7 @@ class MapReduceSpec extends FlatSpec with Matchers {
       val mol1 = emitters((i, j))
       val mol2 = emitters((j, k))
       val mol3 = emitters((i, k))
-      go { case mol1(x) + mol2(y) ⇒ mol3(assocNonCommut(x, y)) }
+      go { case mol1(x) + mol2(y) ⇒ mol3(assocNonCommutOperation(x, y)) }
     })) :+ go { case lastMol(x) ⇒ done(x) }
 
     println(s"created emitters and reactions: at ${elapsed(initTime)} ms")
@@ -355,7 +356,7 @@ class MapReduceSpec extends FlatSpec with Matchers {
     println(s"defined reactions: at ${elapsed(initTime)} ms")
 
     (1 to count).foreach(i ⇒ emitters((i - 1, i))(i * i))
-    f() shouldEqual (1 to count).map(i => i * i).reduce(assocNonCommut)
+    f() shouldEqual (1 to count).map(i => i * i).reduce(assocNonCommutOperation)
     println(s"associative but non-commutative reduceB() on $count numbers with ${emitters.size} unique molecules, ${reactions.size} unique reactions, and $nThreadsSite-thread site pool took ${elapsed(initTime)} ms")
   }
 

--- a/benchmark/src/test/scala/io/chymyst/benchmark/MapReduceSpec.scala
+++ b/benchmark/src/test/scala/io/chymyst/benchmark/MapReduceSpec.scala
@@ -24,7 +24,7 @@ class MapReduceSpec extends FlatSpec with Matchers {
     site(tp)(
       go { case d(n) => r(n * 2) },
       go { case res(list) + r(s) => res(s :: list) },
-      go { case get(_, reply) + res(list) if list.size == count => reply(list) } // expect warning: "non-variable type argument Int in type pattern List[Int] eliminated by erasure"
+      go { case get(_, reply) + res(list) if list.size == count => reply(list) } // ignore warning: "non-variable type argument Int"
     )
 
     (1 to count).foreach(d(_))

--- a/core/src/main/scala/io/chymyst/jc/Core.scala
+++ b/core/src/main/scala/io/chymyst/jc/Core.scala
@@ -161,6 +161,14 @@ object Core {
       if (success) Some(result) else None
     }
 
+    /** A `find` that will return the first value for which `f` returns `Some(...)`.
+      *
+      * This is an optimization over `find`: it does not compute the found value `f(r)` twice.
+      *
+      * @param f Mapping function.
+      * @tparam R Type of the return value `r` under `Option`.
+      * @return `Some(r)` if `f` returned a non-empty option value; `None` otherwise.
+      */
     def findAfterMap[R](f: T => Option[R]): Option[R] = {
       var result: R = null.asInstanceOf[R]
       var found = false
@@ -340,7 +348,7 @@ object Core {
   }
 
   def streamDiff[T](s: Iterator[T], skipBag: MutableMultiset[T]): Iterator[T] = {
-    s.filter{ t ⇒
+    s.filter { t ⇒
       if (skipBag contains t) {
         skipBag.remove(t)
         false

--- a/core/src/main/scala/io/chymyst/jc/Core.scala
+++ b/core/src/main/scala/io/chymyst/jc/Core.scala
@@ -1,6 +1,7 @@
 package io.chymyst.jc
 
 import java.security.MessageDigest
+import java.time.LocalDateTime
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicLong
 
@@ -352,4 +353,7 @@ object Core {
 
   private[jc] def unboundOutputMoleculesString(nonStaticReactions: Seq[Reaction]): String = unboundOutputMolecules(nonStaticReactions).map(_.toString).toList.sorted.mkString(", ")
 
+  private[jc] def logMessage(s: String): Unit = {
+    println(s"${LocalDateTime.now}: $s")
+  }
 }

--- a/core/src/main/scala/io/chymyst/jc/Molecules.scala
+++ b/core/src/main/scala/io/chymyst/jc/Molecules.scala
@@ -218,7 +218,7 @@ final class M[T](val name: String) extends (T => Unit) with Molecule {
   private[jc] def assignStaticMolVolatileValue(molValue: AbsMolValue[_]) =
     volatileValueRef.set(molValue.asInstanceOf[MolValue[T]].moleculeValue)
 
-  private var volatileValueRef: AtomicReference[T] = new AtomicReference[T]()
+  private val volatileValueRef: AtomicReference[T] = new AtomicReference[T]()
 
   override lazy val isStatic: Boolean = reactionSiteWrapper.isStatic()
 

--- a/core/src/main/scala/io/chymyst/jc/Reaction.scala
+++ b/core/src/main/scala/io/chymyst/jc/Reaction.scala
@@ -722,17 +722,6 @@ final case class Reaction(
   // Optimization: this is used often.
   private[jc] val inputMoleculesSet = inputMoleculesSortedAlphabetically.toSet
 
-  // Compute the initial molecule value lock. This requires site-wide indices.
-  private[jc] def getMoleculeValueLock = {
-    val counts: Map[Int, Int] = info.inputsSortedIndependentIrrefutableGrouped
-      .map { case (i, a) ⇒ (i, a.length) }(scala.collection.breakOut)
-    val molecules: Set[Int] = info.inputs
-      .map(_.molecule.siteIndex)
-      .toSet
-      .diff(counts.keySet)
-    MoleculeValueLock(counts, molecules)
-  }
-
   /** A table of required molecule counts for each input molecule in this reaction.
     * This is an optimization used when searching for independent molecule values.
     *

--- a/core/src/main/scala/io/chymyst/jc/Reaction.scala
+++ b/core/src/main/scala/io/chymyst/jc/Reaction.scala
@@ -1,7 +1,5 @@
 package io.chymyst.jc
 
-import java.security.MessageDigest
-
 import Core._
 
 import scala.{Symbol => ScalaSymbol}
@@ -674,6 +672,7 @@ final class ReactionInfo(
 
 /** Represents a reaction body. This class is immutable.
   *
+  * @param info       A value of type [[ReactionInfo]] describing input and output molecules for this reaction.
   * @param body       Partial function of type `InputMoleculeList => Any`
   * @param threadPool Thread pool on which this reaction will be scheduled. (By default, the common pool is used.)
   * @param retry      Whether the reaction should be run again when an exception occurs in its body. Default is false.
@@ -681,8 +680,8 @@ final class ReactionInfo(
 final case class Reaction(
   private[jc] val info: ReactionInfo,
   private[jc] val body: ReactionBody,
-  private[jc] val threadPool: Option[Pool],
-  private[jc] val retry: Boolean
+  threadPool: Option[Pool],
+  retry: Boolean
 ) {
   private[jc] def newChymystThreadInfo = new ChymystThreadInfo(info.staticMols.map(_.siteIndex), info.toString)
 
@@ -715,16 +714,16 @@ final case class Reaction(
       .sortBy(_.toString)
 
   // java.security.MessageDigest is not thread safe, so we use a new MessageDigest for each reaction.
-  private lazy val md: MessageDigest = getMessageDigest
+  private lazy val messageDigest = getMessageDigest
 
   private[jc] lazy val inputInfoSha1: String =
-    getSha1(inputMoleculesSortedAlphabetically.map(_.hashCode()).mkString(","), md) + info.sha1
+    getSha1(inputMoleculesSortedAlphabetically.map(_.hashCode()).mkString(","), messageDigest) + info.sha1
 
   // Optimization: this is used often.
-  private[jc] val inputMoleculesSet: Set[Molecule] = inputMoleculesSortedAlphabetically.toSet
+  private[jc] val inputMoleculesSet = inputMoleculesSortedAlphabetically.toSet
 
   // Compute the initial molecule value lock. This requires site-wide indices.
-  private[jc] lazy val initialMoleculeValueLock = {
+  private[jc] def initialMoleculeValueLock = {
     val counts: Map[Int, Int] = info.inputsSortedIndependentIrrefutableGrouped
       .map { case (i, a) ⇒ (i, a.length) }(scala.collection.breakOut)
     val molecules: Set[Int] = info.inputs

--- a/core/src/main/scala/io/chymyst/jc/Reaction.scala
+++ b/core/src/main/scala/io/chymyst/jc/Reaction.scala
@@ -723,7 +723,7 @@ final case class Reaction(
   private[jc] val inputMoleculesSet = inputMoleculesSortedAlphabetically.toSet
 
   // Compute the initial molecule value lock. This requires site-wide indices.
-  private[jc] def initialMoleculeValueLock = {
+  private[jc] def getMoleculeValueLock = {
     val counts: Map[Int, Int] = info.inputsSortedIndependentIrrefutableGrouped
       .map { case (i, a) ⇒ (i, a.length) }(scala.collection.breakOut)
     val molecules: Set[Int] = info.inputs

--- a/core/src/main/scala/io/chymyst/jc/SmartPool.scala
+++ b/core/src/main/scala/io/chymyst/jc/SmartPool.scala
@@ -2,6 +2,8 @@ package io.chymyst.jc
 
 import java.util.concurrent._
 
+import io.chymyst.jc.Core.logMessage
+
 /** This is similar to scala.concurrent.blocking and is used to annotate expressions that should lead to a possible increase of thread count.
   * Multiple nested calls to `BlockingIdle` are equivalent to one call.
   */
@@ -33,7 +35,7 @@ class SmartPool(parallelism: Int = cpuCores) extends Pool {
       executor.setMaximumPoolSize(newPoolSize)
       executor.setCorePoolSize(newPoolSize)
     } else {
-      println(s"Chymyst Core warning: In $this: It is dangerous to increase the pool size, which is now $currentPoolSize. Memory is ${Runtime.getRuntime.maxMemory}")
+      logMessage(s"Chymyst Core warning: In $this: It is dangerous to increase the pool size, which is now $currentPoolSize. Memory is ${Runtime.getRuntime.maxMemory}")
     }
   }
 

--- a/docs/chymyst-core.md
+++ b/docs/chymyst-core.md
@@ -131,7 +131,12 @@ The status value will be `true` only if the caller has actually received the rep
 ## Debugging
 
 Molecule emitters have the method `setLogLevel`, which is by default set to `-1`.
-Nonnegative values will lead to more debugging output.
+Nonnegative values will lead to more debugging output:
+
+- level 0 will print all internal error messages and exceptions occurring within reactions
+- level 1 will print messages about emitting molecules and removing blocking molecules after timeout
+- level 2 will print messages about scheduling and starting reactions 
+- level 3 will print messages about molecules remaining after starting a reaction, as well as messages about no reactions started 
 
 The log level will affect the entire reaction site to which the molecule is bound.
 


### PR DESCRIPTION
Implement finer granularity in the reaction scheduler, as an automatic optimization.

Reactions involving independent molecules should be scheduled concurrently whenever enough molecules are present. The reaction scheduler should not lock the entire set of all molecules while looking for molecule values. Instead, it should implement granular subset locking, so that several instances of reaction scheduler could look for their molecule values concurrently, when this does not modify the result of the computation.