### PR TITLE
prohibit static molecules as sole static inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ The current implementation is tested under Oracle JDK 8 with Scala `2.11.8` and 
 
 ## Overview of `Chymyst` and the chemical machine paradigm
 
-### [Get started with this extensive tutorial book](https://winitzki.gitbooks.io/concurrency-in-reactions-declarative-multicore-in/content/)
+#### [Get started with this extensive tutorial book](https://winitzki.gitbooks.io/concurrency-in-reactions-declarative-multicore-in/content/)
+ 
+#### [Project documentation at Github Pages](https://chymyst.github.io/chymyst-core/chymyst00.html)
 
 #### [From actors to reactions: a guide for those familiar with the Actor model](https://chymyst.github.io/chymyst-core/chymyst-actor.html)
 

--- a/benchmark/src/main/scala/io/chymyst/benchmark/MainApp.scala
+++ b/benchmark/src/main/scala/io/chymyst/benchmark/MainApp.scala
@@ -18,8 +18,6 @@ object MainApp extends App {
 
   import MainAppConfig._
 
-  val version = "0.1.9-SNAPSHOT"
-
   def run3times(task: => Long): Long = {
     task
     // just priming, no measurement

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ $ sbt
 
 val commonSettings = Defaults.coreDefaultSettings ++ Seq(
   organization := "io.chymyst",
-  version := "0.2.0-SNAPSHOT",
+  version := "0.2.0",
   scalaVersion := "2.12.2",
   crossScalaVersions := Seq("2.11.11", "2.12.2"),
   resolvers ++= Seq(

--- a/core/src/main/scala/io/chymyst/jc/StaticAnalysis.scala
+++ b/core/src/main/scala/io/chymyst/jc/StaticAnalysis.scala
@@ -213,14 +213,9 @@ private[jc] object StaticAnalysis {
         mol → reactionsWithCounts
       }
 
-    val singleConsumed = reactions
-      .map(r ⇒ (r, r.inputMoleculesSortedAlphabetically.headOption))
-      .filter { _._1.info.inputsSortedByConstraintStrength match {
-        // select 1-element input lists such that the input is a static molecule
-        case List(info) ⇒ staticMols contains info.molecule
-        case _ => false
-      }
-    }.collect{ case (r, Some(mol)) ⇒ s"static molecule ($mol) is the only input of reaction ${r.info}"}
+    val onlyStaticConsumed = reactions
+      .filter(_.info.inputs.forall(info ⇒ staticMols.contains(info.molecule)))
+      .map { r ⇒ s"reaction {${r.info}} has only static input molecules (${r.inputMoleculesSortedAlphabetically.mkString(",")})" }
 
     val wrongConsumed = staticMolsConsumedMaxTimes
       .flatMap {
@@ -242,7 +237,7 @@ private[jc] object StaticAnalysis {
       case _ => None
     }
 
-    val errorList = wrongConsumed ++ wrongOutput ++ singleConsumed
+    val errorList = wrongConsumed ++ wrongOutput ++ onlyStaticConsumed
 
     if (errorList.nonEmpty)
       Some(s"Incorrect static molecule usage: ${errorList.mkString("; ")}")
@@ -254,24 +249,33 @@ private[jc] object StaticAnalysis {
   private def checkOutputsForStaticMols(staticMols: Map[MolEmitter, Int], reactions: Seq[Reaction]): Option[String] = {
     val errorList = staticMols.flatMap {
       case (mol, _) =>
-        reactions.flatMap { r =>
-          val outputs = r.info.shrunkOutputs.filter(_.molecule === mol)
-          val outputTimes = outputs.length
-          val containsAsInput = r.inputMoleculesSet.contains(mol)
-          if (outputTimes > 1)
-            Some(s"static molecule ($mol) emitted more than once by reaction {${r.info}}")
-          else if (outputs.count(_.environments.forall(env ⇒ env.linear && env.atLeastOne)) === 1) {
-            if (!containsAsInput)
-              Some(s"static molecule ($mol) emitted but not consumed by reaction {${r.info}}")
+        reactions.flatMap {
+          r =>
+            val outputs = r.info.shrunkOutputs.filter(_.molecule === mol)
+            val outputTimes = outputs.length
+            val containsAsInput = r.inputMoleculesSet.contains(mol)
+            if (outputTimes > 1)
+              Some(s"static molecule ($mol) emitted more than once by reaction {${
+                r.info
+              }}")
+            else if (outputs.count(_.environments.forall(env ⇒ env.linear && env.atLeastOne)) === 1) {
+              if (!containsAsInput)
+                Some(s"static molecule ($mol) emitted but not consumed by reaction {${
+                  r.info
+                }}")
+              else None
+            } else if (outputTimes =!= 0 && containsAsInput) // outputTimes == 0 was already handled by checkInputsForStaticMols
+              Some(s"static molecule ($mol) consumed but not guaranteed to be emitted by reaction {${
+                r.info
+              }}")
             else None
-          } else if (outputTimes =!= 0 && containsAsInput) // outputTimes == 0 was already handled by checkInputsForStaticMols
-            Some(s"static molecule ($mol) consumed but not guaranteed to be emitted by reaction {${r.info}}")
-          else None
         }
     }
 
     if (errorList.nonEmpty)
-      Some(s"Incorrect static molecule usage: ${errorList.mkString("; ")}")
+      Some(s"Incorrect static molecule usage: ${
+        errorList.mkString("; ")
+      }")
     else None
   }
 
@@ -290,33 +294,45 @@ private[jc] object StaticAnalysis {
   private[jc] def findStaticMolDeclarationErrors(staticReactions: Seq[Reaction]): Seq[String] = {
     val foundErrors = staticReactions.map(_.info).filterNot(_.guardPresence.noCrossGuards)
     if (foundErrors.nonEmpty)
-      foundErrors.map { info => s"Static reaction {$info} should not have a guard condition" }
+      foundErrors.map {
+        info => s"Static reaction {$info} should not have a guard condition"
+      }
     else Seq()
   }
 
   // Inspect the static molecules actually emitted. Their multiplicities must be not less than the declared multiplicities.
   private[jc] def findStaticMolsEmissionErrors(staticMolsDeclared: Map[MolEmitter, Int], staticMolsEmitted: Map[MolEmitter, Int]): Seq[String] = {
     val foundErrors = staticMolsDeclared
-      .filter { case (mol, count) => staticMolsEmitted.getOrElse(mol, 0) < count }
-      .map { case (mol, count) =>
-        val countEmitted = staticMolsEmitted.getOrElse(mol, 0)
-        s"$mol emitted $countEmitted times instead of $count"
+      .filter {
+        case (mol, count) => staticMolsEmitted.getOrElse(mol, 0) < count
+      }
+      .map {
+        case (mol, count) =>
+          val countEmitted = staticMolsEmitted.getOrElse(mol, 0)
+          s"$mol emitted $countEmitted times instead of $count"
       }
     if (foundErrors.nonEmpty)
-      Seq(s"Too few static molecules emitted: ${foundErrors.toList.sorted.mkString(", ")}")
+      Seq(s"Too few static molecules emitted: ${
+        foundErrors.toList.sorted.mkString(", ")
+      }")
     else Seq()
   }
 
   // Inspect the static molecules actually emitted. Their multiplicities must be not more than the declared multiplicities.
   private[jc] def findStaticMolsEmissionWarnings(staticMolsDeclared: Map[MolEmitter, Int], staticMolsEmitted: Map[MolEmitter, Int]) = {
     val foundErrors = staticMolsDeclared
-      .filter { case (mol, count) => staticMolsEmitted.getOrElse(mol, 0) > count }
-      .map { case (mol, count) =>
-        val countEmitted = staticMolsEmitted.getOrElse(mol, 0)
-        s"$mol emitted $countEmitted times instead of $count"
+      .filter {
+        case (mol, count) => staticMolsEmitted.getOrElse(mol, 0) > count
+      }
+      .map {
+        case (mol, count) =>
+          val countEmitted = staticMolsEmitted.getOrElse(mol, 0)
+          s"$mol emitted $countEmitted times instead of $count"
       }
     if (foundErrors.nonEmpty)
-      Seq(s"Possibly too many static molecules emitted: ${foundErrors.toList.sorted.mkString(", ")}")
+      Seq(s"Possibly too many static molecules emitted: ${
+        foundErrors.toList.sorted.mkString(", ")
+      }")
     else Seq()
   }
 

--- a/core/src/test/scala/io/chymyst/test/StaticMoleculesSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/StaticMoleculesSpec.scala
@@ -105,7 +105,22 @@ class StaticMoleculesSpec extends LogSpec with BeforeAndAfterEach {
         go { case _ => d() } // static reaction
       )
     }
-    thrown.getMessage shouldEqual "In Site{c/B → ...; d → ...}: Incorrect static molecule usage: static molecule (d) emitted but not consumed by reaction {c/B(_) → d()}; Incorrect static molecule usage: static molecule (d) consumed but not emitted by reaction {d(_) → e()}; static molecule (d) is the only input of reaction d(_) → e()"
+    thrown.getMessage shouldEqual "In Site{c/B → ...; d → ...}: Incorrect static molecule usage: static molecule (d) emitted but not consumed by reaction {c/B(_) → d()}; Incorrect static molecule usage: static molecule (d) consumed but not emitted by reaction {d(_) → e()}; reaction {d(_) → e()} has only static input molecules (d)"
+  }
+
+  it should "signal error when two static molecules are the sole input of a reaction" in {
+    val thrown = intercept[Exception] {
+      val c = b[Unit, String]
+      val d = m[Unit]
+      val e = m[Unit]
+
+      site(tp)(
+        go { case c(_, r) => r("ok"); d() },
+        go { case d(_) + e(_) => e() },
+        go { case _ => d() + e() } // static reaction
+      )
+    }
+    thrown.getMessage shouldEqual "In Site{c/B → ...; d + e → ...}: Incorrect static molecule usage: static molecule (d) emitted but not consumed by reaction {c/B(_) → d()}; Incorrect static molecule usage: static molecule (d) consumed but not emitted by reaction {d(_) + e(_) → e()}; reaction {d(_) + e(_) → e()} has only static input molecules (d,e)"
   }
 
   it should "signal error when a static molecule is emitted but not consumed by reaction" in {

--- a/core/src/test/scala/io/chymyst/test/StaticMoleculesSpec.scala
+++ b/core/src/test/scala/io/chymyst/test/StaticMoleculesSpec.scala
@@ -93,6 +93,21 @@ class StaticMoleculesSpec extends LogSpec with BeforeAndAfterEach {
     thrown.getMessage shouldEqual "In Site{c/B + d → ...}: Incorrect static molecule usage: static molecule (d) emitted more than once by reaction {c/B(_) + d(_) → d() + d()}"
   }
 
+  it should "signal error when a static molecule is the sole input of a reaction" in {
+    val thrown = intercept[Exception] {
+      val c = b[Unit, String]
+      val d = m[Unit]
+      val e = m[Unit]
+
+      site(tp)(
+        go { case c(_, r) => r("ok"); d() },
+        go { case d(_) => e() },
+        go { case _ => d() } // static reaction
+      )
+    }
+    thrown.getMessage shouldEqual "In Site{c/B → ...; d → ...}: Incorrect static molecule usage: static molecule (d) emitted but not consumed by reaction {c/B(_) → d()}; Incorrect static molecule usage: static molecule (d) consumed but not emitted by reaction {d(_) → e()}; static molecule (d) is the only input of reaction d(_) → e()"
+  }
+
   it should "signal error when a static molecule is emitted but not consumed by reaction" in {
     val thrown = intercept[Exception] {
       val c = b[Unit, String]

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ The code of `Chymyst Core` is based on previous Join Calculus implementations by
 
 ### [Get started with this extensive tutorial book](https://winitzki.gitbooks.io/concurrency-in-reactions-declarative-multicore-in/content/)
 
+#### [From actors to reactions: a guide for those familiar with the Actor model](https://chymyst.github.io/chymyst-core/chymyst-actor.html)
+
 #### [A "Hello, world" project](https://github.com/Chymyst/helloworld)
 
 #### [Video presentation of early version of `Chymyst Core`, then called `JoinRun`](https://www.youtube.com/watch?v=jawyHGjUfBU)
@@ -22,15 +24,15 @@ The code of `Chymyst Core` is based on previous Join Calculus implementations by
 This talk was given at [Scalæ by the Bay 2016](https://scalaebythebay2016.sched.org/event/7iU2/concurrent-join-calculus-in-scala).
 See also these [talk slides revised for the current syntax](https://github.com/winitzki/talks/raw/master/join_calculus/join_calculus_2016_revised.pdf).
 
-### [Main features of the chemical machine](docs/chymyst_features.md)
+### [Main features of the chemical machine](chymyst_features.md)
 
-#### [Comparison of the chemical machine vs. academic Join Calculus](docs/chymyst_vs_jc.md#comparison-chemical-machine-vs-academic-join-calculus)
+#### [Comparison of the chemical machine vs. academic Join Calculus](chymyst_vs_jc.md#comparison-chemical-machine-vs-academic-join-calculus)
 
-#### [Comparison of the chemical machine vs. the Actor model](docs/chymyst_vs_jc.md#comparison-chemical-machine-vs-actor-model)
+#### [Comparison of the chemical machine vs. the Actor model](chymyst_vs_jc.md#comparison-chemical-machine-vs-actor-model)
 
-#### [Comparison of the chemical machine vs. the coroutines / channels approach (CSP)](docs/chymyst_vs_jc.md#comparison-chemical-machine-vs-csp)
+#### [Comparison of the chemical machine vs. the coroutines / channels approach (CSP)](chymyst_vs_jc.md#comparison-chemical-machine-vs-csp)
 
-#### [Technical documentation for `Chymyst Core`](docs/chymyst-core.md)
+#### [Technical documentation for `Chymyst Core`](chymyst-core.md)
 
 #### [Source code repository for `Chymyst Core`](https://github.com/Chymyst/chymyst-core)
 

--- a/docs/chymyst04.md
+++ b/docs/chymyst04.md
@@ -419,9 +419,13 @@ Declaring a molecule as static can be a useful tool for avoiding errors in chemi
 
 - A static molecules can be emitted only by a reaction that consumes it, or by the static reaction that defines it.
 - A reaction may not consume more than one copy of a static molecule.
+- A reaction must have other non-static input molecules besides static molecules.
 - It is an error if a reaction consumes a static molecule but does not emit it back into the soup, or emits it more than once.
 - It is also an error if a reaction emits a static molecule it did not consume, or if any other code emits additional copies of the static molecule at any time.
-- A reaction may not emit static molecules in a loop
+- A reaction may not emit static molecules from within a loop or within function calls.
+
+These restrictions are intended to maintain the semantics of static molecules.
+Application code that violates these restrictions will cause an "early" run-time error.
 
 ### Volatile readers for static molecules
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -61,10 +61,8 @@ Version 0.7: Static optimizations: use advanced macros and code transformations 
 # Current To-Do List
 
  value * difficulty - description
-  
- 1 * 1 - static molecules cannot have reactions with only one input (?)
 
- 1 * 1 - blocking molecules cannot have reactions with only one input (?)
+ 1 * 1 - blocking molecules cannot have reactions with only one input (?) - not sure if this is helpful.
 
  4 * 5 - do not schedule reactions if queues are full. At the moment, RejectedExecutionException is thrown. It's best to avoid this. Molecules should be accumulated in the bag, to be inspected at a later time (e.g. when some tasks are finished). Insert a call at the end of each reaction, to re-inspect the bag.
 


### PR DESCRIPTION
Static molecules are guaranteed to be emitted, and having a reaction such as

```
go { c(_) => ...}
```
for a static molecule `c` most probably means a reaction that will run in a livelock. If this reaction is meant to run only once, it's not a concurrent computation and should be performed statically.