### PR TITLE
refactor FixedPool

### DIFF
--- a/benchmark/src/main/scala/io/chymyst/benchmark/Benchmarks1.scala
+++ b/benchmark/src/main/scala/io/chymyst/benchmark/Benchmarks1.scala
@@ -17,7 +17,7 @@ object Benchmarks1 {
     val d = m[Unit]
     val f = b[LocalDateTime,Long]
 
-    withPool(new FixedPool(8)) { tp1 =>
+    withPool(FixedPool(8)) { tp1 =>
       site(tp)( // Right now we don't use tp1. If we use `site(tp, tp1)`, the run time is increased by factor 2.
         go { case c(0) + f(tInit, r) =>
           r(elapsed(tInit))

--- a/benchmark/src/main/scala/io/chymyst/benchmark/Benchmarks9.scala
+++ b/benchmark/src/main/scala/io/chymyst/benchmark/Benchmarks9.scala
@@ -84,7 +84,7 @@ object Benchmarks9 {
     val all_done = m[Int]
     val f = b[LocalDateTime,Long]
 
-    val tp = new BlockingPool(MainAppConfig.threads) // this benchmark will not work with a fixed pool
+    val tp = BlockingPool(MainAppConfig.threads) // this benchmark will not work with a fixed pool
 
     site(tp)(
       go { case all_done(0) + f(tInit, r) => r(elapsed(tInit)) },

--- a/benchmark/src/main/scala/io/chymyst/benchmark/MainApp.scala
+++ b/benchmark/src/main/scala/io/chymyst/benchmark/MainApp.scala
@@ -55,7 +55,7 @@ object MainApp extends App {
   ).zipWithIndex.foreach {
     case ((message, benchmark), i) => println(s"Benchmark ${i + 1} took ${
       run3times {
-        val tp = new FixedPool(threads)
+        val tp = FixedPool(threads)
         val result = benchmark(n, tp)
         tp.shutdownNow()
         result

--- a/benchmark/src/main/scala/io/chymyst/benchmark/MergeSort.scala
+++ b/benchmark/src/main/scala/io/chymyst/benchmark/MergeSort.scala
@@ -33,8 +33,8 @@ object MergeSort {
 
     val finalResult = m[Coll[T]]
     val getFinalResult = b[Unit, Coll[T]]
-    val reactionPool = new FixedPool(threads)
-    val pool2 = new FixedPool(threads)
+    val reactionPool = FixedPool(threads)
+    val pool2 = FixedPool(threads)
 
     site(pool2)(
       go { case finalResult(arr) + getFinalResult(_, r) => r(arr) }

--- a/benchmark/src/test/scala/io/chymyst/benchmark/EightQueensSpec.scala
+++ b/benchmark/src/test/scala/io/chymyst/benchmark/EightQueensSpec.scala
@@ -23,8 +23,8 @@ class EightQueensSpec extends LogSpec {
   }
 
   def run3Queens(supply: Int, boardSize: Int, iterations: Int): Unit = {
-    val tp = new FixedPool(2)
-    val tp2 = new FixedPool(2)
+    val tp = FixedPool(2)
+    val tp2 = FixedPool(2)
     val pos = m[(Int, Int)]
     val done = m[Seq[(Int, Int)]]
     val all_done = m[Unit]
@@ -68,8 +68,8 @@ class EightQueensSpec extends LogSpec {
   }
 
   def run5Queens(supply: Int, boardSize: Int, iterations: Int): Unit = {
-    val tp = new FixedPool(2)
-    val tp2 = new FixedPool(2)
+    val tp = FixedPool(2)
+    val tp2 = FixedPool(2)
     val pos = m[(Int, Int)]
     val done = m[Seq[(Int, Int)]]
     val all_done = m[Unit]
@@ -121,8 +121,8 @@ class EightQueensSpec extends LogSpec {
   }
 
   def run8Queens(supply: Int, boardSize: Int): Seq[(Int, Int)] = {
-    val tp = new FixedPool(1)
-    val tp2 = new FixedPool(2)
+    val tp = FixedPool(1)
+    val tp2 = FixedPool(2)
     val pos = m[(Int, Int)]
     val done = m[Seq[(Int, Int)]]
     val finished = b[Unit, Seq[(Int, Int)]]
@@ -240,15 +240,15 @@ class EightQueensSpec extends LogSpec {
 
   it should "obtain solutions for 3 queens on 4x4 board using n-queens scheme" in {
     // 3 queens exist when board size is at least a 4x4, and require no backtracking
-    withPool(new FixedPool(2))(tp2 => withPool(new FixedPool(2)) { tp ⇒ runNQueens(nQueens = 3, supply = 10, boardSize = 4, iterations = 20000, timeout = 200, tp, tp2) })
+    withPool(FixedPool(2))(tp2 => withPool(FixedPool(2)) { tp ⇒ runNQueens(nQueens = 3, supply = 10, boardSize = 4, iterations = 20000, timeout = 200, tp, tp2) })
   }
 
   it should "obtain solutions for 8 queens on 12x12 board using n-queens scheme" in {
-    withPool(new FixedPool(2))(tp2 => withPool(new FixedPool(2)) { tp ⇒ runNQueens(nQueens = 8, supply = 10, boardSize = 10, iterations = 1000, timeout = 200, tp, tp2) })
+    withPool(FixedPool(2))(tp2 => withPool(FixedPool(2)) { tp ⇒ runNQueens(nQueens = 8, supply = 10, boardSize = 10, iterations = 1000, timeout = 200, tp, tp2) })
   }
 
   it should "obtain solutions for 8 queens on 8x8 board using n-queens scheme" in {
-    withPool(new FixedPool(2))(tp2 => withPool(new FixedPool(2)) { tp ⇒ runNQueens(nQueens = 8, supply = 10, boardSize = 8, iterations = 100, timeout = 200, tp, tp2) })
+    withPool(FixedPool(2))(tp2 => withPool(FixedPool(2)) { tp ⇒ runNQueens(nQueens = 8, supply = 10, boardSize = 8, iterations = 100, timeout = 200, tp, tp2) })
   }
 
   behavior of "eight queens problem - hard-coded number of queens, one RS"

--- a/benchmark/src/test/scala/io/chymyst/benchmark/MapReduceSpec.scala
+++ b/benchmark/src/test/scala/io/chymyst/benchmark/MapReduceSpec.scala
@@ -22,7 +22,7 @@ class MapReduceSpec extends LogSpec {
     val d = m[Int]
     val get = b[Unit, List[Int]]
 
-    val tp = new FixedPool(4)
+    val tp = FixedPool(4)
     site(tp)(
       go { case d(n) => r(n * 2) },
       go { case res(list) + r(s) => res(s :: list) },
@@ -55,7 +55,7 @@ class MapReduceSpec extends LogSpec {
     val accum = m[(Int, Int)]
     val fetch = b[Unit, Int]
 
-    val tp = new FixedPool(8)
+    val tp = FixedPool(8)
 
     // declare the reaction for "map"
     site(tp)(
@@ -93,8 +93,8 @@ class MapReduceSpec extends LogSpec {
     val interm = m[(Int, Int)]
     val fetch = b[Unit, Int]
 
-    val tp = new FixedPool(8)
-    val tp2 = new FixedPool(1)
+    val tp = FixedPool(8)
+    val tp2 = FixedPool(1)
 
     // reactions for "reduce" must be together since they share "interm"
     site(tp)(
@@ -132,8 +132,8 @@ class MapReduceSpec extends LogSpec {
     val fetch = b[Unit, Int]
     val done = m[Int]
 
-    val tp = new FixedPool(8)
-    val tp2 = new FixedPool(1)
+    val tp = FixedPool(8)
+    val tp2 = FixedPool(1)
 
     // reactions for "reduce" must be together since they share "interm"
     site(tp)(
@@ -165,7 +165,7 @@ class MapReduceSpec extends LogSpec {
 
     val count = 10000
 
-    val tp = new FixedPool(cpuCores + 1)
+    val tp = FixedPool(cpuCores + 1)
     val initTime = System.currentTimeMillis()
 
     site(tp)(
@@ -194,8 +194,8 @@ class MapReduceSpec extends LogSpec {
 
     val count = 10000
 
-    val tp = new FixedPool(cpuCores + 1)
-    val tp2 = new FixedPool(1)
+    val tp = FixedPool(cpuCores + 1)
+    val tp2 = FixedPool(1)
     val initTime = System.currentTimeMillis()
 
     site(tp)(
@@ -226,9 +226,9 @@ class MapReduceSpec extends LogSpec {
 
     val count = 100000
 
-    val tp = new FixedPool(cpuCores + 1)
-    val tp2 = new FixedPool(1)
-    val tp3 = new FixedPool(1)
+    val tp = FixedPool(cpuCores + 1)
+    val tp2 = FixedPool(1)
+    val tp3 = FixedPool(1)
     val initTime = System.currentTimeMillis()
 
     site(tp2)(
@@ -287,7 +287,7 @@ class MapReduceSpec extends LogSpec {
     val count = 2
 
     (1 to n).foreach { _ ⇒
-      val tp = new FixedPool(numberOfCounters)
+      val tp = FixedPool(numberOfCounters)
 
       val done = m[Unit]
       val all_done = m[Int]
@@ -346,8 +346,8 @@ class MapReduceSpec extends LogSpec {
     val done = m[Int]
     val f = b[Unit, Int]
 
-    val tp = new FixedPool(cpuCores)
-    val tp2 = new FixedPool(1)
+    val tp = FixedPool(cpuCores)
+    val tp2 = FixedPool(1)
     val initTime = System.currentTimeMillis()
 
     site(tp2)(
@@ -384,7 +384,7 @@ class MapReduceSpec extends LogSpec {
 
     val count = 30
 
-    val tp = new FixedPool(cpuCores)
+    val tp = FixedPool(cpuCores)
     val initTime = System.currentTimeMillis()
 
     site(tp)(
@@ -532,8 +532,8 @@ class MapReduceSpec extends LogSpec {
   }
 
   it should "use algorithm with binary split" in {
-    val tp = new FixedPool(cpuCores + 2)
-    val tp1 = new FixedPool(1)
+    val tp = FixedPool(cpuCores + 2)
+    val tp1 = FixedPool(1)
 
     val result = m[Int]
     val f = b[Unit, Int]
@@ -554,8 +554,8 @@ class MapReduceSpec extends LogSpec {
   }
 
   it should "use algorithm with optimizations in binary split" in {
-    val tp = new FixedPool(cpuCores + 2)
-    val tp1 = new FixedPool(1)
+    val tp = FixedPool(cpuCores + 2)
+    val tp1 = FixedPool(1)
 
     val result = m[Int]
     val f = b[Unit, Int]
@@ -576,8 +576,8 @@ class MapReduceSpec extends LogSpec {
   }
 
   it should "use algorithm with ternary split" in {
-    val tp = new FixedPool(cpuCores + 2)
-    val tp1 = new FixedPool(1)
+    val tp = FixedPool(cpuCores + 2)
+    val tp1 = FixedPool(1)
 
     val result = m[Int]
     val f = b[Unit, Int]
@@ -598,8 +598,8 @@ class MapReduceSpec extends LogSpec {
   }
 
   it should "use algorithm with log(n) reaction sites" in {
-    val tp = new FixedPool(cpuCores + 2)
-    val tp1 = new FixedPool(1)
+    val tp = FixedPool(cpuCores + 2)
+    val tp1 = FixedPool(1)
 
     val count = countHierarchical
 

--- a/benchmark/src/test/scala/io/chymyst/benchmark/MultithreadSpec.scala
+++ b/benchmark/src/test/scala/io/chymyst/benchmark/MultithreadSpec.scala
@@ -21,7 +21,7 @@ class MultithreadSpec extends LogSpec {
       val finished = m[Unit]
       val counter = m[Int]
       val allFinished = b[Unit, Unit]
-      val tp = new FixedPool(threads)
+      val tp = FixedPool(threads)
       site(tp)(
         go { case work(_) => performWork(); finished() },
         go { case counter(n) + finished(_) => counter(n-1) },

--- a/benchmark/src/test/scala/io/chymyst/benchmark/ReactionDelaySpec.scala
+++ b/benchmark/src/test/scala/io/chymyst/benchmark/ReactionDelaySpec.scala
@@ -17,7 +17,7 @@ class ReactionDelaySpec extends LogSpec {
 
   it should "measure simple statistics on reaction delay" in {
     val f = b[Unit, Unit]
-    val tp = new BlockingPool(4)
+    val tp = BlockingPool(4)
     site(tp)(
       go { case f(_, r) => r() }
     )
@@ -36,7 +36,7 @@ class ReactionDelaySpec extends LogSpec {
   it should "measure simple statistics on reaction delay with extra delay" in {
     val extraDelay = 1L
     val f = b[Unit, Unit]
-    val tp = new BlockingPool(4)
+    val tp = BlockingPool(4)
     site(tp)(
       go { case f(_, r) =>
         BlockingIdle {
@@ -64,7 +64,7 @@ class ReactionDelaySpec extends LogSpec {
     val all_done = b[Unit, List[Double]]
     val done = m[Double]
     val begin = m[Unit]
-    val tp = new BlockingPool(4)
+    val tp = BlockingPool(4)
 
     val trials = 800
 
@@ -99,7 +99,7 @@ class ReactionDelaySpec extends LogSpec {
     val a = m[Long]
     val c = m[Long]
     val f = b[Unit, Long]
-    val tp = new BlockingPool(4)
+    val tp = BlockingPool(4)
     site(tp)(
       go { case c(x) + f(_, r) => r(x) },
       go { case a(d) =>
@@ -219,7 +219,7 @@ class ReactionDelaySpec extends LogSpec {
     val trials = 500
     val maxTimeout = 500
 
-    val tp = new BlockingPool(4)
+    val tp = BlockingPool(4)
 
     val result = processResults(measureTimeoutDelays(trials, maxTimeout, tp))
 
@@ -232,7 +232,7 @@ class ReactionDelaySpec extends LogSpec {
     val trials = 20
     val maxTimeout = 200
 
-    val tp = new FixedPool(4)
+    val tp = FixedPool(4)
 
     val result = processResults(measureTimeoutDelays(trials, maxTimeout, tp))
 
@@ -246,7 +246,7 @@ class ReactionDelaySpec extends LogSpec {
   val total = 10000
 
   it should "measure the reply delay using blocking molecules" in {
-    val tp = new FixedPool(1)
+    val tp = FixedPool(1)
 
     val f = b[Unit, Long]
 
@@ -270,7 +270,7 @@ class ReactionDelaySpec extends LogSpec {
   }
 
   it should "measure the reply delay using promises" in {
-    val tp = new FixedPool(1)
+    val tp = FixedPool(1)
 
     val f = m[Promise[Long]]
 
@@ -475,7 +475,7 @@ class ReactionDelaySpec extends LogSpec {
   }
 
   it should "measure emitting non-blocking molecules" in {
-    val tp = new FixedPool(1)
+    val tp = FixedPool(1)
     val c = m[Unit]
     site(tp)(go { case c(_) ⇒ })
     val total = 10000
@@ -503,7 +503,7 @@ class ReactionDelaySpec extends LogSpec {
   }
 
   it should "measure emitting non-blocking molecules using one while loop" in {
-    val tp = new FixedPool(1)
+    val tp = FixedPool(1)
     val c = m[Unit]
     site(tp)(go { case c(_) ⇒ })
     val total = 10000
@@ -525,7 +525,7 @@ class ReactionDelaySpec extends LogSpec {
   }
 
   it should "measure emitting non-blocking molecules using two while loops" in {
-    val tp = new FixedPool(1)
+    val tp = FixedPool(1)
     val c = m[Unit]
     site(tp)(go { case c(_) ⇒ })
     val total = 10000
@@ -624,7 +624,7 @@ class ReactionDelaySpec extends LogSpec {
   }
 
   it should "measure creating a new reaction site" in {
-    val tp = new FixedPool(1)
+    val tp = FixedPool(1)
     val total = 1000
     val drop = 20
     val iterations = 40

--- a/benchmark/src/test/scala/io/chymyst/benchmark/ReactionDelaySpec.scala
+++ b/benchmark/src/test/scala/io/chymyst/benchmark/ReactionDelaySpec.scala
@@ -243,7 +243,7 @@ class ReactionDelaySpec extends LogSpec {
 
   behavior of "blocking reply via promise"
 
-  val total = 10000
+  val total = 1000
 
   it should "measure the reply delay using blocking molecules" in {
     val tp = FixedPool(1)
@@ -251,8 +251,8 @@ class ReactionDelaySpec extends LogSpec {
     val f = b[Unit, Long]
 
     site(tp)(go { case f(_, r) ⇒ r(System.nanoTime()) })
-
-    val res = (1 to 10).map { _ ⇒
+    val drop = 10
+    val res = (1 to 20 + drop).map { i ⇒
       val results = (1 to total).map { _ ⇒
         val t = System.nanoTime()
         val r = f()
@@ -262,9 +262,9 @@ class ReactionDelaySpec extends LogSpec {
       val resLaunch = results.map(_._2)
       val aveDelay = resDelay.sum / resDelay.length
       val aveLaunch = resLaunch.sum / resLaunch.length
-      println(s"Average reply delay with blocking molecules: $aveDelay ns; average launch time: $aveLaunch ns")
+      println(s"Average reply delay with blocking molecules (iteration $i): $aveDelay ns; average launch time: $aveLaunch ns")
       (aveDelay, aveLaunch)
-    }.drop(2)
+    }.drop(drop)
     println(s"Reply delay with blocking molecules: after ${res.length} tries, average is ${res.map(_._1).sum / res.length}, average launch time is ${res.map(_._2).sum / res.length}")
     tp.shutdownNow()
   }
@@ -276,7 +276,7 @@ class ReactionDelaySpec extends LogSpec {
 
     site(tp)(go { case f(promise) ⇒ promise.success(System.nanoTime()) })
     val drop = 10
-    val res = (1 to 20 + drop).map { _ ⇒
+    val res = (1 to 20 + drop).map { i ⇒
       val results = (1 to total).map { _ ⇒
         val t = System.nanoTime()
         val p = Promise[Long]()
@@ -288,7 +288,7 @@ class ReactionDelaySpec extends LogSpec {
       val resLaunch = results.map(_._2)
       val aveDelay = resDelay.sum / resDelay.length
       val aveLaunch = resLaunch.sum / resLaunch.length
-      println(s"Average reply delay with blocking molecules: $aveDelay ns; average launch time: $aveLaunch ns")
+      println(s"Average reply delay with blocking molecules using promises (iteration $i): $aveDelay ns; average launch time: $aveLaunch ns")
       (aveDelay, aveLaunch)
     }.drop(drop)
     println(s"Reply delay with promises: after ${res.length} tries, average is ${res.map(_._1).sum / res.length}, average launch time is ${res.map(_._2).sum / res.length}")

--- a/benchmark/src/test/scala/io/chymyst/benchmark/RepeatedInputSpec.scala
+++ b/benchmark/src/test/scala/io/chymyst/benchmark/RepeatedInputSpec.scala
@@ -15,7 +15,7 @@ class RepeatedInputSpec extends LogSpec {
 
     val (_, elapsed) = elapsedTimeMs(
       (1 to repetitions).foreach { i =>
-        withPool(new FixedPool(8)) { tp =>
+        withPool(FixedPool(8)) { tp =>
           val a = m[Option[Int]]
           val done = m[Int]
           val (all_done, f) = litmus[Boolean](tp)
@@ -39,7 +39,7 @@ class RepeatedInputSpec extends LogSpec {
 
     val (_, elapsed) = elapsedTimeMs(
       (1 to repetitions).foreach { i =>
-        withPool(new FixedPool(8)) { tp =>
+        withPool(FixedPool(8)) { tp =>
           val a = m[Option[Int]]
           val done = m[Int]
           val (all_done, f) = litmus[Boolean](tp)
@@ -67,7 +67,7 @@ class RepeatedInputSpec extends LogSpec {
 
     val (_, elapsed) = elapsedTimeMs(
       (1 to repetitions).foreach { i =>
-        withPool(new FixedPool(8)) { tp =>
+        withPool(FixedPool(8)) { tp =>
           val a = m[Int]
           val done = m[Int]
           val (all_done, f) = litmus[Boolean](tp)
@@ -95,7 +95,7 @@ class RepeatedInputSpec extends LogSpec {
 
     val (_, elapsed) = elapsedTimeMs(
       (1 to repetitions).foreach { i =>
-        withPool(new FixedPool(8)) { tp =>
+        withPool(FixedPool(8)) { tp =>
           val a = m[Int]
           val done = m[Int]
           val (all_done, f) = litmus[Boolean](tp)
@@ -123,7 +123,7 @@ class RepeatedInputSpec extends LogSpec {
 
     val (_, elapsed) = elapsedTimeMs(
       (1 to repetitions).foreach { i =>
-        withPool(new FixedPool(8)) { tp =>
+        withPool(FixedPool(8)) { tp =>
           val a = m[Int]
           val done = m[Int]
           val (all_done, f) = litmus[Boolean](tp)
@@ -165,7 +165,7 @@ class RepeatedInputSpec extends LogSpec {
     val (_, elapsed) = elapsedTimeMs(
       (1 to repetitions).foreach { i =>
         //        println(s"iteration $i")
-        withPool(new FixedPool(8)) { tp =>
+        withPool(FixedPool(8)) { tp =>
           val a = m[Long]
           val done = m[Int]
           val (all_done, f) = litmus[Boolean](tp)

--- a/benchmark/src/test/scala/io/chymyst/benchmark/SingleThreadSpec.scala
+++ b/benchmark/src/test/scala/io/chymyst/benchmark/SingleThreadSpec.scala
@@ -26,7 +26,7 @@ class SingleThreadSpec extends LogSpec {
   it should "schedule tasks" in {
 
     counter.set(0)
-    withPool(new FixedPool(1)) { tp =>
+    withPool(FixedPool(1)) { tp =>
       (1 to n).foreach { _ => tp.runReaction(incrementTask.run()) }
       val done = Promise[Unit]()
       tp.runReaction(doneTask(done).run())

--- a/core/src/main/scala/io/chymyst/jc/BlockingPool.scala
+++ b/core/src/main/scala/io/chymyst/jc/BlockingPool.scala
@@ -23,12 +23,12 @@ object BlockingIdle {
 final class BlockingPool(name: String, override val parallelism: Int = cpuCores, priority: Int = Thread.NORM_PRIORITY) extends Pool(name, priority) {
 
   // Looks like we will die hard at about 2021 threads...
-  val maxPoolSize: Int = 1000 + 2 * parallelism
+  val poolSizeLimit: Int = math.min(2000, 1000 + 2 * parallelism)
 
   def currentPoolSize: Int = executor.getCorePoolSize
 
-  private[jc] override def startedBlockingCall(selfBlocking: Boolean) = synchronized {
-    val newPoolSize = math.min(currentPoolSize + 1, maxPoolSize)
+  private[jc] override def startedBlockingCall(selfBlocking: Boolean) = synchronized { // Need a lock to modify the pool sizes.
+    val newPoolSize = math.min(currentPoolSize + 1, poolSizeLimit)
     if (newPoolSize > currentPoolSize) {
       executor.setMaximumPoolSize(newPoolSize)
       executor.setCorePoolSize(newPoolSize)
@@ -37,7 +37,7 @@ final class BlockingPool(name: String, override val parallelism: Int = cpuCores,
     }
   }
 
-  private[jc] override def finishedBlockingCall(selfBlocking: Boolean) = synchronized {
+  private[jc] override def finishedBlockingCall(selfBlocking: Boolean) = synchronized { // Need a lock to modify the pool sizes.
     val newPoolSize = math.max(parallelism, currentPoolSize - 1)
     executor.setCorePoolSize(newPoolSize) // Must set them in this order, so that the core pool size is never larger than the maximum pool size.
     executor.setMaximumPoolSize(newPoolSize)

--- a/core/src/main/scala/io/chymyst/jc/ChymystThread.scala
+++ b/core/src/main/scala/io/chymyst/jc/ChymystThread.scala
@@ -5,7 +5,7 @@ package io.chymyst.jc
   *
   * @param runnable The initial task given to the thread. (Required by the [[Thread]] interface.)
   */
-private[jc] final class ChymystThread(runnable: Runnable, val pool: Pool) extends Thread(runnable) {
+private[jc] final class ChymystThread(runnable: Runnable, val pool: Pool) extends Thread(pool.threadGroup, runnable, pool.nextThreadName) {
   private var inBlockingCall: Boolean = false
 
   private[jc] var reactionInfoString: String = Core.NO_REACTION_INFO_STRING

--- a/core/src/main/scala/io/chymyst/jc/Core.scala
+++ b/core/src/main/scala/io/chymyst/jc/Core.scala
@@ -2,8 +2,8 @@ package io.chymyst.jc
 
 import java.security.MessageDigest
 import java.time.LocalDateTime
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicLong
-import java.util.concurrent.{ConcurrentLinkedQueue, LinkedBlockingQueue, ThreadPoolExecutor, TimeUnit}
 import javax.xml.bind.DatatypeConverter
 
 import scala.annotation.tailrec

--- a/core/src/main/scala/io/chymyst/jc/Core.scala
+++ b/core/src/main/scala/io/chymyst/jc/Core.scala
@@ -395,12 +395,4 @@ object Core {
 
   val NO_REACTION_INFO_STRING = "<none>"
 
-  private[jc] def newSingleThreadedExecutor: ThreadPoolExecutor = {
-    val queue = new LinkedBlockingQueue[Runnable]
-    val secondsToRecycleThread = 1L
-    val executor = new ThreadPoolExecutor(1, 1, secondsToRecycleThread, TimeUnit.SECONDS, queue)
-    executor.allowCoreThreadTimeOut(true)
-    executor
-  }
-
 }

--- a/core/src/main/scala/io/chymyst/jc/FixedPool.scala
+++ b/core/src/main/scala/io/chymyst/jc/FixedPool.scala
@@ -12,16 +12,16 @@ final class FixedPool(name: String, override val parallelism: Int = cpuCores, pr
   private[jc] val blockingCalls = new AtomicInteger(0)
 
   private[jc] def deadlockCheck(): Unit = {
-    val deadlock = blockingCalls.get >= executor.getMaximumPoolSize
+    val deadlock = blockingCalls.get >= workerExecutor.getMaximumPoolSize
     if (deadlock) {
-      val message = s"Error: deadlock occurred in fixed pool (${executor.getMaximumPoolSize} threads) due to ${blockingCalls.get} concurrent blocking calls, reaction: ${Core.getReactionInfo}"
+      val message = s"Error: deadlock occurred in fixed pool (${workerExecutor.getMaximumPoolSize} threads) due to ${blockingCalls.get} concurrent blocking calls, reaction: ${Core.getReactionInfo}"
       Core.logError(message, print = true)
     }
   }
 
   private[chymyst] def runReaction(closure: => Unit): Unit = {
     deadlockCheck()
-    executor.execute { () ⇒ closure }
+    workerExecutor.execute { () ⇒ closure }
   }
 
   private[jc] override def startedBlockingCall(selfBlocking: Boolean) = if (selfBlocking) {

--- a/core/src/main/scala/io/chymyst/jc/FixedPool.scala
+++ b/core/src/main/scala/io/chymyst/jc/FixedPool.scala
@@ -1,0 +1,68 @@
+package io.chymyst.jc
+
+import java.util.concurrent._
+import java.util.concurrent.atomic.AtomicInteger
+
+/** Basic implementation of a thread pool, typically with a fixed number of threads.
+  * This class has an abstract method that produces a [[ThreadPoolExecutor]] and a [[BlockingQueue]].
+  *
+  * @param threads Initial number of threads.
+  */
+class FixedPool(threads: Int = 8) extends Pool {
+
+  private[jc] val queue: BlockingQueue[Runnable] = new LinkedBlockingQueue[Runnable]
+
+  protected val executor: ThreadPoolExecutor = {
+    val newThreadFactory = new ThreadFactory {
+      override def newThread(r: Runnable): Thread = new ChymystThread(r, FixedPool.this)
+    }
+    val secondsToRecycleThread = 1L
+    val executor = new ThreadPoolExecutor(threads, threads, secondsToRecycleThread, TimeUnit.SECONDS, queue, newThreadFactory)
+    executor.allowCoreThreadTimeOut(true)
+    executor
+  }
+
+  val blockingCalls = new AtomicInteger(0)
+
+  val sleepTime = 200L
+
+  def shutdownNow(): Unit = new Thread {
+    try {
+      queue.clear()
+      executor.shutdown()
+      executor.awaitTermination(sleepTime, TimeUnit.MILLISECONDS)
+    } finally {
+      executor.shutdownNow()
+      executor.awaitTermination(sleepTime, TimeUnit.MILLISECONDS)
+      executor.shutdownNow()
+      ()
+    }
+  }.start()
+
+  private[jc] def deadlockCheck(): Unit = {
+    val deadlock = blockingCalls.get >= executor.getMaximumPoolSize
+    if (deadlock) {
+      val message = s"Error: deadlock occurred in fixed pool (${executor.getMaximumPoolSize} threads) due to ${blockingCalls.get} concurrent blocking calls, reaction: ${Core.getReactionInfo}"
+      Core.logError(message, print = true)
+    }
+  }
+
+  private[chymyst] def runReaction(closure: => Unit): Unit = {
+    deadlockCheck()
+    executor.execute { () ⇒ closure }
+  }
+
+  override def isInactive: Boolean = executor.isShutdown || executor.isTerminated
+
+  private[jc] override def startedBlockingCall(selfBlocking: Boolean) = if (selfBlocking) {
+    blockingCalls.getAndIncrement()
+    deadlockCheck()
+  }
+
+  private[jc] override def finishedBlockingCall(selfBlocking: Boolean) = if (selfBlocking) {
+    blockingCalls.getAndDecrement()
+    deadlockCheck()
+  }
+
+}
+

--- a/core/src/main/scala/io/chymyst/jc/Macros.scala
+++ b/core/src/main/scala/io/chymyst/jc/Macros.scala
@@ -2,12 +2,12 @@ package io.chymyst.jc
 
 import java.security.MessageDigest
 
-import Core._
+import io.chymyst.jc.Core._
 import io.chymyst.util.ConjunctiveNormalForm.CNF
 
 import scala.language.experimental.macros
-import scala.reflect.macros.blackbox
 import scala.reflect.NameTransformer.LOCAL_SUFFIX_STRING
+import scala.reflect.macros.blackbox
 
 class CommonMacros(val c: blackbox.Context) {
 
@@ -152,7 +152,7 @@ final class MoleculeMacros(override val c: blackbox.Context) extends CommonMacro
 
   import c.universe._
 
-  def mImpl[T: c.WeakTypeTag]: c.universe.Tree = {
+  def mImpl[T: c.WeakTypeTag]: Tree = {
     val moleculeName = getEnclosingName
     val moleculeValueType = c.weakTypeOf[T]
     q"new M[$moleculeValueType]($moleculeName)"
@@ -166,6 +166,32 @@ final class MoleculeMacros(override val c: blackbox.Context) extends CommonMacro
     val replyValueType = c.weakTypeOf[R]
 
     q"new B[$moleculeValueType,$replyValueType]($moleculeName)"
+  }
+
+}
+
+final class PoolMacros(override val c: blackbox.Context) extends CommonMacros(c) {
+
+  import c.universe._
+
+  def newFixedPoolImpl0(): Tree = {
+    val poolName = getEnclosingName
+    q"new FixedPool($poolName)"
+  }
+
+  def newFixedPoolImpl1(parallelism: c.Expr[Int]): Tree = {
+    val poolName = getEnclosingName
+    q"new FixedPool($poolName, $parallelism)"
+  }
+
+  def newBlockingPoolImpl0(): Tree = {
+    val poolName = getEnclosingName
+    q"new BlockingPool($poolName)"
+  }
+
+  def newBlockingPoolImpl1(parallelism: c.Expr[Int]): Tree = {
+    val poolName = getEnclosingName
+    q"new BlockingPool($poolName, $parallelism)"
   }
 
 }

--- a/core/src/main/scala/io/chymyst/jc/Pool.scala
+++ b/core/src/main/scala/io/chymyst/jc/Pool.scala
@@ -1,7 +1,8 @@
 package io.chymyst.jc
 
 
-import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent._
 
 import scala.concurrent.ExecutionContext
 
@@ -9,12 +10,12 @@ import scala.concurrent.ExecutionContext
   * Tasks submitted for execution can have Chymyst-specific info (useful for debugging) when scheduled using `runReaction`.
   * The pool can be shut down, in which case all further tasks will be refused.
   */
-trait Pool extends AutoCloseable {
-  def shutdownNow(): Unit
-
+abstract class Pool(val name: String, val priority: Int) extends AutoCloseable {
   private[jc] def startedBlockingCall(selfBlocking: Boolean): Unit
 
   private[jc] def finishedBlockingCall(selfBlocking: Boolean): Unit
+
+  def parallelism: Int
 
   /** Run a reaction closure on the thread pool.
     * The reaction closure will be created by [[ReactionSite.reactionClosure]].
@@ -23,15 +24,55 @@ trait Pool extends AutoCloseable {
     */
   private[chymyst] def runReaction(closure: => Unit): Unit
 
-  def isInactive: Boolean
+  def isInactive: Boolean = executor.isShutdown || executor.isTerminated
 
   override def close(): Unit = shutdownNow()
 
-  private val schedulerExecutor: ThreadPoolExecutor = Core.newSingleThreadedExecutor
+  def recycleThreadTimeMs: Long = 1000L
 
-  protected def executor: ThreadPoolExecutor
+  def shutdownWaitTimeMs: Long = 200L
+
+  protected val schedulerExecutor: ThreadPoolExecutor = Core.newSingleThreadedExecutor
+
+  protected val executor: ThreadPoolExecutor = {
+    val executor = new ThreadPoolExecutor(0, parallelism, recycleThreadTimeMs, TimeUnit.MILLISECONDS, queue, threadFactory)
+    executor.allowCoreThreadTimeOut(true)
+    executor
+  }
 
   val executionContext: ExecutionContext = ExecutionContext.fromExecutor(executor)
 
-  def runScheduler(runnable: Runnable): Unit = schedulerExecutor.execute(runnable)
+  private[jc] val queue: BlockingQueue[Runnable] = new LinkedBlockingQueue[Runnable]
+
+  private[jc] def runScheduler(runnable: Runnable): Unit = schedulerExecutor.execute(runnable)
+
+  private val threadGroupName = "chymyst-thread-group-" + name
+
+  private val threadNameBase = "chymyst-thread-" + name
+
+  val threadGroup: ThreadGroup = {
+    val tg = new ThreadGroup(threadGroupName)
+    tg.setMaxPriority(priority)
+    tg
+  }
+
+  protected val threadFactory: ThreadFactory = { (r: Runnable) ⇒ new ChymystThread(r, Pool.this) }
+
+  private val currentThreadId: AtomicInteger = new AtomicInteger(0)
+
+  private[jc] def nextThreadName: String = threadNameBase + currentThreadId.getAndIncrement()
+
+  def shutdownNow(): Unit = new Thread {
+    try {
+      executor.getQueue.clear()
+      executor.shutdown()
+      executor.awaitTermination(shutdownWaitTimeMs, TimeUnit.MILLISECONDS)
+    } finally {
+      executor.shutdownNow()
+      executor.awaitTermination(shutdownWaitTimeMs, TimeUnit.MILLISECONDS)
+      executor.shutdownNow()
+      ()
+    }
+  }.start()
+
 }

--- a/core/src/main/scala/io/chymyst/jc/Pool.scala
+++ b/core/src/main/scala/io/chymyst/jc/Pool.scala
@@ -1,23 +1,9 @@
 package io.chymyst.jc
 
 
-import java.util.concurrent._
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.ThreadPoolExecutor
 
 import scala.concurrent.ExecutionContext
-
-class FixedPool(threads: Int) extends PoolExecutor(threads) {
-  protected override def execFactory(threads: Int): (ExecutorService, BlockingQueue[Runnable]) = {
-    val queue = new LinkedBlockingQueue[Runnable]
-    val newThreadFactory = new ThreadFactory {
-      override def newThread(r: Runnable): Thread = new ChymystThread(r, FixedPool.this)
-    }
-    val secondsToRecycleThread = 1L
-    val executor = new ThreadPoolExecutor(threads, threads, secondsToRecycleThread, TimeUnit.SECONDS, queue, newThreadFactory)
-    executor.allowCoreThreadTimeOut(true)
-    (executor, queue)
-  }
-}
 
 /** A pool of execution threads, or another way of running tasks (could use actors or whatever else).
   * Tasks submitted for execution can have Chymyst-specific info (useful for debugging) when scheduled using `runReaction`.
@@ -48,59 +34,4 @@ trait Pool extends AutoCloseable {
   val executionContext: ExecutionContext = ExecutionContext.fromExecutor(executor)
 
   def runScheduler(runnable: Runnable): Unit = schedulerExecutor.execute(runnable)
-}
-
-/** Basic implementation of a thread pool, typically with a fixed number of threads.
-  * This class has an abstract method that produces a [[ThreadPoolExecutor]] and a [[BlockingQueue]].
-  *
-  * @param threads Initial number of threads.
-  */
-private[jc] abstract class PoolExecutor(threads: Int = 8) extends Pool {
-
-  protected def execFactory(threads: Int): (ExecutorService, BlockingQueue[Runnable])
-
-  protected val (executor: ThreadPoolExecutor, queue: BlockingQueue[Runnable]) = execFactory(threads)
-
-  val blockingCalls = new AtomicInteger(0)
-
-  val sleepTime = 200L
-
-  def shutdownNow(): Unit = new Thread {
-    try {
-      queue.clear()
-      executor.shutdown()
-      executor.awaitTermination(sleepTime, TimeUnit.MILLISECONDS)
-    } finally {
-      executor.shutdownNow()
-      executor.awaitTermination(sleepTime, TimeUnit.MILLISECONDS)
-      executor.shutdownNow()
-      ()
-    }
-  }.start()
-
-  private[jc] def deadlockCheck(): Unit = {
-    val deadlock = blockingCalls.get >= executor.getMaximumPoolSize
-    if (deadlock) {
-      val message = s"Error: deadlock occurred in fixed pool (${executor.getMaximumPoolSize} threads) due to ${blockingCalls.get} concurrent blocking calls, reaction: ${Core.getReactionInfo}"
-      Core.logError(message, print = true)
-    }
-  }
-
-  private[chymyst] def runReaction(closure: => Unit): Unit = {
-    deadlockCheck()
-    executor.execute { () ⇒ closure }
-  }
-
-  override def isInactive: Boolean = executor.isShutdown || executor.isTerminated
-
-  private[jc] override def startedBlockingCall(selfBlocking: Boolean) = if (selfBlocking) {
-    blockingCalls.getAndIncrement()
-    deadlockCheck()
-  }
-
-  private[jc] override def finishedBlockingCall(selfBlocking: Boolean) = if (selfBlocking) {
-    blockingCalls.getAndDecrement()
-    deadlockCheck()
-  }
-
 }

--- a/core/src/main/scala/io/chymyst/jc/Pool.scala
+++ b/core/src/main/scala/io/chymyst/jc/Pool.scala
@@ -68,7 +68,9 @@ abstract class Pool(val name: String, val priority: Int) extends AutoCloseable {
 
   private[jc] def nextThreadName: String = threadNameBase + "-" + currentThreadId.getAndIncrement().toString
 
-  def shutdownNow(): Unit = new Thread {
+  def shutdownNow(): Unit = ()
+
+  /*def shutdownNow(): Unit = new Thread {
     try {
       executor.getQueue.clear()
       executor.shutdown()
@@ -80,6 +82,6 @@ abstract class Pool(val name: String, val priority: Int) extends AutoCloseable {
       ()
     }
   }.start()
-
+*/
   override val toString: String = s"${this.getClass.getSimpleName}:$name"
 }

--- a/core/src/main/scala/io/chymyst/jc/package.scala
+++ b/core/src/main/scala/io/chymyst/jc/package.scala
@@ -46,7 +46,7 @@ package object jc {
     * @param reactionBody The body of the reaction. This must be a partial function with pattern-matching on molecules.
     * @return A [[Reaction]] value, containing the reaction body as well as static information about input and output molecules.
     */
-  def go(reactionBody: Core.ReactionBody): Reaction = macro BlackboxMacros.buildReactionImpl // IDEA cannot resolve symbol `BlackboxMacros`, but compilation works.
+  def go(reactionBody: Core.ReactionBody): Reaction = macro BlackboxMacros.buildReactionImpl // IntelliJ cannot resolve symbol `BlackboxMacros`, but compilation works.
 
   /**
     * Convenience syntax: users can write `a(x) + b(y)` to emit several molecules at once.
@@ -71,7 +71,7 @@ package object jc {
     * @tparam T Type of the value carried by the molecule.
     * @return A new instance of class [[io.chymyst.jc.M]]`[T]`.
     */
-  def m[T]: M[T] = macro MoleculeMacros.mImpl[T] // IDEA cannot resolve symbol `MoleculeMacros`, but compilation works.
+  def m[T]: M[T] = macro MoleculeMacros.mImpl[T] // IntelliJ cannot resolve symbol `MoleculeMacros`, but compilation works.
 
   /** Declare a new blocking molecule emitter.
     * The name of the molecule will be automatically assigned (via macro) to the name of the enclosing variable.
@@ -80,10 +80,10 @@ package object jc {
     * @tparam R Type of the reply value.
     * @return A new instance of class [[io.chymyst.jc.B]]`[T,R]`.
     */
-  def b[T, R]: B[T, R] = macro MoleculeMacros.bImpl[T, R] // IDEA cannot resolve symbol `MoleculeMacros`, but compilation works.
+  def b[T, R]: B[T, R] = macro MoleculeMacros.bImpl[T, R] // IntelliJ cannot resolve symbol `MoleculeMacros`, but compilation works.
 
   /** This pool is used for sites that do not specify a thread pool. */
-  lazy val defaultPool = new BlockingPool()
+  lazy val defaultPool = new BlockingPool("defaultPool")
 
   /** Access the global error log used by all reaction sites to report runtime errors.
     *
@@ -98,7 +98,7 @@ package object jc {
 
   /** A helper method to run a closure that uses a thread pool, safely closing the pool after use.
     *
-    * @param pool   A thread pool value, evaluated lazily - typically `new BlockingPool(...)`.
+    * @param pool   A thread pool value, evaluated lazily - typically `BlockingPool(...)`.
     * @param doWork A closure, typically containing a `site(pool)(...)` call.
     * @tparam T Type of the value returned by the closure.
     * @return The value returned by the closure, wrapped in a `Try`.

--- a/core/src/test/scala/io/chymyst/jc/CoreSpec.scala
+++ b/core/src/test/scala/io/chymyst/jc/CoreSpec.scala
@@ -225,7 +225,7 @@ class CoreSpec extends LogSpec {
   }
 
   it should "give reaction info inside reaction" in {
-    withPool(new FixedPool(2)) { tp =>
+    withPool(FixedPool(2)) { tp =>
       val a = m[Int]
       val f = b[Unit, String]
 

--- a/core/src/test/scala/io/chymyst/jc/GuardsSpec.scala
+++ b/core/src/test/scala/io/chymyst/jc/GuardsSpec.scala
@@ -529,7 +529,7 @@ class GuardsSpec extends LogSpec {
     val bb = m[Option[Int]]
     val f = b[Unit, Boolean]
 
-    withPool(new FixedPool(4)) { tp ⇒
+    withPool(FixedPool(4)) { tp ⇒
       site(tp)(go { case a(Some(px@(1))) + bb(py@Some(y)) + f(_, r) // ignore warning about "non-variable type argument Int"
         if py.get > px ⇒ r(true) })
       // TODO: fix type breakage if we write z + px.get instead of z + x: the reason is that `px` is inferred to be Some[Any] instead of Some[Int]
@@ -545,7 +545,7 @@ class GuardsSpec extends LogSpec {
     val a = m[Int]
     val f = b[Unit, Unit]
 
-    val status = withPool(new FixedPool(4)) { tp =>
+    val status = withPool(FixedPool(4)) { tp =>
       site(tp)(go { case a(x) + a(y) + f(_, r) if x == y + 1 => r() })
 
       (1 to 3).foreach(_ => a(0) + a(1))
@@ -579,7 +579,7 @@ class GuardsSpec extends LogSpec {
     val a = m[Int]
     val f = b[Unit, Boolean]
 
-    withPool(new FixedPool(4)) { tp ⇒
+    withPool(FixedPool(4)) { tp ⇒
       site(tp)(go { case a(1) + a(y) + a(z) + f(_, r) if y > z ⇒ r(true) })
 
       (1 to 3).foreach { i ⇒ a(i) }
@@ -591,7 +591,7 @@ class GuardsSpec extends LogSpec {
     val a = m[Option[Int]]
     val f = b[Unit, Boolean]
 
-    withPool(new FixedPool(4)) { tp ⇒
+    withPool(FixedPool(4)) { tp ⇒
       site(tp)(go { case a(Some(1)) + a(Some(y)) + a(Some(z)) + f(_, r) if y > z && z > 1 ⇒ r(true) })
       (1 to 3).foreach(_ ⇒ (1 to 3).foreach { i ⇒ a(Some(i)) })
       (1 to 3).map(_ ⇒ f.timeout()(1.second)).map(_.get).reduce(_ && _)
@@ -602,7 +602,7 @@ class GuardsSpec extends LogSpec {
     val a = m[Option[Int]]
     val f = b[Unit, Boolean]
 
-    withPool(new FixedPool(4)) { tp ⇒
+    withPool(FixedPool(4)) { tp ⇒
       site(tp)(go { case a(Some(px@(1))) + a(py@Some(y)) + a(Some(z)) + f(_, r) // ignore warning about "non-variable type argument Int"
         if py.get >= z + px ⇒ r(true) })
       // TODO: fix type breakage if we write z + px.get instead of z + x: the reason is that `px` is inferred to be Some[Any] instead of Some[Int]

--- a/core/src/test/scala/io/chymyst/jc/MacrosSpec.scala
+++ b/core/src/test/scala/io/chymyst/jc/MacrosSpec.scala
@@ -16,7 +16,7 @@ class MacrosSpec extends LogSpec with BeforeAndAfterEach {
   def waitSome(): Unit = Thread.sleep(warmupTimeMs)
 
   override def beforeEach(): Unit = {
-    tp0 = new FixedPool(4)
+    tp0 = FixedPool(4)
   }
 
   override def afterEach(): Unit = {

--- a/core/src/test/scala/io/chymyst/jc/PoolSpec.scala
+++ b/core/src/test/scala/io/chymyst/jc/PoolSpec.scala
@@ -50,7 +50,7 @@ class PoolSpec extends LogSpec {
 
     tp.shutdownNow()
   }
-
+/*
   it should "interrupt a thread when shutting down" in {
     val waiter = new Waiter
 
@@ -76,13 +76,15 @@ class PoolSpec extends LogSpec {
 
     waiter.await()(patienceConfig, implicitly[Position])
   }
-
+*/
   behavior of "Chymyst thread"
 
   it should "return empty info by default" in {
     val tp = BlockingPool()
     val thread = new ChymystThread(() ⇒ (), tp)
     thread.reactionInfo shouldEqual Core.NO_REACTION_INFO_STRING
+
+    thread.getName shouldEqual "BlockingPool:tp,worker_thread:0"
   }
 
   behavior of "fixed pool"

--- a/core/src/test/scala/io/chymyst/jc/PoolSpec.scala
+++ b/core/src/test/scala/io/chymyst/jc/PoolSpec.scala
@@ -15,7 +15,7 @@ class PoolSpec extends LogSpec {
 
   it should "refuse to increase the thread pool beyond its limit" in {
     val n = 1065
-    val tp = new BlockingPool(2)
+    val tp = BlockingPool(2)
 
     tp.maxPoolSize should be < n
     tp.currentPoolSize shouldEqual 2
@@ -32,7 +32,7 @@ class PoolSpec extends LogSpec {
   it should "run a task on a separate thread" in {
     val waiter = new Waiter
 
-    val tp = new FixedPool(2)
+    val tp = FixedPool(2)
 
     tp.executionContext.isInstanceOf[ExecutionContext] shouldEqual true
 
@@ -55,7 +55,7 @@ class PoolSpec extends LogSpec {
   it should "interrupt a thread when shutting down" in {
     val waiter = new Waiter
 
-    val tp = new FixedPool(2)
+    val tp = FixedPool(2)
 
     tp.runReaction({
       try {
@@ -78,7 +78,7 @@ class PoolSpec extends LogSpec {
   behavior of "Chymyst thread"
 
   it should "return empty info by default" in {
-    val tp = new BlockingPool()
+    val tp = BlockingPool()
     val thread = new ChymystThread(() ⇒ (), tp)
     thread.reactionInfo shouldEqual Core.NO_REACTION_INFO_STRING
   }
@@ -86,7 +86,7 @@ class PoolSpec extends LogSpec {
   behavior of "blocking pool"
 
   it should "initialize with default CPU core parallelism" in {
-    val tp = new BlockingPool()
+    val tp = BlockingPool()
 
     tp.currentPoolSize shouldEqual cpuCores
     tp.executionContext.isInstanceOf[ExecutionContext] shouldEqual true

--- a/core/src/test/scala/io/chymyst/jc/PoolSpec.scala
+++ b/core/src/test/scala/io/chymyst/jc/PoolSpec.scala
@@ -50,7 +50,7 @@ class PoolSpec extends LogSpec {
 
     tp.shutdownNow()
   }
-/*
+
   it should "interrupt a thread when shutting down" in {
     val waiter = new Waiter
 
@@ -76,7 +76,7 @@ class PoolSpec extends LogSpec {
 
     waiter.await()(patienceConfig, implicitly[Position])
   }
-*/
+
   behavior of "Chymyst thread"
 
   it should "return empty info by default" in {

--- a/core/src/test/scala/io/chymyst/jc/ReactionSiteSpec.scala
+++ b/core/src/test/scala/io/chymyst/jc/ReactionSiteSpec.scala
@@ -105,7 +105,7 @@ class ReactionSiteSpec extends LogSpec with BeforeAndAfterEach {
   }
 
   it should "run reactions with cross-molecule conditionals but without cross-molecule guards" in {
-    withPool(new FixedPool(2)) { tp =>
+    withPool(FixedPool(2)) { tp =>
       val a = m[Int]
       val f = b[Unit, Int]
       site(tp)(
@@ -221,7 +221,7 @@ class ReactionSiteSpec extends LogSpec with BeforeAndAfterEach {
     clearGlobalErrorLog()
     val x = 10
 
-    withPool(new FixedPool(2)) { tp =>
+    withPool(FixedPool(2)) { tp =>
       site(tp)(
         go { case f(_, r) =>
           if (x > 0) throw new Exception("crash! ignore this exception")
@@ -238,7 +238,7 @@ class ReactionSiteSpec extends LogSpec with BeforeAndAfterEach {
     clearGlobalErrorLog()
     val x = 10
 
-    withPool(new FixedPool(2)) { tp =>
+    withPool(FixedPool(2)) { tp =>
       site(tp)(
         go { case f(_, r) =>
           if (x > 0) throw new Exception("crash! ignore this exception")

--- a/core/src/test/scala/io/chymyst/test/BlockingMoleculesSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/BlockingMoleculesSpec.scala
@@ -15,7 +15,7 @@ class BlockingMoleculesSpec extends LogSpec with BeforeAndAfterEach {
   var tp0: Pool = _
 
   override def beforeEach(): Unit = {
-    tp0 = new BlockingPool(12)
+    tp0 = BlockingPool(12)
   }
 
   override def afterEach(): Unit = {
@@ -140,7 +140,7 @@ class BlockingMoleculesSpec extends LogSpec with BeforeAndAfterEach {
     val g = b[Unit, Int]
     val g2 = b[Unit, Int]
     val h = b[Unit, Int]
-    val tp = new FixedPool(4)
+    val tp = FixedPool(4)
     site(tp0)(
       go { case c(_) => e(g2()) }, // e(0) should be emitted now
       go { case d(_) + g(_, r) + g2(_, r2) => r(0); r2(0) } onThreads tp,
@@ -163,7 +163,7 @@ class BlockingMoleculesSpec extends LogSpec with BeforeAndAfterEach {
     val g = b[Unit, Int]
     val g2 = b[Unit, Int]
     val h = b[Unit, Int]
-    val tp = new FixedPool(4)
+    val tp = FixedPool(4)
     site(tp0)(
       go { case c(_) => val x = g(); g2(); e(x) }, // e(0) should never be emitted because this thread is deadlocked
       go { case g(_, r) + g2(_, r2) => r(0); r2(0) } onThreads tp,
@@ -188,7 +188,7 @@ class BlockingMoleculesSpec extends LogSpec with BeforeAndAfterEach {
     val d = m[Unit]
     val g = b[Unit, Int]
     val g2 = b[Unit, Int]
-    val tp = new FixedPool(2)
+    val tp = FixedPool(2)
     site(tp)(
       go { case d(_) => g(); () }, // this will be used to emit g() and block the thread
       go { case c(_) + g(_, r) => r(0) }, // this will not start because we have no c()
@@ -205,7 +205,7 @@ class BlockingMoleculesSpec extends LogSpec with BeforeAndAfterEach {
     val d = m[Unit]
     val g = b[Unit, Int]
     val g2 = b[Unit, Int]
-    val tp = new FixedPool(1)
+    val tp = FixedPool(1)
     site(tp)(
       go { case d(_) => g(); () }, // this will be used to emit g() and block one thread
       go { case c(_) + g(_, r) => r(0) }, // this will not start because we have no c()
@@ -237,14 +237,14 @@ class BlockingMoleculesSpec extends LogSpec with BeforeAndAfterEach {
   }
 
   it should "block the fixed threadpool when one thread is sleeping with Thread.sleep" in {
-    val tp = new FixedPool(1)
+    val tp = FixedPool(1)
     val res = makeBlockingCheck(Thread.sleep(1000), tp)
     res._2.timeout()(150 millis) shouldEqual None // this should be blocked
     tp.shutdownNow()
   }
 
   it should "block the fixed threadpool when one thread is sleeping with BlockingIdle(Thread.sleep)" in {
-    val tp = new FixedPool(1)
+    val tp = FixedPool(1)
     val res = makeBlockingCheck(BlockingIdle {
       Thread.sleep(500)
     }, tp)
@@ -253,7 +253,7 @@ class BlockingMoleculesSpec extends LogSpec with BeforeAndAfterEach {
   }
 
   it should "not block the blocking threadpool with BlockingIdle(Thread.sleep)" in {
-    val tp = new BlockingPool(1)
+    val tp = BlockingPool(1)
     val (g, g2) = makeBlockingCheck(BlockingIdle {
       Thread.sleep(500)
     }, tp)
@@ -266,7 +266,7 @@ class BlockingMoleculesSpec extends LogSpec with BeforeAndAfterEach {
   }
 
   it should "implement BlockingIdle(BlockingIdle()) as BlockingIdle()" in {
-    val tp = new BlockingPool(1)
+    val tp = BlockingPool(1)
     val (g, g2) = makeBlockingCheck(BlockingIdle {
       BlockingIdle {
         Thread.sleep(500)
@@ -306,28 +306,28 @@ class BlockingMoleculesSpec extends LogSpec with BeforeAndAfterEach {
   }
 
   it should "block the fixed threadpool when all threads are waiting for new reactions" in {
-    withPool(new FixedPool(2)) { tp =>
+    withPool(FixedPool(2)) { tp =>
       val g = blockThreadsDueToBlockingMolecule(tp)
       g.timeout()(timeout) shouldEqual None
     }.get
   }
 
   it should "not block the fixed threadpool when more threads are available" in {
-    withPool(new FixedPool(3)) { tp =>
+    withPool(FixedPool(3)) { tp =>
       val g = blockThreadsDueToBlockingMolecule(tp)
       g.timeout()(timeout) shouldEqual Some(())
     }.get
   }
 
   it should "not block the blocking threadpool when all threads are waiting for new reactions" in {
-    withPool(new BlockingPool(2)) { tp ⇒
+    withPool(BlockingPool(2)) { tp ⇒
       val g = blockThreadsDueToBlockingMolecule(tp)
       g.timeout()(timeout) shouldEqual Some(())
     }.get
   }
 
   it should "not block the blocking threadpool when more threads are available" in {
-    withPool(new BlockingPool(3)) { tp ⇒
+    withPool(BlockingPool(3)) { tp ⇒
       val g = blockThreadsDueToBlockingMolecule(tp)
       g.timeout()(timeout) shouldEqual Some(())
     }.get

--- a/core/src/test/scala/io/chymyst/test/DiningPhilosophersSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/DiningPhilosophersSpec.scala
@@ -25,7 +25,7 @@ class DiningPhilosophersSpec extends LogSpec {
 
   private def diningPhilosophers(cycles: Int) = {
 
-    val tp = new FixedPool(8)
+    val tp = FixedPool(8)
 
     val hungry1 = m[Int]
     val hungry2 = m[Int]

--- a/core/src/test/scala/io/chymyst/test/FairnessSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/FairnessSpec.scala
@@ -27,7 +27,7 @@ class FairnessSpec extends LogSpec {
       val a3 = m[Unit]
       //n = 4
 
-      val tp = new FixedPool(4)
+      val tp = FixedPool(4)
 
       site(tp)(
         go { case getC(_, r) + done(arr) => r(arr) },
@@ -96,7 +96,7 @@ class FairnessSpec extends LogSpec {
     val gather = m[List[Int]]
     val a = m[Int]
 
-    val tp = new FixedPool(8)
+    val tp = FixedPool(8)
 
     site(tp)(
       go { case done(arr) + getC(_, r) => r(arr) },
@@ -135,7 +135,7 @@ class FairnessSpec extends LogSpec {
     val f = m[(Int, Int, Int)]
     val g = b[Unit, (Int, Int)]
 
-    val tp = new FixedPool(8)
+    val tp = FixedPool(8)
 
     site(tp)(
       go { case a(x) + bb(y) if x == y => d() },
@@ -173,7 +173,7 @@ class FairnessSpec extends LogSpec {
   // This test failed to complete in 500ms on Travis CI with Scala 2.10, but succeeds with 2.11. However, this could have been a fluctuation.
   it should "fail to schedule reactions fairly after multiple emission into separate RSs" in {
 
-    val tp = new FixedPool(8)
+    val tp = FixedPool(8)
 
     def makeRS(d1: M[Unit], d2: M[Unit]): (M[Unit], M[Unit], M[Unit]) = {
       val a = m[Unit]

--- a/core/src/test/scala/io/chymyst/test/GameOfLifeSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/GameOfLifeSpec.scala
@@ -34,9 +34,9 @@ class GameOfLifeSpec extends LogSpec {
     // blocking molecule to fetch the final accumulator value
     val g = b[Unit, Array[Array[Int]]]
 
-    val tp = new FixedPool(4)
+    val tp = FixedPool(4)
 
-    val tp2 = new FixedPool(2)
+    val tp2 = FixedPool(2)
 
     // Toroidal board of size m * n
     val boardSize = BoardSize(5, 5)
@@ -130,8 +130,8 @@ class GameOfLifeSpec extends LogSpec {
     // blocking molecule to fetch the final accumulator value
     val g = b[Unit, Array[Array[Int]]]
 
-    val tp = new FixedPool(16)
-    val tp2 = new FixedPool(2)
+    val tp = FixedPool(16)
+    val tp2 = FixedPool(2)
 
     // Toroidal board of size m * n
     val boardSize = BoardSize(5, 5)
@@ -229,8 +229,8 @@ class GameOfLifeSpec extends LogSpec {
     // blocking molecule to fetch the final accumulator value
     val g = b[Unit, Array[Array[Int]]]
 
-    val tp = new FixedPool(16)
-    val tp2 = new FixedPool(2)
+    val tp = FixedPool(16)
+    val tp2 = FixedPool(2)
 
     // Toroidal board of size m * n
     val boardSize = BoardSize(10, 10)
@@ -365,8 +365,8 @@ class GameOfLifeSpec extends LogSpec {
     // blocking molecule to fetch the final accumulator value
     val g = b[Unit, Array[Array[Int]]]
 
-    val tp = new FixedPool(16)
-    val tp2 = new FixedPool(2)
+    val tp = FixedPool(16)
+    val tp2 = FixedPool(2)
 
     // Toroidal board of size m * n
     val boardSize = BoardSize(10, 10)
@@ -503,8 +503,8 @@ class GameOfLifeSpec extends LogSpec {
     // blocking molecule to fetch the final accumulator value
     val g = b[Unit, Array[Array[Int]]]
 
-    val tp = new FixedPool(16) // maximum parallelism
-    val tp2 = new FixedPool(2)
+    val tp = FixedPool(16) // maximum parallelism
+    val tp2 = FixedPool(2)
 
     val emptyBoard: Array[Array[Int]] = Array.fill(boardSize.x, boardSize.y)(0)
 

--- a/core/src/test/scala/io/chymyst/test/MoleculesSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/MoleculesSpec.scala
@@ -17,7 +17,7 @@ class MoleculesSpec extends LogSpec with BeforeAndAfterEach {
 
   override def beforeEach(): Unit = {
     clearGlobalErrorLog()
-    tp0 = new FixedPool(4)
+    tp0 = FixedPool(4)
   }
 
   override def afterEach(): Unit = {
@@ -309,7 +309,7 @@ class MoleculesSpec extends LogSpec with BeforeAndAfterEach {
   // The way to avoid this problem is to define nested reaction sites *before* the new emitters are used.
   // This test intentionally defines the reaction site defining the {e -> } reaction *after* the `e` emitter is passed to the `a` reaction.
   it should "start reactions and throw exception when molecule emitters are passed to nested reactions slightly before they are bound" in {
-    val tp1 = new FixedPool(2)
+    val tp1 = FixedPool(2)
     clearGlobalErrorLog()
     val total = 100
     (1 to total).foreach { i =>
@@ -409,7 +409,7 @@ class MoleculesSpec extends LogSpec with BeforeAndAfterEach {
     val a = new M[Int]("all_finished")
     val g = new B[Unit, Int]("getValue")
 
-    val tp = new FixedPool(1)
+    val tp = FixedPool(1)
 
     site(tp0)(
       go { case c(x) + d(_) => Thread.sleep(300); c(x - 1) + f() } onThreads tp,
@@ -436,7 +436,7 @@ class MoleculesSpec extends LogSpec with BeforeAndAfterEach {
     val a = new M[Int]("all_finished")
     val g = new B[Unit, Int]("getValue")
 
-    val tp = new FixedPool(2)
+    val tp = FixedPool(2)
 
     site(tp0)(
       go { case c(_) + d(_) => Thread.sleep(300); f() } onThreads tp,
@@ -471,7 +471,7 @@ class MoleculesSpec extends LogSpec with BeforeAndAfterEach {
     val c = new M[Int]("counter")
     val d = new M[Unit]("decrement")
     val g = new B[Unit, Unit]("getValue")
-    val tp = new FixedPool(2)
+    val tp = FixedPool(2)
 
     site(tp0)(
       go { case c(x) + d(_) =>
@@ -496,7 +496,7 @@ class MoleculesSpec extends LogSpec with BeforeAndAfterEach {
     val c = new M[Int]("counter")
     val d = new M[Unit]("decrement")
     val g = new B[Unit, Unit]("getValue")
-    val tp = new FixedPool(2)
+    val tp = FixedPool(2)
 
     site(tp0)(
       go { case c(x) + d(_) =>
@@ -522,7 +522,7 @@ class MoleculesSpec extends LogSpec with BeforeAndAfterEach {
     val c = new M[Int]("counter")
     val d = new M[Unit]("decrement")
     val g = new B[Unit, Unit]("getValue")
-    val tp = new FixedPool(2)
+    val tp = FixedPool(2)
 
     site(tp0)(
       go { case c(x) + d(_) =>
@@ -548,7 +548,7 @@ class MoleculesSpec extends LogSpec with BeforeAndAfterEach {
     val c = new M[Int]("counter")
     val d = new B[Unit, Unit]("decrement")
     val g = new B[Unit, Unit]("getValue")
-    val tp = new FixedPool(2)
+    val tp = FixedPool(2)
 
     site(tp0)(
       go { case c(x) + d(_, r) =>

--- a/core/src/test/scala/io/chymyst/test/MoreBlockingSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/MoreBlockingSpec.scala
@@ -17,7 +17,7 @@ class MoreBlockingSpec extends LogSpec {
     val c = m[Int]
     val d = m[Int]
 
-    val tp = new FixedPool(6)
+    val tp = FixedPool(6)
 
     site(tp)(
       go { case f(_, r) => r(123) },
@@ -36,7 +36,7 @@ class MoreBlockingSpec extends LogSpec {
     val f = b[Unit,Int]
     val g = b[Unit, Boolean]
 
-    val tp = new FixedPool(4)
+    val tp = FixedPool(4)
 
     site(tp)(
       go { case g(_, r) + a(x) => r(x) },
@@ -54,7 +54,7 @@ class MoreBlockingSpec extends LogSpec {
     val f = b[Unit,Unit]
     val g = b[Unit, Boolean]
 
-    val tp = new FixedPool(4)
+    val tp = FixedPool(4)
 
     site(tp)(
       go { case g(_, r) + a(x) => r(x) },
@@ -72,7 +72,7 @@ class MoreBlockingSpec extends LogSpec {
 
     val waiter = Promise[Boolean]()
 
-    val tp = new FixedPool(4)
+    val tp = FixedPool(4)
 
     site(tp)(
       go { case f(_, r) => val res = r(123); waiter.success(res) }
@@ -90,7 +90,7 @@ class MoreBlockingSpec extends LogSpec {
     val f = b[Unit, Int]
     val get = b[Unit, Int]
 
-    val tp = new FixedPool(6)
+    val tp = FixedPool(6)
 
     site(tp)(
       go { case f(_, reply) => a(reply(123)) },
@@ -116,7 +116,7 @@ class MoreBlockingSpec extends LogSpec {
     val a = m[Int]
     val f = b[Unit,Int]
 
-    val tp = new FixedPool(2)
+    val tp = FixedPool(2)
 
     site(tp)(
       go { case f(_, r) + a(x) => r(x); a(0) }
@@ -143,7 +143,7 @@ class MoreBlockingSpec extends LogSpec {
     val c = m[Int]
     val f = b[Int,Int]
 
-    val tp = new FixedPool(6)
+    val tp = FixedPool(6)
     site(tp)(
       go { case f(x, r) + a(y) => c(x); val s = f(x+y); r(s) },
       go { case f(x, r) + c(y) => r(x*y) }
@@ -162,7 +162,7 @@ class MoreBlockingSpec extends LogSpec {
     val incr = b[Unit, Unit]
     val get_d = b[Unit, Int]
 
-    val tp = new FixedPool(6)
+    val tp = FixedPool(6)
 
     site(tp)(
       go { case get_d(_, r) + d(x) => r(x) },
@@ -187,7 +187,7 @@ class MoreBlockingSpec extends LogSpec {
     val incr = b[Unit, Unit]
     val get_f = b[Unit, Int]
 
-    val tp = new FixedPool(6)
+    val tp = FixedPool(6)
 
     site(tp)(
       go { case get_f(_, r) + f(x) => r(x) },
@@ -212,7 +212,7 @@ class MoreBlockingSpec extends LogSpec {
     val get_f = b[Unit, Int]
 
     clearGlobalErrorLog()
-    val tp = new FixedPool(4)
+    val tp = FixedPool(4)
 
     site(tp)(
       go { case get_f(_, r) + f(x) => r(x) },
@@ -240,7 +240,7 @@ class MoreBlockingSpec extends LogSpec {
     val get_f = b[Unit, Int]
 
     clearGlobalErrorLog()
-    val tp = new FixedPool(2)
+    val tp = FixedPool(2)
 
     site(tp)(
       go { case get_f(_, r) + f(x) => r(x) },

--- a/core/src/test/scala/io/chymyst/test/ParallelOrSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/ParallelOrSpec.scala
@@ -59,7 +59,7 @@ class ParallelOrSpec extends LogSpec {
     val fastFalse = b[Unit, Boolean]
     val slowFalse = b[Unit, Boolean]
 
-    val tp = new FixedPool(30)
+    val tp = FixedPool(30)
 
     site(tp)(
       go { case never(_, r) => r(neverReturn[Boolean]) },
@@ -126,7 +126,7 @@ class ParallelOrSpec extends LogSpec {
     val fast = b[Unit, String]
     val slow = b[Unit, String]
 
-    val tp = new FixedPool(30)
+    val tp = FixedPool(30)
 
     site(tp)(
       go { case never(_, r) => r(neverReturn[String]) },

--- a/core/src/test/scala/io/chymyst/test/Patterns01Spec.scala
+++ b/core/src/test/scala/io/chymyst/test/Patterns01Spec.scala
@@ -15,7 +15,7 @@ class Patterns01Spec extends LogSpec with BeforeAndAfterEach {
   var tp: Pool = _
 
   override def beforeEach(): Unit = {
-    tp = new BlockingPool(8)
+    tp = BlockingPool(8)
   }
 
   override def afterEach(): Unit = {
@@ -165,7 +165,7 @@ class Patterns01Spec extends LogSpec with BeforeAndAfterEach {
     val n = 100 // The number of rendezvous participants needs to be known in advance, or else we don't know how long still to wait for rendezvous.
 
     // There will be 2*n blocked threads; the test will fail with FixedPool(2*n-1).
-    withPool(new FixedPool(2 * n)) { pool =>
+    withPool(FixedPool(2 * n)) { pool =>
 
       val barrier = b[Unit, Unit]
       val counterInit = m[Unit]
@@ -239,7 +239,7 @@ class Patterns01Spec extends LogSpec with BeforeAndAfterEach {
     val done = b[Unit, Vector[Int]]
 
     val total = 10000
-    val tp = new BlockingPool(4) // Use BlockingPool because using a FixedPool gives a deadlock.
+    val tp = BlockingPool(4) // Use BlockingPool because using a FixedPool gives a deadlock.
     site(tp)(
       go { case danceCounter(x) + done(_, r) if x.size == total => r(x); danceCounter(x) }, // ignore warning about "non-variable type argument Int"
       go { case beginDancing(xy) + danceCounter(x) => danceCounter(x :+ xy) },
@@ -281,10 +281,10 @@ class Patterns01Spec extends LogSpec with BeforeAndAfterEach {
 
     val total = 50000
 
-    val tp1a = new FixedPool(1)
-    val tp1b = new FixedPool(1)
-    val tp1c = new FixedPool(1)
-    val tp1d = new FixedPool(1)
+    val tp1a = FixedPool(1)
+    val tp1b = FixedPool(1)
+    val tp1c = FixedPool(1)
+    val tp1d = FixedPool(1)
 
     site(tp)(
       go { case danceCounter(x) + done(_, r) if x.size == total => r(x); danceCounter(x) }, // ignore warning about "non-variable type argument Int"

--- a/core/src/test/scala/io/chymyst/test/Patterns02Spec.scala
+++ b/core/src/test/scala/io/chymyst/test/Patterns02Spec.scala
@@ -12,7 +12,7 @@ class Patterns02Spec extends LogSpec with BeforeAndAfterEach {
   var tp: Pool = _
 
   override def beforeEach(): Unit = {
-    tp = new BlockingPool(6)
+    tp = BlockingPool(6)
   }
 
   override def afterEach(): Unit = {

--- a/core/src/test/scala/io/chymyst/test/Patterns03Spec.scala
+++ b/core/src/test/scala/io/chymyst/test/Patterns03Spec.scala
@@ -14,7 +14,7 @@ class Patterns03Spec extends LogSpec with BeforeAndAfterEach {
   var tp: Pool = _
 
   override def beforeEach(): Unit = {
-    tp = new BlockingPool(4)
+    tp = BlockingPool(4)
   }
 
   override def afterEach(): Unit = {

--- a/core/src/test/scala/io/chymyst/test/ShutdownSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/ShutdownSpec.scala
@@ -8,9 +8,11 @@ import io.chymyst.jc._
   */
 class ShutdownSpec extends LogSpec {
 
-  it should "not fail to schedule reactions after a timeout of site pool" in {
+  behavior of "pool threads"
 
-    val pool = FixedPool(2)
+  it should "not fail to schedule reactions after a timeout when fixed pool may free threads" in {
+
+    val pool = FixedPool()
 
     val x = m[Unit]
     site(pool)(go { case x(()) => })
@@ -20,7 +22,23 @@ class ShutdownSpec extends LogSpec {
     pool.shutdownNow()
   }
 
-  it should "not fail to schedule reactions after shutdown of custom reaction pool" in {
+  it should "not fail to schedule reactions after a timeout when BlockingPool may free threads" in {
+
+    val pool = BlockingPool()
+
+    pool.currentPoolSize shouldEqual cpuCores
+
+    val x = m[Unit]
+    site(pool)(go { case x(()) => })
+    x()
+    pool.currentPoolSize shouldEqual cpuCores
+    Thread.sleep(5000)
+    pool.currentPoolSize shouldEqual cpuCores
+    x()
+    pool.shutdownNow()
+  }
+
+/*  it should "not fail to schedule reactions after shutdown of custom reaction pool" in {
 
     val pool = FixedPool(2)
     pool.shutdownNow()
@@ -43,4 +61,5 @@ class ShutdownSpec extends LogSpec {
       x()
     } should have message "In Site{x → ...}: Cannot emit molecule x() because reaction pool is not active"
   }
+  */
 }

--- a/core/src/test/scala/io/chymyst/test/ShutdownSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/ShutdownSpec.scala
@@ -10,7 +10,7 @@ class ShutdownSpec extends LogSpec {
 
   it should "not fail to schedule reactions after a timeout of site pool" in {
 
-    val pool = new FixedPool(2)
+    val pool = FixedPool(2)
 
     val x = m[Unit]
     site(pool)(go { case x(()) => })
@@ -22,7 +22,7 @@ class ShutdownSpec extends LogSpec {
 
   it should "not fail to schedule reactions after shutdown of custom reaction pool" in {
 
-    val pool = new FixedPool(2)
+    val pool = FixedPool(2)
     pool.shutdownNow()
 
     val x = m[Unit]

--- a/core/src/test/scala/io/chymyst/test/ShutdownSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/ShutdownSpec.scala
@@ -38,7 +38,7 @@ class ShutdownSpec extends LogSpec {
     pool.shutdownNow()
   }
 
-/*  it should "not fail to schedule reactions after shutdown of custom reaction pool" in {
+  it should "not fail to schedule reactions after shutdown of custom reaction pool" in {
 
     val pool = FixedPool(2)
     pool.shutdownNow()
@@ -61,5 +61,5 @@ class ShutdownSpec extends LogSpec {
       x()
     } should have message "In Site{x → ...}: Cannot emit molecule x() because reaction pool is not active"
   }
-  */
+
 }

--- a/core/src/test/scala/io/chymyst/test/StaticAnalysisSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/StaticAnalysisSpec.scala
@@ -476,7 +476,7 @@ class StaticAnalysisSpec extends LogSpec {
   behavior of "livelock with static molecules"
 
   it should "give warning in a simple reaction with possible livelock" in {
-    withPool(new FixedPool(2)) { tp ⇒
+    withPool(FixedPool(2)) { tp ⇒
       val a = m[Int]
       val warnings = site(tp)(
         go { case _ ⇒ a(1) },
@@ -487,7 +487,7 @@ class StaticAnalysisSpec extends LogSpec {
   }
 
   it should "give an error in a reaction with static molecule emitted conditionally" in {
-    val tp = new FixedPool(2)
+    val tp = FixedPool(2)
     val a = m[Int]
     the[Exception] thrownBy {
       val warnings = site(tp)(
@@ -500,7 +500,7 @@ class StaticAnalysisSpec extends LogSpec {
   }
 
   it should "give warning in a reaction with static molecule emitted conditionally with two branches" in {
-    val tp = new FixedPool(2)
+    val tp = FixedPool(2)
     val a = m[Int]
     val warnings = site(tp)(
       go { case _ ⇒ a(1) },

--- a/core/src/test/scala/io/chymyst/test/StaticMoleculesSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/StaticMoleculesSpec.scala
@@ -11,7 +11,7 @@ class StaticMoleculesSpec extends LogSpec with BeforeAndAfterEach {
 
   var tp: Pool = _
 
-  override def beforeEach(): Unit = tp = new FixedPool(3)
+  override def beforeEach(): Unit = tp = FixedPool(3)
 
   override def afterEach(): Unit = tp.shutdownNow()
 
@@ -22,7 +22,7 @@ class StaticMoleculesSpec extends LogSpec with BeforeAndAfterEach {
     val f = b[Unit, String]
     val d = m[String]
 
-    val tp1 = new FixedPool(1) // This test works only with single threads.
+    val tp1 = FixedPool(1) // This test works only with single threads.
 
     site(tp1)(
       go { case f(_, r) + d(text) => r(text); d(text) },
@@ -42,7 +42,7 @@ class StaticMoleculesSpec extends LogSpec with BeforeAndAfterEach {
 
   it should "refuse to emit a static molecule immediately after reaction site" in {
 
-    val tp1 = new FixedPool(1) // This test works only with single threads.
+    val tp1 = FixedPool(1) // This test works only with single threads.
 
     repeat(20, { i =>
       val f = b[Unit, String]
@@ -437,8 +437,8 @@ class StaticMoleculesSpec extends LogSpec with BeforeAndAfterEach {
     val incr = b[Unit, Unit]
     val stabilize_d = b[Unit, Unit]
 
-    val tp1 = new FixedPool(1)
-    val tp3 = new BlockingPool(5)
+    val tp1 = FixedPool(1)
+    val tp3 = BlockingPool(5)
 
     site(tp3)(
       go { case wait(_, r) + e(_) => r() } onThreads tp3,

--- a/core/src/test/scala/io/chymyst/util/FinalTagless.scala
+++ b/core/src/test/scala/io/chymyst/util/FinalTagless.scala
@@ -1,5 +1,8 @@
 package io.chymyst.util
 
+// Exploration of final tagless types. This implements Option[T] as a final tagless type.
+// Results are not satisfactory: FTOption[T] cannot avoid allocations because it has a type parameter T and thus cannot have `val`
+
 object FinalTagless {
 
   trait FTOptionAlg[T, X] {

--- a/docs/chymyst-core.md
+++ b/docs/chymyst-core.md
@@ -503,7 +503,7 @@ Thus, creating many thousands of new reaction pools is impossible.
 A thread pool is created like this:
 
 ```scala
-val tp = new BlockingPool(8)
+val tp = BlockingPool(8)
 
 ```
 
@@ -513,7 +513,7 @@ As a convenience, the method `cpuCores` can be used to determine the number of a
 This value is used by `BlockingPool`'s default constructor.
 
 ```scala
-val tp1 = new BlockingPool() // same as new BlockingPool(cpuCores)
+val tp1 = BlockingPool() // same as BlockingPool(cpuCores)
 
 ```
 
@@ -521,7 +521,7 @@ Another available reaction pool is `FixedPool`.
 This pool holds a fixed, never changing number of reaction threads (and a single, dedicated scheduler thread).
 
 ```scala
-val tp1 = new FixedPool(4) // 4 threads for reactions, one thread for scheduler
+val tp1 = FixedPool(4) // 4 threads for reactions, one thread for scheduler
 
 ```
 
@@ -530,7 +530,7 @@ val tp1 = new FixedPool(4) // 4 threads for reactions, one thread for scheduler
 The `site()` call can take an additional argument that specifies a thread pool for all reactions at this RS.
 
 ```scala
-val tp = new BlockingPool(8)
+val tp = BlockingPool(8)
 
 val a = m[Unit]
 val c = m[Unit]
@@ -546,9 +546,9 @@ site(tp)(
 When it is desired that a particular reaction should be scheduled on a particular thread pool, the `onThreads()` method can be used.
 
 ```scala
-val tp = new BlockingPool(8)
+val tp = BlockingPool(8)
 
-val tp2 = new BlockingPool(2)
+val tp2 = BlockingPool(2)
 
 val a = m[Unit]
 val c = m[Unit]
@@ -576,7 +576,7 @@ Since JVM will not quit when some threads are still active, the programmer needs
 The method `shutdownNow()` will stop the threads in the thread pool.
 
 ```scala
-val tp = new BlockingPool(8)
+val tp = BlockingPool(8)
 
 site(tp)(...)
 
@@ -607,7 +607,7 @@ The user needs to employ `BlockingIdle` explicitly only when a reaction contains
 Example:
 
 ```scala
-val pool = new BlockingPool(8)
+val pool = BlockingPool(8)
 
 val a = m[Url]
 val b = m[Client]

--- a/docs/chymyst-core.md
+++ b/docs/chymyst-core.md
@@ -485,7 +485,7 @@ To facilitate this control, `Chymyst Core` implements the thread pool feature.
 Each RS uses a special thread pool (the `reactionPool`).
 The reaction pool contains two sets of threads:
 
-1. A common thread executor for running reactions. This thread executor can have one or more threads.
+1. A common `ThreadPoolExecutor` for running reactions. This thread executor (called `workerExecutor` in `Pool.scala`) can have one or more threads.
 2. A single, dedicated scheduler thread for deciding new reactions (called the `schedulerExecutor` in the code).
 
 By default, the reaction sites use a statically allocated reaction pool that is shared by all RSs.
@@ -559,10 +559,6 @@ site(tp)(
  go { case c(_) => ... }, // this reaction will run on `tp`
 )
 
-// Wait until all done.
-tp.shutdownNow()
-tp2.shutdownNow()
-
 ```
 
 By default, all sites will use the `defaultPool`.
@@ -571,9 +567,9 @@ If the reaction pool is specified for a particular RS, all reactions in that RS 
 
 ## Stopping a thread pool
 
-Since JVM will not quit when some threads are still active, the programmer needs to stop the thread pool when all tasks are finished and no more reactions need to be run.
+Sometimes the programmer needs to stop the thread pool imediately, so that no more reactions can be run.
 
-The method `shutdownNow()` will stop the threads in the thread pool.
+The method `shutdownNow()` will interrupt all threads in the thread pool and clear out the reaction queue.
 
 ```scala
 val tp = BlockingPool(8)
@@ -582,14 +578,16 @@ site(tp)(...)
 
 // Emit molecules
   ...
-// Now wait until all tasks are finished.
-
+// All work needs to be stopped now.
 tp.shutdownNow()
 
 ```
 
 Thread pools also implement the `AutoCloseable` interface.
 The `close()` method is an alias to `shutdownNow()`.
+
+Thread pools will stop their threads when idle for a certain time `Pool.recycleThreadTimeMs()`.
+So usually it is not necessary to shut down the pools manually.
 
 ## Blocking calls and thread pools
 

--- a/docs/chymyst_features.md
+++ b/docs/chymyst_features.md
@@ -188,8 +188,8 @@ Each reaction site and each reaction can be run on a different, separate thread 
 The user can control the number of threads in thread pools.
 
 ```scala
-val tp1 = new FixedPool(1)
-val tp8 = new BlockingPool(8)
+val tp1 = FixedPool(1)
+val tp8 = BlockingPool(8)
 
 site(tp8)( // reaction site runs on tp8
   go { case a(x) => ... } onThreads tp1, // this reaction runs on tp1
@@ -206,7 +206,7 @@ So, blocking operations do not decrease the degree of parallelism.
 When a `Chymyst`-based program needs to exit, it can shut down the thread pools that run reactions.
 
 ```scala
-val tp = new BlockingPool(8)
+val tp = BlockingPool(8)
 
 // define reactions and run them
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 # Version history
 
-- 0.2.0 Renamed "SmartPool" to "BlockingPool" and simplified the thread info handling. More static checks for emission of static molecules. Radical rewrite of blocking molecules code without semaphores and without error replies, simplifying the API. The call `reply.checkTimeout()` is eliminated: the reply emitters now always return `Boolean`. Reactions will not throw exceptions any more to unblock waiting calls when errors occur. Instead, a better error recovery mechanism will be implemented. 
+- 0.2.0 Renamed "SmartPool" to "BlockingPool" and simplified the thread info handling. More static checks for emission of static molecules. Radical rewrite of blocking molecules code without semaphores and without error replies, simplifying the API. The call `reply.checkTimeout()` is eliminated: the reply emitters now always return `Boolean`. Reactions will not throw exceptions any more to unblock waiting calls when errors occur. Instead, a better error recovery mechanism will be implemented. New functionality: pool names, shorter pool syntax, thread group priorities, and automatic pool shutdown. Added documentation chapter on `Chymyst` as an evolution of Actor model. 
 
 - 0.1.9 Static molecules are now restricted to a linear output context, in a similar way to blocking replies. Reaction schedulers now run on a single dedicated thread; site pools are eliminated. New examples: 8 queens and hierarchical map/reduce. Added a simple facility for deadlock warning, used for `FixedPool`. Tutorial updated with a new "quick start" guide that avoids requiring too many new concepts. Miscellaneous bug fixes and performance improvements.
 
@@ -48,13 +48,13 @@ This will allow us to implement interesting features such as:
 - allow nonlinear input patterns and arbitrary guards (done in 0.1.5, optimized in 0.1.8)
 - automatic pipelining (i.e. strict ordering of consumed molecules) should give a speedup (done in 0.1.8)
 
-Version 0.3: Investigate interoperability with streaming frameworks such as Scala Streams, Scalaz Streams, FS2, Akka Streaming, Kafka, Heron. Use "pipelined" molecules that are optimized for streaming usage.
+Version 0.3: Investigate interoperability with streaming frameworks such as Scala Streams, Scalaz Streams, FS2, Akka Streaming, Kafka, Heron. Use "pipelined" molecules that are optimized for streaming usage (done in 0.1.8).
 
 Version 0.4: Enterprise readiness: fault tolerance, monitoring, flexible logging, assertions on static molecules and perhaps on some other situations, thread fusing for static or pipelined molecule reactions.
 
 Version 0.5: Application framework `Chymyst`, converting between molecules and various external APIs such as HTTP, GUI toolkits, Unix files and processes.
 
-Version 0.6: Automatic distributed and fault-tolerant execution of chemical reactions ("soup pools").
+Version 0.6: Automatic distributed and fault-tolerant execution of chemical reactions ("soup pools" or another mechanism).
 
 Version 0.7: Static optimizations: use advanced macros and code transformations to completely eliminate all blocking and all inessential pattern-matching overhead.
 
@@ -63,6 +63,8 @@ Version 0.7: Static optimizations: use advanced macros and code transformations 
  value * difficulty - description
   
  1 * 1 - static molecules cannot have reactions with only one input (?)
+
+ 1 * 1 - blocking molecules cannot have reactions with only one input (?)
 
  4 * 5 - do not schedule reactions if queues are full. At the moment, RejectedExecutionException is thrown. It's best to avoid this. Molecules should be accumulated in the bag, to be inspected at a later time (e.g. when some tasks are finished). Insert a call at the end of each reaction, to re-inspect the bag.
 
@@ -74,22 +76,33 @@ Version 0.7: Static optimizations: use advanced macros and code transformations 
 
  3 * 3 - add logging of reactions currently in progress at a given RS. (Need a custom thread class, or a registry of reactions?)
  
- 3 * 4 - use `java.management` to get statistics over how much time is spent running reactions, waiting while BlockingIdle(), etc. 
+ 3 * 4 - use `java.management` to get statistics over how much time is spent running reactions, waiting while `BlockingIdle()`, etc. 
+ This should be a pool-based API and use an external logger; or it can use special molecules.
+ 
+ 5 * 5 - reaction sites should detect the situation when another reaction site is pumping molecules into this RS while these molecules can't be consumed quickly enough.
+ It should identify which reactions are emitting these molecules, and notify the other RS about it ("backpressure").
+ 
+ 2 * 2 - thread pools should have an API for changing the number of threads at run time.
 
  2 * 3 - implement `Perishable()` static molecules that can be eventually consumed (but not repeatedly emitted)
 
- 2 * 2 - refactor ActorPool into a separate project with its own artifact and dependency. Similarly for interop with Akka Stream, Scalaz Task etc.
+ 2 * 2 - refactor ActorPool into a separate project with its own artifact and dependency (right now it's not used). Similarly for interop with Akka Stream, Scalaz Task etc.
 
  3 * 4 - implement "thread fusion" like in iOS/Android: 1) when a blocking molecule is emitted from a thread T and the corresponding reaction site runs on the same thread T, do not schedule a task but simply run the reaction site synchronously (non-blocking molecules still require a scheduled task? not sure); 2) when a reaction is scheduled from a reaction site that runs on thread T and the reaction is configured to run on the same thread, do not schedule a task but simply run the reaction synchronously.
 
  3 * 5 - implement automatic thread fusion for static molecules? — not sure how that would work.
  
+ 4 * 3 - as an option, run a reaction site on the current thread (?) or on a given executor
+ 
  2 * 3 - when attaching molecules to futures or futures to molecules, we can perhaps schedule the new futures on the same thread pool as the reaction site to which the molecule is bound? This requires having access to that thread pool. Maybe that access would be handy to users anyway?
  
  5 * 5 - is it possible to implement distributed execution by sharing the site pool with another machine (but running the reaction sites only on the master node)? Use Paxos, Raft, or other consensus algorithm to ensure consistency?
 
- 3 * 4 - LAZY values on molecules? By default? What about pattern-matching then? Probably need to refactor SyncMol and AsyncMol into non-case classes and change some other logic. — Will not do now. Not sure that lazy values on molecules are important as a primitive. We can always simulate them using closures.
-
+ 5 * 5 - implement per-molecule unit testing API. `mol.onEmit(callback: T => Unit)`, `mol.onConsume(callback: T => Unit)`, `mol.onDecide(callback: T => Unit)`. Through this, we can also implement Future-yielding APIs, `mol.nextEmit : Future[T]` etc. - These APIs should be considered debug-only; callbacks cannot be assigned within reactions (??) and/or can be assigned only once (??). Using these test features, chemistry can be tested via scalacheck by formulating a law such as:
+ `c(n); d().awaitConsumed(); now assert f() == n-1.`
+ 
+ 5 * 5 - Distributed vs. Remote; molecule vs. reaction vs. reaction site. This yields 6 distinct possibilities for distributed / remote execution. Need to figure out their logical dependencies and implementation possibilities. Note that, compared with the Actor model, we do not need to check that the actor is alive; distributed execution model only needs to verify that (1) network is up, (2) remote application is running.
+  
  3 * 2 - add per-molecule logging; log to file or to logger function
 
  5 * 5 - implement "progress and safety" assertions so that we could prevent deadlock in more cases
@@ -99,8 +112,6 @@ Version 0.7: Static optimizations: use advanced macros and code transformations 
  2 * 4 - allow molecule values to be parameterized types or even higher-kinded types? Need to test this.
 
  2 * 2 - make memory profiling / benchmarking; how many molecules can we have per 1 GB of RAM?
-
- 2 * 2 - annotate thread pools with names. Make a macro for auto-naming thread pools of various kinds.
 
  2 * 2 - add tests for Pool such that we submit a closure that sleeps and then submit another closure. Should get / or not get the RejectedExecutionException
 
@@ -113,7 +124,7 @@ Version 0.7: Static optimizations: use advanced macros and code transformations 
 
  5 * 5 - How to rewrite reaction sites so that blocking molecules are transparently replaced by a pair of non-blocking molecules? Can this be done even if blocking emitters are used inside functions? (Perhaps with extra molecules emitted at the end of the function call?) Is it useful to emit an auxiliary molecule at the end of an "if" expression, to avoid code duplication? How can we continue to support real blocking emitters when used outside of macro code? 
  
- 5 * 5 - Can we perform the unblocking transformation using delimited continuations?
+ 5 * 5 - Can we perform the unblocking transformation using delimited continuations? -- Not sure. Delimited continuations seem to require all code to reside inside `reset()`.
  
  2 * 2 - Revisit Philippe's error reporting branch, perhaps salvage some code
   
@@ -123,8 +134,29 @@ Version 0.7: Static optimizations: use advanced macros and code transformations 
  
  3 * 3 - Write a tutorial section about timers and time-outs: cancellable recurring jobs, cancellable subscriptions, time-outs on receiving replies from non-blocking molecules (?)
  
+ 3 * 4 - Blocking molecule emitter should have a Future[] API as well. When exception is thrown in the reaction, the Promise will fail. Emitting thread could inspect the promise and detect the failure. In this way, we can still have some error reporting from exceptions (which was removed in 0.2.0). However, a better mechanism could be implemented.
+ 
+ 5 * 5 - Implement full error recovery: attach an error handler to a reaction. Error handler is another reaction that has an automatic `Throwable` input and otherwise has the same input molecules as the errored reaction. `go { case a(x) + b(y) => ... } recoverWith { (e: Throwable) => go { case a(x) + b(y) => ... } }`
+  Recovery semantics:
+  
+  - Reaction is _disabled_ for the duration of recovery, i.e. no new instances of the reaction can be scheduled.
+  - Recovery handler returns a Policy value which determines whether we:
+    - Run the reaction again, keeping its recovery option (this risks an infinite recovery loop)
+    - Run the reaction again but disable it permanently if it fails next time (or up to retry count)
+    - Disable the reaction permanently and re-emit its consumed inputs back into the soup
+    - Disable the reaction permanently but do not re-emit its inputs
+ 
+ 1 * 1 - Implement Reaction.withRetry(retry: Boolean) as another alias to the existing API. Also, Reaction.enable(enable: Boolean) ?
+ 
+ 5 * 5 - Implement performance metrics either through a given logger or through special molecules.
+ Need to monitor: Bag size at reaction site; arrival rate; consumption rate; reaction error rate; reaction compute time; thread utilization (busy / locked waiting / idle) both for scheduler thread and for worker threads.
+ 
+ 3 * 3 - Nested reactions could be automatically defined at the same reaction site as parent reactions? This seems to be required for the automatic unblocking transformation.
+ 
 ## Will not do for now
  
+ 3 * 4 - LAZY values on molecules? By default? What about pattern-matching then? Probably need to refactor SyncMol and AsyncMol into non-case classes and change some other logic. — Will not do now. Not sure that lazy values on molecules are important as a primitive. We can always simulate them using closures.
+
  2 * 3 - investigate using wait/notify instead of semaphore; does it give better performance? - So far, attempts to do this failed.
  
  5 * 5 - implement fairness with respect to molecules. - Will not do now. If reactions depend on fairness, something is probably wrong with the chemistry. Instead, pipelining should be a very often occurring optimization.


### PR DESCRIPTION
`FixedPool` needs refactoring. Also, this PR will explore other features to be added to pools:

- Pools can have names
- shorter syntax with a macro
- threads are named too
- Pool threads are in a JVM thread group with priority setting etc.
- all pool threads need to time out, and there should be no core threads - will this allow us to shutdown automatically?
- JMX could be used for performance metrics as a Pool-based API