### PR TITLE
try to avoid test failure due to pipelined storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ scala:
   - 2.11.11
   - 2.12.2
   - 2.12.3
+  - 2.12.4
 jdk:
   - oraclejdk8
 
@@ -29,7 +30,7 @@ deploy:
   provider: releases
   api_key:
     secure: "QtQK+MK4yylLKyLV6wDF4uuT9R9i/8OhK7OGC8pKAIzu9wylWGMfFmje3JwD69Ek0yd06h+3xG8OU8rRAfQ+hfCRubXGHKi76zeouvxe8BGpbQ6PSsrnUZV6mmOKFWG2EMhVds+r8vZkV/LcT8+RJ6hZoQWkxrsQ7teiV/Bxm5FYiN3hQJHjbJ5H7jRKBRDnDTI1LbTejpVaNCYq7habYhjSYwHpzfuLrtoE0RZvArAz06ltG8iAgLUZiYGPzv3eVWwhhtsj+dTX+B4p5hvdj5ULeRUdU5+XbBwu6+ZneYI1nDLZCxQiN2LWmqhfBvYSeYsmAOySexueOMIwL/+92mD3EHTNoXs39ZX0DSa8sulLQdq+SCeTc7F2SlpsZVesmDm3Y2cfGC5uhIdj7TeP0XD7ex5sL7Wt7gYrrEjhghxaTbyMZy9KtGHw0YEfSM3n9QbDXPun9mk7YPJs+m1jvTa5cL5kxFWI+Oz3eoFV/tSpmVNfxjTIQLlWcasriotMjIM1JoO/qcAe8eoLefpJnfsZZK3IdBRtPm2Gvv+b4I4ET/td/N5k4cFJqp6++vk6ByE+MnctYsOmeftpNPlLRAfh4Ma3OTg9xbaTXUWV62E39XYb6RRTEj0KfI3wvOounWcYIZdhUnLr8hBkczXO8AsPlOHviYU7fpldut6tCUs="
-  file: "core/target/scala-2.11/*core*.jar"
+  file: "core/target/scala-2.12/*core*.jar"
   skip_cleanup: true
   on:
     tags

--- a/build.sbt
+++ b/build.sbt
@@ -17,8 +17,8 @@ $ sbt
 val commonSettings = Defaults.coreDefaultSettings ++ Seq(
   organization := "io.chymyst",
   version := "0.2.1-SNAPSHOT",
-  scalaVersion := "2.12.3",
-  crossScalaVersions := Seq("2.11.11", "2.12.3"),
+  scalaVersion := "2.12.4",
+  crossScalaVersions := Seq("2.11.11", "2.12.4"),
   resolvers ++= Seq(
     Resolver.sonatypeRepo("snapshots"),
     Resolver.sonatypeRepo("releases"),

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ val commonSettings = Defaults.coreDefaultSettings ++ Seq(
     //    "-language:existentials",
     "-language:higherKinds",
     "-language:implicitConversions",
-    "-opt:l:project",
+//    "-opt:l:project", // this is deprecated
     "-Yvirtpatmat",
     "-Ydelambdafy:inline",
     // "-Xfatal-warnings",

--- a/core/src/test/scala/io/chymyst/test/Patterns01Spec.scala
+++ b/core/src/test/scala/io/chymyst/test/Patterns01Spec.scala
@@ -227,10 +227,10 @@ class Patterns01Spec extends LogSpec with BeforeAndAfterEach {
   }
 
   it should "implement dance pairing without queue labels" in {
-    val man = m[Unit]
+    val man = m[Int]
     val manL = m[Int]
     val queueMen = m[Int]
-    val woman = m[Unit]
+    val woman = m[Int]
     val womanL = m[Int]
     val queueWomen = m[Int]
     val beginDancing = m[Int]
@@ -254,10 +254,10 @@ class Patterns01Spec extends LogSpec with BeforeAndAfterEach {
     )
     checkExpectedPipelined(Seq(man, woman, queueMen, queueWomen, manL, womanL).map(_ → true).toMap) shouldEqual ""
 
-    (0 until total / 2).foreach(_ => man())
+    (0 until total / 2).foreach(x => man(x))
     danceCounter.volatileValue shouldEqual Nil
-    (0 until total / 2).foreach(_ => man() + woman())
-    (0 until total / 2).foreach(_ => woman())
+    (0 until total / 2).foreach(x => man(x) + woman(x))
+    (0 until total / 2).foreach(x => woman(x))
 
     val initTime = System.currentTimeMillis()
     val ordering = done()

--- a/docs/chymyst-core.md
+++ b/docs/chymyst-core.md
@@ -5,7 +5,7 @@
 `Chymyst Core` provides an embedded DSL for declarative concurrency in Scala.
 It follows the **chemical machine** paradigm and provides high-level, purely functional concurrency primitives used by the `Chymyst` framework.
 
-Currently, it compiles with Scala 2.11 and Scala 2.12 on Oracle JDK 8.
+Currently, it is tested with Scala 2.11 and Scala 2.12 on Oracle JDK 8.
 
 # Main structures
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.13
+sbt.version = 0.13.16


### PR DESCRIPTION
A "dancing pair" test fails because reactions are not always started in random order.

- try to make molecules carry integers
- try to make them non-pipelined