### PR TITLE
restore coverage for non-constant matchers

### DIFF
--- a/core/src/main/scala/io/chymyst/jc/Reaction.scala
+++ b/core/src/main/scala/io/chymyst/jc/Reaction.scala
@@ -347,7 +347,8 @@ final case class InputMoleculeInfo(molecule: Molecule, index: Int, flag: InputPa
           case ConstInputPattern(c) =>
             Some(matcher1.isDefinedAt(c))
           case OtherInputPattern(_, _, false) =>
-            if (sha1 === info.sha1) Some(true)
+            if (sha1 === info.sha1)
+              Some(true)
             else None // We can reliably determine identical matchers.
           case _ =>
             Some(false) // Here we can reliably determine that this matcher is not weaker.

--- a/core/src/test/scala/io/chymyst/test/MoleculesSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/MoleculesSpec.scala
@@ -15,7 +15,7 @@ class MoleculesSpec extends LogSpec with Matchers with TimeLimitedTests with Bef
 
   implicit val patienceConfig = PatienceConfig(timeout = Span(500, Millis))
 
-  def logShouldHave(message: String): Unit = {
+  def logShouldHave(message: String) = {
     globalErrorLog.exists(_ endsWith message) should be(true)
   }
 


### PR DESCRIPTION
Coverage has slipped due to optimizations in shadowing detection.